### PR TITLE
Multiple dirsearch improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,5 @@ Special thanks for these people.
 - k2l8m11n2
 - vlohacks
 - r0p0s3c
+- V-Rico
+- russtone

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Features
 - Options to display only items with response length from range (--min & --max)
 - Option to whitelist response codes (-i 200,500)
 - Option to remove output from console (-q, keeps output to files)
+- Option to add custom suffixes to filenames without dots (--suff .BAK,.old, example.%EXT%%SUFFIX%)
 
 About wordlists
 ---------------

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Features
 - Option to remove dot from extension when forcing (--nd, example%EXT% instead of example.%EXT%)
 - Options to display only items with response length from range (--min & --max)
 - Option to whitelist response codes (-i 200,500)
+- Option to remove output from console (-q, keeps output to files)
 
 About wordlists
 ---------------

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Features
 - Request delaying
 - Option to remove dot from extension when forcing (--nd, example%EXT% instead of example.%EXT%)
 - Options to display only items with response length from range (--min & --max)
+- Option to whitelist response codes (-i 200,500)
 
 About wordlists
 ---------------

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Features
 - User agent randomization
 - Batch processing
 - Request delaying
+- Option to remove dot from extension when forcing (--nd, example%EXT% instead of example.%EXT%)
+- Options to display only items with response length from range (--min & --max)
 
 About wordlists
 ---------------

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -204,6 +204,7 @@ class Controller(object):
     def printConfig(self):
         self.output.config(
             ', '.join(self.arguments.extensions),
+            ', '.join(self.arguments.suffixes),
             str(self.arguments.threadsCount),
             str(len(self.dictionary)),
             str(self.httpmethod),
@@ -285,7 +286,7 @@ class Controller(object):
             else:
                 fileName = ('{}_'.format(basePath) if basePath != '' else '')
                 fileName += time.strftime('%y-%m-%d_%H-%M-%S')
-                directoryPath = FileUtils.buildPath(self.savePath, 'reports', requester.host)
+                directoryPath = FileUtils.buildPath(self.savePath, 'reports', f'{requester.protocol}_{requester.host}_{requester.httpmethod}')
 
             outputFile = FileUtils.buildPath(directoryPath, fileName)
 

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -94,6 +94,7 @@ class Controller(object):
             self.savePath = savePath
 
         self.reportsPath = FileUtils.buildPath(self.savePath, "logs")
+        self.quietMode = self.arguments.quietMode
         self.blacklists = self.getBlacklists()
         self.fuzzer = None
         self.includeStatusCodes = self.arguments.includeStatusCodes
@@ -288,6 +289,8 @@ class Controller(object):
 
             outputFile = FileUtils.buildPath(directoryPath, fileName)
 
+            self.output.newLine("Output File: {0}\n".format(outputFile))
+
             if FileUtils.exists(outputFile):
                 i = 2
 
@@ -338,7 +341,7 @@ class Controller(object):
 
         if path.status is not None:
             if path.status not in self.excludeStatusCodes and (
-                    self.includeStatusCodes and path.status in self.includeStatusCodes) and (
+                    not self.includeStatusCodes or path.status in self.includeStatusCodes) and (
                     self.blacklists.get(path.status) is None or path.path not in self.blacklists.get(
                 path.status)) and not (
                     self.suppressEmpty and (len(path.response.body) == 0)) and not (
@@ -355,7 +358,9 @@ class Controller(object):
                         del path
                         return
 
-                self.output.statusReport(path.path, path.response)
+                if not self.quietMode:
+                    self.output.statusReport(path.path, path.response)
+
                 if path.response.redirect:
                     self.addRedirectDirectory(path)
                 else:

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -108,7 +108,7 @@ class Controller(object):
         self.directories = Queue()
         self.excludeSubdirs = (arguments.excludeSubdirs if arguments.excludeSubdirs is not None else [])
         self.output.header(program_banner)
-        self.dictionary = Dictionary(self.arguments.wordlist, self.arguments.extensions,
+        self.dictionary = Dictionary(self.arguments.wordlist, self.arguments.extensions, self.arguments.suffixes,
                                      self.arguments.lowercase, self.arguments.forceExtensions,
                                      self.arguments.noDotExtensions)
         self.printConfig()

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -344,9 +344,9 @@ class Controller(object):
                     not self.includeStatusCodes or path.status in self.includeStatusCodes) and (
                     self.blacklists.get(path.status) is None or path.path not in self.blacklists.get(
                 path.status)) and not (
-                    self.suppressEmpty and (len(path.response.body) == 0)) and not (
-                    self.minimumResponseSize and not self.minimumResponseSize <= len(path.response.body)) and not (
-                    self.maximumResponseSize and not self.maximumResponseSize >= len(path.response.body)):
+                    self.suppressEmpty and (len(path.response.body) == 0)) and not ((
+                    self.minimumResponseSize and self.minimumResponseSize > len(path.response.body)) or (
+                    self.maximumResponseSize and self.maximumResponseSize < len(path.response.body))):
 
                 for excludeText in self.excludeTexts:
                     if excludeText in path.response.body.decode():

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -105,7 +105,8 @@ class Controller(object):
         self.excludeSubdirs = (arguments.excludeSubdirs if arguments.excludeSubdirs is not None else [])
         self.output.header(program_banner)
         self.dictionary = Dictionary(self.arguments.wordlist, self.arguments.extensions,
-                                     self.arguments.lowercase, self.arguments.forceExtensions)
+                                     self.arguments.lowercase, self.arguments.forceExtensions,
+                                     self.arguments.noDotExtensions)
         self.printConfig()
         self.errorLog = None
         self.errorLogPath = None

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -101,6 +101,8 @@ class Controller(object):
         self.excludeRegexps = self.arguments.excludeRegexps
         self.recursive = self.arguments.recursive
         self.suppressEmpty = self.arguments.suppressEmpty
+        self.minimumResponseSize = self.arguments.minimumResponseSize
+        self.maximumResponseSize = self.arguments.maximumResponseSize
         self.directories = Queue()
         self.excludeSubdirs = (arguments.excludeSubdirs if arguments.excludeSubdirs is not None else [])
         self.output.header(program_banner)
@@ -337,7 +339,9 @@ class Controller(object):
             if path.status not in self.excludeStatusCodes and (
                     self.blacklists.get(path.status) is None or path.path not in self.blacklists.get(
                 path.status)) and not (
-                    self.suppressEmpty and (len(path.response.body) == 0)):
+                    self.suppressEmpty and (len(path.response.body) == 0)) and not (
+                    self.minimumResponseSize and not self.minimumResponseSize <= len(path.response.body)) and not (
+                    self.maximumResponseSize and not self.maximumResponseSize >= len(path.response.body)):
 
                 for excludeText in self.excludeTexts:
                     if excludeText in path.response.body.decode():

--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -96,6 +96,7 @@ class Controller(object):
         self.reportsPath = FileUtils.buildPath(self.savePath, "logs")
         self.blacklists = self.getBlacklists()
         self.fuzzer = None
+        self.includeStatusCodes = self.arguments.includeStatusCodes
         self.excludeStatusCodes = self.arguments.excludeStatusCodes
         self.excludeTexts = self.arguments.excludeTexts
         self.excludeRegexps = self.arguments.excludeRegexps
@@ -337,6 +338,7 @@ class Controller(object):
 
         if path.status is not None:
             if path.status not in self.excludeStatusCodes and (
+                    self.includeStatusCodes and path.status in self.includeStatusCodes) and (
                     self.blacklists.get(path.status) is None or path.path not in self.blacklists.get(
                 path.status)) and not (
                     self.suppressEmpty and (len(path.response.body) == 0)) and not (

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -279,7 +279,7 @@ class ArgumentParser(object):
                               help='Force extensions for every wordlist entry (like in DirBuster)',
                               action='store_true', dest='forceExtensions', default=self.forceExtensions)
         dictionary.add_option('--nd', '--no-dot-extensions',
-                              help='Don\'t add a \'.\' character before extensiond', action='store_true',
+                              help='Don\'t add a \'.\' character before extensions', action='store_true',
                               dest='noDotExtensions', default=self.noDotExtensions)
 
         # Optional Settings

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -148,6 +148,7 @@ class ArgumentParser(object):
         self.wordlist = list(oset([wordlist.strip() for wordlist in options.wordlist.split(',')]))
         self.lowercase = options.lowercase
         self.forceExtensions = options.forceExtensions
+        self.noDotExtensions = options.noDotExtensions
         self.simpleOutputFile = options.simpleOutputFile
         self.plainTextOutputFile = options.plainTextOutputFile
         self.jsonOutputFile = options.jsonOutputFile
@@ -223,6 +224,7 @@ class ArgumentParser(object):
                                         FileUtils.buildPath(self.script_path, "db", "dicc.txt"))
         self.lowercase = config.safe_getboolean("dictionary", "lowercase", False)
         self.forceExtensions = config.safe_get("dictionary", "force-extensions", False)
+        self.noDotExtensions = config.safe_get("dictionary", "no-dot-extensions", False)
 
         # Connection
         self.useRandomAgents = config.safe_get("connection", "random-user-agents", False)
@@ -273,6 +275,9 @@ class ArgumentParser(object):
         dictionary.add_option('-f', '--force-extensions',
                               help='Force extensions for every wordlist entry (like in DirBuster)',
                               action='store_true', dest='forceExtensions', default=self.forceExtensions)
+        dictionary.add_option('--nd', '--no-dot-extensions',
+                              help='Don\'t add a \'.\' character before extensiond', action='store_true',
+                              dest='noDotExtensions', default=self.noDotExtensions)
 
         # Optional Settings
         general = OptionGroup(parser, 'General Settings')

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -232,7 +232,7 @@ class ArgumentParser(object):
         self.suppressEmpty = config.safe_getboolean("general", "suppress-empty", False)
         self.testFailPath = config.safe_get("general", "scanner-fail-path", "").strip()
         self.saveHome = config.safe_getboolean("general", "save-logs-home", False)
-        self.defaultExtensions = config.safe_get("general", "default-extensions", "php,asp,aspx,jsp,js,html,do,action")
+        self.defaultExtensions = config.safe_get("general", "default-extensions", "php,asp,aspx,jsp,js,do,action,html,js,json,yml,yaml,xml,cfg,bak,txt,md,sql,zip,tar.gz,tgz")
 
         # Reports
         self.quietMode = config.safe_get("reports", "quiet-mode", False)

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -164,6 +164,7 @@ class ArgumentParser(object):
         self.simpleOutputFile = options.simpleOutputFile
         self.plainTextOutputFile = options.plainTextOutputFile
         self.jsonOutputFile = options.jsonOutputFile
+        self.quietMode = options.quietMode
         self.delay = options.delay
         self.timeout = options.timeout
         self.ip = options.ip
@@ -233,6 +234,7 @@ class ArgumentParser(object):
         self.defaultExtensions = config.safe_get("general", "default-extensions", "php,asp,aspx,jsp,js,html,do,action")
 
         # Reports
+        self.quietMode = config.safe_get("reports", "quiet-mode", False)
         self.autoSave = config.safe_getboolean("reports", "autosave-report", False)
         self.autoSaveFormat = config.safe_get("reports", "autosave-report-format", "plain", ["plain", "json", "simple"])
         # Dictionary
@@ -346,6 +348,9 @@ class ArgumentParser(object):
         reports.add_option('--plain-text-report', action='store',
                            help="Found paths with status codes", dest='plainTextOutputFile', default=None)
         reports.add_option('--json-report', action='store', dest='jsonOutputFile', default=None)
+        reports.add_option('-q', '--quiet-mode', help='Disable output to console (only to reports)', action='store_true',
+                           dest='quietMode', default=self.quietMode)
+
         parser.add_option_group(mandatory)
         parser.add_option_group(dictionary)
         parser.add_option_group(general)

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -112,6 +112,18 @@ class ArgumentParser(object):
 
         self.threadsCount = options.threadsCount
 
+        if options.includeStatusCodes is not None:
+
+            try:
+                self.includeStatusCodes = list(
+                    oset([int(includeStatusCode.strip()) if includeStatusCode else None for includeStatusCode in
+                          options.includeStatusCodes.split(',')]))
+            except ValueError:
+                self.includeStatusCodes = []
+
+        else:
+            self.includeStatusCodes = []
+
         if options.excludeStatusCodes is not None:
 
             try:
@@ -210,6 +222,7 @@ class ArgumentParser(object):
 
         # General
         self.threadsCount = config.safe_getint("general", "threads", 10, list(range(1, 50)))
+        self.includeStatusCodes = config.safe_get("general", "include-status", None)
         self.excludeStatusCodes = config.safe_get("general", "exclude-status", None)
         self.redirect = config.safe_getboolean("general", "follow-redirects", False)
         self.recursive = config.safe_getboolean("general", "recursive", False)
@@ -309,6 +322,8 @@ class ArgumentParser(object):
                            default=None)
         general.add_option('-t', '--threads', help='Number of Threads', action='store', type='int', dest='threadsCount'
                            , default=self.threadsCount)
+        general.add_option('-i', '--include-status', help='Show only included status codes, separated by comma (example: 301, 500)'
+                           , action='store', dest='includeStatusCodes', default=self.includeStatusCodes)
         general.add_option('-x', '--exclude-status', help='Exclude status code, separated by comma (example: 301, 500)'
                            , action='store', dest='excludeStatusCodes', default=self.excludeStatusCodes)
         general.add_option('--exclude-texts', help='Exclude responses by texts, separated by comma (example: "Not found", "Error")'

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -157,6 +157,7 @@ class ArgumentParser(object):
         else:
             self.excludeRegexps = []
 
+        self.suffixes = [] if not options.suffixes else list(oset([suffix.strip() for suffix in options.suffixes.split(',')]))
         self.wordlist = list(oset([wordlist.strip() for wordlist in options.wordlist.split(',')]))
         self.lowercase = options.lowercase
         self.forceExtensions = options.forceExtensions
@@ -289,6 +290,9 @@ class ArgumentParser(object):
                               help='Customize wordlist (separated by comma)',
                               default=self.wordlist)
         dictionary.add_option('-l', '--lowercase', action='store_true', dest='lowercase', default=self.lowercase)
+        dictionary.add_option('--suff', '--suffixes',
+                             help='Add custom suffixes to all files, ignores directories (example.%EXT%%SUFFIX%)',
+                             action='store', dest='suffixes', default=None)
 
         dictionary.add_option('-f', '--force-extensions',
                               help='Force extensions for every wordlist entry (like in DirBuster)',

--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -158,6 +158,9 @@ class ArgumentParser(object):
         self.maxRetries = options.maxRetries
         self.recursive = options.recursive
         self.suppressEmpty = options.suppressEmpty
+        self.minimumResponseSize = options.minimumResponseSize
+        self.maximumResponseSize = options.maximumResponseSize
+
 
         if options.scanSubdirs is not None:
             self.scanSubdirs = list(oset([subdir.strip() for subdir in options.scanSubdirs.split(',')]))
@@ -291,6 +294,10 @@ class ArgumentParser(object):
                            default=self.recursive_level_max)
 
         general.add_option('--suppress-empty', "--suppress-empty", action="store_true", dest='suppressEmpty')
+        general.add_option('--min', action='store', dest='minimumResponseSize', type='int', default=None,
+                           help='Minimal response length')
+        general.add_option('--max', action='store', dest='maximumResponseSize', type='int', default=None,
+                           help='Maximal response length')
 
         general.add_option('--scan-subdir', '--scan-subdirs',
                            help='Scan subdirectories of the given -u|--url (separated by comma)', action='store',

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -28,11 +28,12 @@ from thirdparty.oset import *
 
 class Dictionary(object):
 
-    def __init__(self, paths, extensions, lowercase=False, forcedExtensions=False, noDotExtensions=False):
+    def __init__(self, paths, extensions, suffixes=None, lowercase=False, forcedExtensions=False, noDotExtensions=False):
         self.entries = []
         self.currentIndex = 0
         self.condition = threading.Lock()
         self._extensions = extensions
+        self._suffixes = suffixes
         self._paths = paths
         self._forcedExtensions = forcedExtensions
         self._noDotExtensions = noDotExtensions
@@ -117,6 +118,13 @@ class Dictionary(object):
                 # Append line unmodified.
                 else:
                     result.append(self.quote(line))
+
+        # Adding suffixes for finding backups etc
+        if self._suffixes:
+            for res in list(result):
+                if not res.rstrip().endswith("/"):
+                    for suff in self._suffixes:
+                        result.append(res + suff)
 
         # oset library provides inserted ordered and unique collection.
         if self.lowercase:

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -16,6 +16,7 @@
 #
 #  Author: Mauro Soria
 
+import re
 import threading
 
 import urllib.error
@@ -79,6 +80,8 @@ class Dictionary(object):
     """
 
     def generate(self):
+        reext = re.compile('\%ext\%', re.IGNORECASE)
+        reextdot = re.compile('\.\%ext\%', re.IGNORECASE)
         result = []
         # Enable to use multiple dictionaries at once
         for dictFile in self.dictionaryFiles:
@@ -91,13 +94,12 @@ class Dictionary(object):
                 # Classic dirsearch wordlist processing (with %EXT% keyword)
                 if '%EXT%' in line or '%ext%' in line:
                     for extension in self._extensions:
-                        if '%EXT%' in line:
-                            newline = line.replace('%EXT%', extension)
+                        if self._noDotExtensions:
+                            line = reextdot.sub(extension, line)
 
-                        if '%ext%' in line:
-                            newline = line.replace('%ext%', extension)
+                        line = reext.sub(extension, line)
 
-                        quote = self.quote(newline)
+                        quote = self.quote(line)
                         result.append(quote)
 
                 # If forced extensions is used and the path is not a directory ... (terminated by /)
@@ -113,6 +115,7 @@ class Dictionary(object):
                             result.append(quoted + ('' if self._noDotExtensions else '.') + extension)
 
                     if quoted.strip() not in ['']:
+                        result.append(quoted)
                         result.append(quoted + "/")
 
                 # Append line unmodified.

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -28,13 +28,14 @@ from thirdparty.oset import *
 
 class Dictionary(object):
 
-    def __init__(self, paths, extensions, lowercase=False, forcedExtensions=False):
+    def __init__(self, paths, extensions, lowercase=False, forcedExtensions=False, noDotExtensions=False):
         self.entries = []
         self.currentIndex = 0
         self.condition = threading.Lock()
         self._extensions = extensions
         self._paths = paths
         self._forcedExtensions = forcedExtensions
+        self._noDotExtensions = noDotExtensions
         self.lowercase = lowercase
         self.dictionaryFiles = [File(path) for path in self.paths]
         self.generate()
@@ -108,7 +109,7 @@ class Dictionary(object):
                         if extension.strip() == '':
                             result.append(quoted)
                         else:
-                            result.append(quoted + '.' + extension)
+                            result.append(quoted + ('' if self._noDotExtensions else '.') + extension)
 
                     if quoted.strip() not in ['']:
                         result.append(quoted + "/")

--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -173,11 +173,14 @@ class CLIOutput(object):
         message = Style.BRIGHT + Fore.MAGENTA + text + Style.RESET_ALL
         self.newLine(message)
 
-    def config(self, extensions, threads, wordlist_size, method, recursive, recursion_level):
+    def config(self, extensions, suffixes, threads, wordlist_size, method, recursive, recursion_level):
         separator = Fore.MAGENTA + ' | ' + Fore.YELLOW
         config = Style.BRIGHT + Fore.YELLOW
         config += 'Extensions: {0}'.format(Fore.CYAN + extensions + Fore.YELLOW)
         config += separator
+        if suffixes != '':
+            config += 'Suffixes: {0}'.format(Fore.CYAN + suffixes + Fore.YELLOW)
+            config += separator
         config += 'HTTP method: {0}'.format(Fore.CYAN + method + Fore.YELLOW)
         config += separator
         config += 'Threads: {0}'.format(Fore.CYAN + threads + Fore.YELLOW)


### PR DESCRIPTION
Here are some improvements that can be useful for different situations:

- Option to remove dot from extension when forcing (--nd, example%EXT% instead of example.%EXT%)
- Options to display only items with response length from range (--min & --max)
- Option to whitelist response codes (-i 200,500)
- Option to remove output from console (-q, keeps output to files)
- Option to add custom suffixes to filenames without dots (--suff .BAK,.old, example.%EXT%%SUFFIX%)
- Multiple output improvements

_TODO:_
_make suffix option working only for found files_