### PR TITLE
Make it possible to use as command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,23 @@
 reports/
 logs/
 
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ python3 dirsearch.py -u <URL> -e <EXTENSION>
 you can also use this alias to send directly to proxy
 `python3 /path/to/dirsearch/dirsearch.py --http-proxy=localhost:8080`
 
+If you use dirsearch as command:
+
+```
+python3 setup.py install
+dirsearch -u <URL> -e <EXTENSION>
+```
 
 Options
 -------

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -19,22 +19,24 @@
 
 import os
 import sys
-
-if sys.version_info < (3, 0):
-    sys.stdout.write("Sorry, dirsearch requires Python 3.x\n")
-    sys.exit(1)
-
 from lib.core import ArgumentParser
 from lib.controller import *
 from lib.output import *
+from lib.utils import FileUtils
 
 
 class Program(object):
     def __init__(self, script_path, save_path):
         self.arguments = ArgumentParser(script_path)
         self.output = CLIOutput()
+        log_path = os.path.join(save_path, 'logs')
+        if not FileUtils.exists(log_path):
+            FileUtils.createDirectory(log_path)
         self.controller = Controller(script_path, save_path, self.arguments, self.output)
 
-if __name__ == '__main__':
-    current_path = os.path.dirname(os.path.realpath(__file__))
-    main = Program(current_path, current_path)
+def run_as_command():
+    if sys.version_info < (3, 0):
+        sys.stdout.write("Sorry, dirsearch requires Python 3.x\n")
+        sys.exit(1)
+
+    main = Program(os.path.dirname(os.path.dirname(__file__)), './')

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -47,7 +47,7 @@ VERSION = {
 
 
 class Controller(object):
-    def __init__(self, script_path, arguments, output):
+    def __init__(self, script_path, save_path, arguments, output):
         global VERSION
         program_banner = open(FileUtils.buildPath(script_path, "lib", "controller", "banner.txt")).read().format(
             **VERSION)
@@ -56,7 +56,7 @@ class Controller(object):
         self.exit = False
         self.arguments = arguments
         self.output = output
-        self.savePath = self.script_path
+        self.savePath = save_path
         self.doneDirs = []
 
         self.recursive_level_max = self.arguments.recursive_level_max

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+import setuptools
+import io
+import os
+import sys
+
+# Package meta-data
+NAME = 'dirsearch'
+DESCRIPTION = 'A simple command line tool designed to brute force directories and files in websites.'
+URL = 'https://github.com/maurosoria/dirsearch'
+AUTHOR = 'Mauro Soria'
+VERSION = '0.3.8'
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
+
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author=AUTHOR,
+    url=URL,
+    packages=setuptools.find_packages(),
+    data_files=[
+        ('', ['default.conf']), 
+        ('db', [
+            'db/400_blacklist.txt',
+            'db/403_blacklist.txt',
+            'db/500_blacklist.txt',
+            'db/dicc.txt',
+            'db/user-agents.txt'
+            ]
+        ),
+        ('lib/controller', ['lib/controller/banner.txt'])
+    ],
+    entry_points={
+        'console_scripts':[
+            'dirsearch = lib.cli:run_as_command',
+        ],
+    },
+    license='GPLv2',
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+    ],
+)


### PR DESCRIPTION
This pull request make it possible to use as `dirsearch` command. It will be more useful.
I think it would be bad to change the usage suddenly, and `dirsearch.py` is still there. I can also delete this file.