### PR TITLE
Batch results were reported one more time in plain text report.

### DIFF
--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -181,9 +181,6 @@ class Controller(object):
                 except SkipTargetInterrupt:
                     continue
 
-                finally:
-                    self.reportManager.save()
-
         except KeyboardInterrupt:
             self.output.error('\nCanceled by the user')
             exit(0)


### PR DESCRIPTION
It is fixed! Just try to check with --plain-text-report in batch mode, it can be seen that the results printing lots of time. The output is printing using matchCallback function and also the init function. I remove the line related printing output from init function. The results are printing using just matchCallback function now.