### PR TITLE
Fix #274

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -22,6 +22,7 @@ import threading
 import time
 
 import urllib.parse
+from posixpath import join as urljoin
 
 from lib.utils.FileUtils import *
 from lib.utils.TerminalSize import get_terminal_size
@@ -101,11 +102,11 @@ class CLIOutput(object):
                 contentLength = FileUtils.sizeHuman(size)
 
             if self.basePath is None:
-                showPath = urllib.parse.urljoin("/", path)
+                showPath = urljoin("/", path)
 
             else:
-                showPath = urllib.parse.urljoin("/", self.basePath)
-                showPath = urllib.parse.urljoin(showPath, path)
+                showPath = urljoin("/", self.basePath)
+                showPath = urljoin(showPath, path)
             message = "[{0}] {1} - {2} - {3}".format(
                 time.strftime("%H:%M:%S"), status, contentLength.rjust(6, " "), showPath
             )

--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -21,7 +21,6 @@ import sys
 import threading
 import time
 
-import urllib.parse
 from posixpath import join as urljoin
 
 from lib.utils.FileUtils import *

--- a/lib/output/PrintOutput.py
+++ b/lib/output/PrintOutput.py
@@ -21,7 +21,7 @@ import sys
 import threading
 import time
 
-import urllib.parse
+from posixpath import join as urljoin
 
 from lib.utils.FileUtils import *
 from lib.utils.TerminalSize import get_terminal_size
@@ -74,11 +74,11 @@ class PrintOutput(object):
                 contentLength = FileUtils.sizeHuman(size)
 
             if self.basePath is None:
-                showPath = urllib.parse.urljoin("/", path)
+                showPath = urljoin("/", path)
 
             else:
-                showPath = urllib.parse.urljoin("/", self.basePath)
-                showPath = urllib.parse.urljoin(showPath, path)
+                showPath = urljoin("/", self.basePath)
+                showPath = urljoin(showPath, path)
                 showPath = self.target + showPath
             message = "{0} - {1} - {2}".format(
                 status, contentLength.rjust(6, " "), showPath


### PR DESCRIPTION
Fix #274. I have tested VERY carefully and found that my solution can parse everything the same as `urllib.parse.urljoin`. The only difference is that `posixpath.join` won't edit anything in the path even though there are `..`, `.` or how much `/` in the path:

```python
>>> from posixpath import join as urljoin
>>> urljoin('/', 'test')
'/test'
>>> urljoin('/', 'test/')
'/test/'
>>> urljoin('/', 'test/blah')
'/test/blah'
>>> urljoin('/foo', 'test/blah')
'/foo/test/blah'
>>> urljoin('/foo/bar', 'test/blah')
'/foo/bar/test/blah'
>>> urljoin('/', '../../../../../../etc/passwd')
'/../../../../../../etc/passwd'
>>> urljoin('/', './admin')
'/./admin'
>>> urljoin('/', '/////something')
'/////something'
>>> urljoin('https://google.com', 'path')
'https://google.com/path'
```