### PR TITLE
Add default.conf to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 .idea
 
 db/test.txt
+
+default.conf


### PR DESCRIPTION
Fixed #163 

default.conf is a configuration file which will be updated by the user accordingly so it would be nice to keep it in .gitignore so the changes to that file doesn't show up in `git status`