### PR TITLE
Add Deskpro helpdesk software RCE

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -1840,6 +1840,7 @@ api/
 api/error_log
 api/jsonws/invoke
 api/swagger.yml
+api/v2/helpdesk/discover
 apibuild.pyc
 app
 APP


### PR DESCRIPTION
REF: https://blog.redforce.io/attacking-helpdesks-part-1-rce-chain-on-deskpro-with-bitdefender-as-case-study/