### PR TITLE
Added feature for former DirBuster Users

### DIFF
--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -78,7 +78,8 @@ class Controller(object):
         self.excludeSubdirs = (arguments.excludeSubdirs if arguments.excludeSubdirs is not None else [])
         self.output.header(PROGRAM_BANNER)
         self.dictionary = Dictionary(self.arguments.wordlist, self.arguments.extensions,
-                                     self.arguments.lowercase)
+                                     self.arguments.lowercase, self.arguments.forceExtensions)
+        self.output.newLine("\n" + str(self.arguments.forceExtensions))
         self.printConfig()
         self.errorLog = None
         self.errorLogPath = None

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -79,7 +79,6 @@ class Controller(object):
         self.output.header(PROGRAM_BANNER)
         self.dictionary = Dictionary(self.arguments.wordlist, self.arguments.extensions,
                                      self.arguments.lowercase, self.arguments.forceExtensions)
-        self.output.newLine("\n" + str(self.arguments.forceExtensions))
         self.printConfig()
         self.errorLog = None
         self.errorLogPath = None

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -96,6 +96,7 @@ class ArgumentParser(object):
             self.excludeStatusCodes = []
         self.wordlist = options.wordlist
         self.lowercase = options.lowercase
+        self.forceExtensions = options.forceExtensions
         self.simpleOutputFile = options.simpleOutputFile
         self.plainTextOutputFile = options.plainTextOutputFile
         self.jsonOutputFile = options.jsonOutputFile
@@ -148,6 +149,8 @@ class ArgumentParser(object):
         self.wordlist = config.safe_get("dictionary", "wordlist",
                                         FileUtils.buildPath(self.script_path, "db", "dicc.txt"))
         self.lowercase = config.safe_getboolean("dictionary", "lowercase", False)
+        self.forceExtensions = config.safe_get("dictionary", "force-extensions", False)
+
         # Connection
         self.useRandomAgents = config.safe_get("connection", "random-user-agents", False)
         self.useragent = config.safe_get("connection", "user-agent", None)
@@ -182,6 +185,9 @@ class ArgumentParser(object):
         dictionary.add_option('-w', '--wordlist', action='store', dest='wordlist',
                               default=self.wordlist)
         dictionary.add_option('-l', '--lowercase', action='store_true', dest='lowercase', default=self.lowercase)
+
+        dictionary.add_option('-f', '--force-extensions', help='Force extensions for every wordlist entry (like in DirBuster)', 
+                              action='store_true', dest='forceExtensions', default=self.forceExtensions)
 
         # Optional Settings
         general = OptionGroup(parser, 'General Settings')

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -24,12 +24,13 @@ from thirdparty.oset import *
 
 class Dictionary(object):
 
-    def __init__(self, path, extensions, lowercase=False):
+    def __init__(self, path, extensions, lowercase=False, forcedExtensions=False):
         self.entries = []
         self.currentIndex = 0
         self.condition = threading.Lock()
         self._extensions = extensions
         self._path = path
+        self._forcedExtensions = forcedExtensions
         self.lowercase = lowercase
         self.dictionaryFile = File(self.path)
         self.generate(lowercase=self.lowercase)
@@ -65,6 +66,9 @@ class Dictionary(object):
                 for extension in self._extensions:
                     self.entries.append(self.quote(line.replace('%EXT%', extension)))
             else:
+                if self._forcedExtensions:
+                    for extension in self._extensions:
+                        self.entries.append(self.quote(line) + '.' + extension)
                 quote = self.quote(line)
                 self.entries.append(quote)
         if lowercase == True:


### PR DESCRIPTION
Hi, 

Like your tool very much, thanks for the effort, it is a cool successor for the abandoned DirBuster tool. I missed one feature to use a plain dirbuster wordlist with extensions and added it, maybe you also find it useful. 
Added option -f / --force-extenisons to brute force a plain wordlist with all extensions (like in dirbuster) without needing the %EXT% wildcard.

Regards Florian 