### PR TITLE
Update ArgumentParser.py

### DIFF
--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -281,7 +281,7 @@ class ArgumentParser(object):
         # General
 
         self.threadsCount = config.safe_getint(
-            "general", "threads", 10, list(range(1, 200))
+            "general", "threads", 12, list(range(1, 200))
         )
 
         self.includeStatusCodes = config.safe_get("general", "include-status", None)


### PR DESCRIPTION
Most hackers now are having their own wordlist, and the size of it is really huge. `ffuf` is now defeating `dirsearch` at speed, so I have updated the default threads number of `dirsearch` so it will be faster a little bit for people who doesn't know or lazy to set the threads. 

*Remember that the default threads number of `ffuf` is 40*