### PR TITLE
Fix tilde extension prepended by a dot

### DIFF
--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -107,6 +107,8 @@ class Dictionary(object):
                         # Why? check https://github.com/maurosoria/dirsearch/issues/70
                         if extension.strip() == '':
                             result.append(quoted)
+                        elif extension.strip() == '~':
+                            result.append(quoted + extension)
                         else:
                             result.append(quoted + '.' + extension)
 


### PR DESCRIPTION
Like for https://github.com/maurosoria/dirsearch/issues/70, this pr fix text editor backup files discovery (ending with tilde (~) without dot (.) before)

```dirsearch.py -u http://host/ -w wordlist.txt -e php,txt,~ -f```

Actual behavior:
```
/test.php
/test.txt
/test.~
```

Expected behavior:
```
/test.php
/test.txt
/test~       <-- Without dot 
```
