### PR TITLE
typo in config

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -179,7 +179,7 @@ class CLIOutput(object):
     def config(
         self,
         extensions,
-        suffixes.
+        suffixes,
         threads,
         wordlist_size,
         method,


### PR DESCRIPTION
Eliminate SyntaxError: invalid syntax when executing due to a typo