### PR TITLE
fixing excludeTexts option

### DIFF
--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -287,6 +287,7 @@ class ArgumentParser(object):
         self.includeStatusCodes = config.safe_get("general", "include-status", None)
 
         self.excludeStatusCodes = config.safe_get("general", "exclude-status", None)
+        self.excludeTexts = config.safe_get("general", "exclude-texts", None)
         self.redirect = config.safe_getboolean("general", "follow-redirects", False)
         self.recursive = config.safe_getboolean("general", "recursive", False)
         self.recursive_level_max = config.safe_getint(


### PR DESCRIPTION
on line  175 it checks if option excludeTexts is None which it's gonna be none all the time since the parseConfig fun does not have it, i added it to the fun so now if a user used it it will not be None anymore.