### PR TITLE
Fix a bug in output with extensions and suffixes

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -175,8 +175,8 @@ class CLIOutput(object):
 
     def config(
         self,
-        suffixes,
         extensions,
+        suffixes.
         threads,
         wordlist_size,
         request_count,

--- a/lib/output/PrintOutput.py
+++ b/lib/output/PrintOutput.py
@@ -120,9 +120,8 @@ class PrintOutput(object):
 
     def config(
         self,
-        
-        suffixes,
         extensions,
+        suffixes,
         threads,
         wordlist_size,
         request_count,


### PR DESCRIPTION
From **/lib/controller/Controller.py**:

```python
        self.output.config(
            ', '.join(self.arguments.extensions),   <-
            ', '.join(self.arguments.suffixes),     <-
            str(self.arguments.threadsCount),
            str(len(self.dictionary)),
            str(requestCount),
            str(self.httpmethod),
            self.recursive,
            str(self.recursive_level_max),
        )
```

Error:

```python
$ dirsearch.py -u https://example.com -e html,htm,php,jsp,asp,js,json
...
Extensions:  | HTTP method: GET | Suffixes: html, htm, php, jsp, asp, js, json | ...
```