### PR TITLE
Fix Python SyntaxWarning

### DIFF
--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -331,7 +331,7 @@ class Controller(object):
     def setupReports(self, requester):
         if self.arguments.autoSave:
 
-            basePath = "/" if requester.basePath is "" else requester.basePath
+            basePath = "/" if requester.basePath == "" else requester.basePath
             basePath = basePath.replace(os.path.sep, ".")[1:-1]
             fileName = None
             directoryPath = None

--- a/lib/reports/PlainTextReport.py
+++ b/lib/reports/PlainTextReport.py
@@ -49,7 +49,7 @@ class PlainTextReport(TailableFileBaseReport):
             result += "{0}://{1}:{2}/".format(self.protocol, self.host, self.port)
             result += (
                 "{0}".format(path)
-                if self.basePath is ""
+                if self.basePath == ""
                 else "{0}/{1}".format(self.basePath, path)
             )
             if location:

--- a/lib/reports/SimpleReport.py
+++ b/lib/reports/SimpleReport.py
@@ -29,7 +29,7 @@ class SimpleReport(TailableFileBaseReport):
             result += "{0}://{1}:{2}/".format(self.protocol, self.host, self.port)
             result += (
                 "{0}\n".format(path)
-                if self.basePath is ""
+                if self.basePath == ""
                 else "{0}/{1}\n".format(self.basePath, path)
             )
 


### PR DESCRIPTION
This is the warning message I received when running dirsearch:

```python
/home/shelld3v/dirsearch/lib/controller/Controller.py:318: SyntaxWarning: "is" with a literal. Did you mean "=="?
  basePath = "/" if requester.basePath is "" else requester.basePath
/home/shelld3v/dirsearch/lib/reports/PlainTextReport.py:52: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.basePath is ""
/home/shelld3v/dirsearch/lib/reports/SimpleReport.py:32: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.basePath is ""
```
Simple test:

```python
>>> test = ""
>>> test is ""
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
>>> test == ""
True
>>>
```