### PR TITLE
Remove "Request count" information

### DIFF
--- a/lib/controller/Controller.py
+++ b/lib/controller/Controller.py
@@ -226,17 +226,11 @@ class Controller(object):
 
     def printConfig(self):
 
-        requestCount = len(self.dictionary)
-
-        if self.arguments.scanSubdirs is not None:
-            requestCount = requestCount * len(self.arguments.scanSubdirs)
-
         self.output.config(
             ', '.join(self.arguments.extensions),
             ', '.join(self.arguments.suffixes),
             str(self.arguments.threadsCount),
             str(len(self.dictionary)),
-            str(requestCount),
             str(self.httpmethod),
             self.recursive,
             str(self.recursive_level_max),

--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -179,7 +179,6 @@ class CLIOutput(object):
         extensions,
         threads,
         wordlist_size,
-        request_count,
         method,
         recursive,
         recursion_level,
@@ -202,15 +201,6 @@ class CLIOutput(object):
         config += separator
         config += "Wordlist size: {0}".format(Fore.CYAN + wordlist_size + Fore.YELLOW)
         config += separator
-
-        if recursive == False:
-            config += "Request count: {0}".format(
-                Fore.CYAN + request_count + Fore.YELLOW
-            )
-        else:
-            config += "Request count: {0} (+recursive)".format(
-                Fore.CYAN + request_count + Fore.YELLOW
-            )
 
         if recursive == True:
             config += separator

--- a/lib/output/PrintOutput.py
+++ b/lib/output/PrintOutput.py
@@ -125,7 +125,6 @@ class PrintOutput(object):
         extensions,
         threads,
         wordlist_size,
-        request_count,
         method,
         recursive,
         recursion_level,


### PR DESCRIPTION
This is just an option for you if you want it or not. But totally, I feel that adding *request count* just makes the terminal looked dirtier. Keep the config information in one line is the best:

What I want:

```python
Extensions: html | HTTP method: GET | Threads: 9 | Wordlist size: 15315 | Recursion level: 1
```
```python
Extensions: html | HTTP method: GET | Suffixes: php | Threads: 9 | Wordlist size: 15315 | Recursion level: 1
```
But:

```python
Extensions: html | HTTP method: GET | Threads: 9 | Wordlist size: 15315 | Request count: 15315 (+recursive) | Recursion 
level: 1
```
```python
Extensions: html | HTTP method: GET | Suffixes: php | Threads: 9 | Wordlist size: 15315 | Request count: 15315 (+recursi
ve) | Recursion level: 1
```