### PR TITLE
fix TooManyRedirects exception

### DIFF
--- a/lib/connection/Requester.py
+++ b/lib/connection/Requester.py
@@ -126,6 +126,8 @@ class Requester(object):
                 result = Response(response.status_code, response.reason, response.headers, response.content)
                 del headers
                 break
+            except requests.exceptions.TooManyRedirects as e:
+                raise RequestException({'message': 'Too many redirects: {0}'.format(e)})
             except requests.exceptions.ConnectionError as e:
                 if self.proxy is not None:
                     raise RequestException({'message': 'Error with the proxy: {0}'.format(e)})


### PR DESCRIPTION
This fixes the following exception

```
Traceback (most recent call last):
  File "/root/dirsearch/dirsearch.py", line 40, in <module>
    main = Program()
  File "/root/dirsearch/dirsearch.py", line 34, in __init__
    self.controller = Controller(self.script_path, self.arguments, self.output)
  File "/root/dirsearch/lib/controller/Controller.py", line 108, in __init__
    self.requester.request("/")
  File "/root/dirsearch/lib/connection/Requester.py", line 125, in request
    headers=headers, timeout=self.timeout)
  File "/root/dirsearch/thirdparty/requests/api.py", line 69, in get
    return request('get', url, params=params, **kwargs)
  File "/root/dirsearch/thirdparty/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/root/dirsearch/thirdparty/requests/sessions.py", line 470, in request
    resp = self.send(prep, **send_kwargs)
  File "/root/dirsearch/thirdparty/requests/sessions.py", line 599, in send
    history = [resp for resp in gen] if allow_redirects else []
  File "/root/dirsearch/thirdparty/requests/sessions.py", line 599, in <listcomp>
    history = [resp for resp in gen] if allow_redirects else []
  File "/root/dirsearch/thirdparty/requests/sessions.py", line 113, in resolve_redirects
    raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects)
thirdparty.requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
```