### PR TITLE
Update dicc.txt

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -1869,6 +1869,7 @@ app/vendor-src
 app_admin
 App_Code
 App_Data
+app.js
 app.php
 app_dev.php
 appadmin
@@ -5004,6 +5005,7 @@ server.cfg
 server.log
 Server.php
 server.xml
+server.js
 Server/
 server_admin_small/
 server_stats


### PR DESCRIPTION
add:
`app.js` and `server.js` for checking JS server code. Sometimes admins are using directory for static files as a JS server code (misconfiguration problem).
Link: [blog.blackfan.ru](https://blog.blackfan.ru/2018/01/pda-test.yandex.ru-file-reading.html)