### PR TITLE
[BugFix] Bug fixes in header

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -175,8 +175,8 @@ class CLIOutput(object):
 
     def config(
         self,
-        suffixes,
         extensions,
+        suffixes,
         threads,
         wordlist_size,
         request_count,
@@ -189,8 +189,6 @@ class CLIOutput(object):
         config = Style.BRIGHT + Fore.YELLOW
         config += "Extensions: {0}".format(Fore.CYAN + extensions + Fore.YELLOW)
         config += separator
-
-        config += "HTTP method: {0}".format(Fore.CYAN + method + Fore.YELLOW)
 
         if suffixes != '':
             config += 'Suffixes: {0}'.format(Fore.CYAN + suffixes + Fore.YELLOW)


### PR DESCRIPTION
Hi,

Header was a little bit messed up. 

**Bugs fixed:**
* In header, "HTTP Method" was shown multiple times
* In place of Suffixes, Extensions were shown
* In place of Extensions, Suffixes were shown

**Before:**
![before](https://user-images.githubusercontent.com/24238512/88016846-cbbfa700-cb3d-11ea-9fd8-b4cf1a78bc8a.png)

**After:**
![after](https://user-images.githubusercontent.com/24238512/88016872-d7ab6900-cb3d-11ea-8720-bca9fca42e54.png)



