### PR TITLE
Allow recursive search with third party wordlists

### DIFF
--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -334,10 +334,10 @@ class Controller(object):
     def addDirectory(self, path):
         if not self.recursive:
             return False
-        if not (".") in path:
+        if path.endswith('/'):
             if path in [directory + '/' for directory in self.excludeSubdirs]:
                 return False
-            self.directories.put(self.currentDirectory + path + '/')
+            self.directories.put(self.currentDirectory + path)
             return True
         else:
             return False

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -334,10 +334,10 @@ class Controller(object):
     def addDirectory(self, path):
         if not self.recursive:
             return False
-        if path.endswith('/'):
+        if not (".") in path:
             if path in [directory + '/' for directory in self.excludeSubdirs]:
                 return False
-            self.directories.put(self.currentDirectory + path)
+            self.directories.put(self.currentDirectory + path + '/')
             return True
         else:
             return False

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -192,7 +192,8 @@ class ArgumentParser(object):
 
         # Dictionary settings
         dictionary = OptionGroup(parser, 'Dictionary Settings')
-        dictionary.add_option('-w', '--wordlist', action='store', dest='wordlist',
+        dictionary.add_option('-w', '--wordlist', action='store', dest='wordlist', help= "Recommended uses is with \
+                                                                                         the -f option below",
                               default=self.wordlist)
         dictionary.add_option('-l', '--lowercase', action='store_true', dest='lowercase', default=self.lowercase)
 

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -196,7 +196,8 @@ class ArgumentParser(object):
                               default=self.wordlist)
         dictionary.add_option('-l', '--lowercase', action='store_true', dest='lowercase', default=self.lowercase)
 
-        dictionary.add_option('-f', '--force-extensions', help='Force extensions for every wordlist entry (like in DirBuster)',
+        dictionary.add_option('-f', '--force-extensions', help='Force extensions and add directory "/" for every \
+        wordlist entry (like in DirBuster). Recommended for custom wordlists',
                               action='store_true', dest='forceExtensions', default=self.forceExtensions)
 
         # Optional Settings

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -69,7 +69,7 @@ class Dictionary(object):
                 if self._forcedExtensions:
                     for extension in self._extensions:
                         self.entries.append(self.quote(line) + '.' + extension)
-                    if ("/") not in line:
+                    if ("/") not in line and (".") not in line:
                         self.entries.append(self.quote(line) + '/')
                 quote = self.quote(line)
                 self.entries.append(quote)

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -69,8 +69,8 @@ class Dictionary(object):
                 if self._forcedExtensions:
                     for extension in self._extensions:
                         self.entries.append(self.quote(line) + '.' + extension)
-                quote = self.quote(line)
-                self.entries.append(quote)
+                if (".") not in line and ("/") not in line:
+                	self.entries.append(self.quote(line) + '/')
         if lowercase == True:
             self.entries = list(oset([entry.lower() for entry in self.entries]))
 

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -69,8 +69,8 @@ class Dictionary(object):
                 if self._forcedExtensions:
                     for extension in self._extensions:
                         self.entries.append(self.quote(line) + '.' + extension)
-                if (".") not in line and ("/") not in line:
-                	self.entries.append(self.quote(line) + '/')
+                    if ("/") not in line:
+                        self.entries.append(self.quote(line) + '/')
                 quote = self.quote(line)
                 self.entries.append(quote)
         if lowercase == True:

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -72,7 +72,7 @@ class Dictionary(object):
                 if (".") not in line and ("/") not in line:
                 	self.entries.append(self.quote(line) + '/')
                 quote = self.quote(line)
--               self.entries.append(quote)
+                self.entries.append(quote)
         if lowercase == True:
             self.entries = list(oset([entry.lower() for entry in self.entries]))
 

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -72,7 +72,7 @@ class Dictionary(object):
                 if (".") not in line and ("/") not in line:
                 	self.entries.append(self.quote(line) + '/')
                 quote = self.quote(line)
--               self.entries.append(quote)	
+-               self.entries.append(quote)
         if lowercase == True:
             self.entries = list(oset([entry.lower() for entry in self.entries]))
 

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -71,6 +71,8 @@ class Dictionary(object):
                         self.entries.append(self.quote(line) + '.' + extension)
                 if (".") not in line and ("/") not in line:
                 	self.entries.append(self.quote(line) + '/')
+                quote = self.quote(line)
+-               self.entries.append(quote)	
         if lowercase == True:
             self.entries = list(oset([entry.lower() for entry in self.entries]))
 

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -69,7 +69,7 @@ class Dictionary(object):
                 if self._forcedExtensions:
                     for extension in self._extensions:
                         self.entries.append(self.quote(line) + '.' + extension)
-                    if ("/") not in line and (".") not in line:
+                    if ("/") not in line and (".") not in line and line !='':
                         self.entries.append(self.quote(line) + '/')
                 quote = self.quote(line)
                 self.entries.append(quote)


### PR DESCRIPTION
dirsearch's own dictionary specifically had '/' appended to words it wanted to test as directories, but other wordlists such as from dirbuster don't. This meant that recursion wouldn't work as Controller.addDirectory would specifically test for the presence of '/' in a successful search term to judge if it's a directory to be recursively searched. 

This fix will, as the terms are read in from the dictionary, append a '/' if one isn't present (and also if a '.' isn't present), but also keep the raw word for submission also. so for example if 'install' is in the dictionary, 'install' and 'install/' will both be tested.

The downside of this is that with the default dictionary since 'install' and 'install/' are already separately defined this may add overhead as the same term will be searched multiple times, but as it's a small dictionary i don't think it should be too much of a problem.  A possible mitigation for this would be to wrap the current fix in a check that ensures we aren't using the default dirsearch dictionary.