### PR TITLE
Add missing separator to 'HTTP method' section of CLI output

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -191,6 +191,7 @@ class CLIOutput(object):
         config += separator
 
         config += "HTTP method: {0}".format(Fore.CYAN + method + Fore.YELLOW)
+        config += separator
 
         if suffixes != '':
             config += 'Suffixes: {0}'.format(Fore.CYAN + suffixes + Fore.YELLOW)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26336858/86035449-38d59600-b9f1-11ea-8e72-6b6c1824352c.png)

Separator was missing in the CLI output.