### PR TITLE
Added option to force requests by hostname

### DIFF
--- a/lib/connection/Requester.py
+++ b/lib/connection/Requester.py
@@ -41,7 +41,7 @@ class Requester(object):
         }
 
     def __init__(self, url, cookie=None, useragent=None, maxPool=1, maxRetries=5, timeout=30, ip=None, proxy=None,
-                 redirect=False):
+                 redirect=False, queryByHosename=False):
         # if no backslash, append one
         if not url.endswith('/'):
             url = url + '/'
@@ -85,6 +85,7 @@ class Requester(object):
         self.proxy = proxy
         self.redirect = redirect
         self.randomAgents = None
+        self.queryByHostname = queryByHostname
 
     def setHeader(self, header, content):
         self.headers[header] = content
@@ -103,7 +104,10 @@ class Requester(object):
             try:
                 if self.proxy is not None:
                     proxy = {"https" : self.proxy, "http" : self.proxy}
-                url = "{0}://{1}:{2}".format(self.protocol, self.ip, self.port)
+                if self.queryByHostname:
+                    url = "{0}://{1}:{2}".format(self.protocol, self.host, self.port)
+                else:
+                    url = "{0}://{1}:{2}".format(self.protocol, self.ip, self.port)
                 url = urllib.parse.urljoin(url, self.basePath)
 
                 # Joining with concatenation because a urljoin bug with "::"

--- a/lib/connection/Requester.py
+++ b/lib/connection/Requester.py
@@ -41,7 +41,7 @@ class Requester(object):
         }
 
     def __init__(self, url, cookie=None, useragent=None, maxPool=1, maxRetries=5, timeout=30, ip=None, proxy=None,
-                 redirect=False, queryByHosename=False):
+                 redirect=False, requestByHostname=False):
         # if no backslash, append one
         if not url.endswith('/'):
             url = url + '/'
@@ -85,7 +85,7 @@ class Requester(object):
         self.proxy = proxy
         self.redirect = redirect
         self.randomAgents = None
-        self.queryByHostname = queryByHostname
+        self.requestByHostname = requestByHostname
 
     def setHeader(self, header, content):
         self.headers[header] = content
@@ -104,7 +104,7 @@ class Requester(object):
             try:
                 if self.proxy is not None:
                     proxy = {"https" : self.proxy, "http" : self.proxy}
-                if self.queryByHostname:
+                if self.requestByHostname:
                     url = "{0}://{1}:{2}".format(self.protocol, self.host, self.port)
                 else:
                     url = "{0}://{1}:{2}".format(self.protocol, self.ip, self.port)

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -105,7 +105,7 @@ class Controller(object):
                                                maxRetries=self.arguments.maxRetries, timeout=self.arguments.timeout,
                                                ip=self.arguments.ip, proxy=self.arguments.proxy,
                                                redirect=self.arguments.redirect, 
-                                               queryByHostname=self.arguments.queryByHostname)
+                                               requestByHostname=self.arguments.requestByHostname)
                         self.requester.request("/")
                     except RequestException as e:
                         self.output.error(e.args[0]['message'])

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -104,7 +104,8 @@ class Controller(object):
                                                useragent=self.arguments.useragent, maxPool=self.arguments.threadsCount,
                                                maxRetries=self.arguments.maxRetries, timeout=self.arguments.timeout,
                                                ip=self.arguments.ip, proxy=self.arguments.proxy,
-                                               redirect=self.arguments.redirect)
+                                               redirect=self.arguments.redirect, 
+                                               queryByHostname=self.arguments.queryByHostname)
                         self.requester.request("/")
                     except RequestException as e:
                         self.output.error(e.args[0]['message'])

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -128,6 +128,7 @@ class ArgumentParser(object):
         else:
             self.excludeSubdirs = None
         self.redirect = options.noFollowRedirects
+        self.queryByHostname = options.queryByHostName
 
     def parseConfig(self):
         config = DefaultConfigParser()
@@ -157,6 +158,7 @@ class ArgumentParser(object):
         self.timeout = config.safe_getint("connection", "timeout", 30)
         self.maxRetries = config.safe_getint("connection", "max-retries", 5)
         self.proxy = config.safe_get("connection", "http-proxy", None)
+        self.queryByHostname = config.safe_get("connection", "query-by-hostname", False)
 
     def parseArguments(self):
         usage = 'Usage: %prog [-u|--url] target [-e|--extensions] extensions [options]'
@@ -214,6 +216,9 @@ class ArgumentParser(object):
                            help='Headers to add (example: --header "Referer: example.com" --header "User-Agent: IE"',
                            action='append', type='string', dest='headers', default=None)
         general.add_option('--random-agents', '--random-user-agents', action="store_true", dest='useRandomAgents')
+        general.add_option('-h', '--query-by-hostname', 
+                           help='By default dirsearch will query by IP for speed. This forces queries by hostname', 
+                           action='store_true', dest='queryByHostname', default=self.queryByHostname)
         reports = OptionGroup(parser, 'Reports')
         reports.add_option('--simple-report', action='store', help="Only found paths",
                            dest='simpleOutputFile', default=None)

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -128,7 +128,7 @@ class ArgumentParser(object):
         else:
             self.excludeSubdirs = None
         self.redirect = options.noFollowRedirects
-        self.queryByHostname = options.queryByHostName
+        self.requestByHostname = options.requestByHostname
 
     def parseConfig(self):
         config = DefaultConfigParser()
@@ -158,7 +158,7 @@ class ArgumentParser(object):
         self.timeout = config.safe_getint("connection", "timeout", 30)
         self.maxRetries = config.safe_getint("connection", "max-retries", 5)
         self.proxy = config.safe_get("connection", "http-proxy", None)
-        self.queryByHostname = config.safe_get("connection", "query-by-hostname", False)
+        self.requestByHostname = config.safe_get("connection", "request-by-hostname", False)
 
     def parseArguments(self):
         usage = 'Usage: %prog [-u|--url] target [-e|--extensions] extensions [options]'
@@ -181,6 +181,9 @@ class ArgumentParser(object):
                               default=self.proxy, help='Http Proxy (example: localhost:8080')
         connection.add_option('--max-retries', action='store', dest='maxRetries', type='int',
                               default=self.maxRetries)
+        connection.add_option('-b', '--request-by-hostname', 
+                               help='By default dirsearch will request by IP for speed. This forces requests by hostname', 
+                               action='store_true', dest='requestByHostname', default=self.requestByHostname)
 
         # Dictionary settings
         dictionary = OptionGroup(parser, 'Dictionary Settings')
@@ -216,9 +219,7 @@ class ArgumentParser(object):
                            help='Headers to add (example: --header "Referer: example.com" --header "User-Agent: IE"',
                            action='append', type='string', dest='headers', default=None)
         general.add_option('--random-agents', '--random-user-agents', action="store_true", dest='useRandomAgents')
-        general.add_option('-h', '--query-by-hostname', 
-                           help='By default dirsearch will query by IP for speed. This forces queries by hostname', 
-                           action='store_true', dest='queryByHostname', default=self.queryByHostname)
+
         reports = OptionGroup(parser, 'Reports')
         reports.add_option('--simple-report', action='store', help="Only found paths",
                            dest='simpleOutputFile', default=None)


### PR DESCRIPTION
By default, dirsearch queries by IP, with the hostname in the Host header.

This is fine for most webservers, but some hosts (like CDNs) can get picky about this and reject requests that are made by IP address.

I added a boolean -b / --request-by-hostname argument that will override the default behaviour and instead query by hostname