### PR TITLE
Update FuzzerDictionary.py

### DIFF
--- a/lib/core/FuzzerDictionary.py
+++ b/lib/core/FuzzerDictionary.py
@@ -62,7 +62,10 @@ class FuzzerDictionary(object):
                 for extension in self._extensions:
                     self.entries.append(urllib.parse.quote(line.replace('%EXT%', extension)))
             else:
-                self.entries.append(urllib.parse.quote(line))
+                if line.endswith('/'): self.entries.append(urllib.parse.quote(line))
+                else:
+                    self.entries.append(urllib.parse.quote(line))
+                    self.entries.append(urllib.parse.quote(line)+'/')
         if lowercase == True:
             self.entries = list(oset([entry.lower() for entry in self.entries]))
 


### PR DESCRIPTION
When reading the dictionary file any word that doesnt ends with char "/" or doesnt contains "%EXT%" is added two times:
1) just as is
2) with a "/" appended

So, if the dictionary file is like this:

# DictionaryFile
web
index.%EXT%

and the command is called this way:
$ ./dirs3arch -w DictionaryFile -e "php,html" -u url

the fuzzed dictionary will be:

web
web/
index.php
index.html

The result is the same we'll get with this dictionary file:

# DictionaryFile
web
web/
index.%EXT%

The reason for this change is that, sometimes, web servers return a 404 when the directory resource is hit but the url resource without "/" returns a differente code what it usually means that it contains more resources...

It's not complicated to create a new dictionary file for this kind of webs but I prefer dirs3arch doing the work for me...