### PR TITLE
Recurse on directory redirects

### DIFF
--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -428,8 +428,8 @@ class Controller(object):
         baseUrl = self.currentUrl.rstrip("/") + "/" + self.currentDirectory
         absoluteUrl = urllib.parse.urljoin(baseUrl, path.response.redirect)
         if absoluteUrl.startswith(baseUrl) and absoluteUrl != baseUrl and absoluteUrl.endswith("/"):
-            parsed = urllib.parse.urlparse(absoluteUrl)
-            self.directories.put(parsed.path.lstrip("/"))
+            subdir = absoluteUrl[len(baseUrl):]
+            self.directories.put(subdir)
             return True
 
         return False


### PR DESCRIPTION
When in recursive mode, if the response is a redirect to a directory, schedule it to scan later.

The redirect needs to be resolved relative to the current URL to make relative redirects work. We only add it to self.directories when it is a subdirectory, to avoid endless loops when two subdirectories redirect to one another.

This is pretty experimental. I have tested it on a test server, but not in production yet.