### PR TITLE
Fixing output missing separator

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -191,13 +191,13 @@ class CLIOutput(object):
         config += separator
 
         config += "HTTP method: {0}".format(Fore.CYAN + method + Fore.YELLOW)
+        config += separator
 
         if suffixes != '':
             config += 'Suffixes: {0}'.format(Fore.CYAN + suffixes + Fore.YELLOW)
             config += separator
         config += 'HTTP method: {0}'.format(Fore.CYAN + method + Fore.YELLOW)
 
-        config += separator
         config += "Threads: {0}".format(Fore.CYAN + threads + Fore.YELLOW)
         config += separator
         config += "Wordlist size: {0}".format(Fore.CYAN + wordlist_size + Fore.YELLOW)


### PR DESCRIPTION
This PR fixes the following issue with CLIOutput on config output. **HTTP method** and **Suffixes** where not correctly separated.

**From:**
```
 _|. _ _  _  _  _ _|_    v0.3.9
(_||| _) (/_(_|| (_| )

Extensions:  | HTTP method: getSuffixes: html, php, zip | HTTP method: get | Threads: 64 | Wordlist size: 102360 | Request count: 102360 (+recursive) | Recursion level: 3
```

**To:**

```
 _|. _ _  _  _  _ _|_    v0.3.9
(_||| _) (/_(_|| (_| )

Extensions:  | HTTP method: get | Suffixes: html, php, zip | HTTP method: getThreads: 64 | Wordlist size: 102360 | Request count: 102360 (+recursive) | Recursion level: 3
```