### PR TITLE
Add option to use default extension list

### DIFF
--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -58,9 +58,12 @@ class ArgumentParser(object):
         else:
             self.urlList = [options.url]
 
-        if options.extensions == None:
-            print('No extension specified. You must specify at least one extension')
+        if not options.extensions and not options.extensions_list:
+            print('No extension specified. You must specify at least one extension or try using default extension list.')
             exit(0)
+
+        if not options.extensions and options.extensions_list:
+            options.extensions = "html,php,tar.gz,txt,xml,zip,jpg,png,jpeg"
 
         with File(options.wordlist) as wordlist:
             if not wordlist.exists():
@@ -238,6 +241,8 @@ class ArgumentParser(object):
                              default=None)
         mandatory.add_option('-e', '--extensions', help='Extension list separated by comma (Example: php,asp)',
                              action='store', dest='extensions', default=None)
+        mandatory.add_option('-E', '--extensions-list', help='Use predefined list of common extensions',
+                             action='store_true', default=False)
 
         connection = OptionGroup(parser, 'Connection Settings')
         connection.add_option('--timeout', action='store', dest='timeout', type='int',


### PR DESCRIPTION
Fix #146

I have added an option called `--extension-list` that stores value `True` or `False`. So if this option is provided then a predefine small list of the extension will be used in place of extension. I haven't used the wordlist suggested by @noraj i.e `: fuzzdb/discovery/predictable-filepaths/filename-dirname-bruteforce/Extensions.Common.txt` because this file had like 800 extension and using that many extension as the default would slow down the process.

Now the hardcoding of the common extension might seem odd so we can either add an option to read those default extensions from the configuration file or we can also have the option of supporting the extension file. But I think the support for extension file should be added for the existing argument `-e or --extension` instead of this new `--extension-list`. 

If anything else looks bad in this PR then please let me know.