### PR TITLE
Remove a separator

### DIFF
--- a/lib/output/CLIOutput.py
+++ b/lib/output/CLIOutput.py
@@ -203,7 +203,6 @@ class CLIOutput(object):
         config += "Threads: {0}".format(Fore.CYAN + threads + Fore.YELLOW)
         config += separator
         config += "Wordlist size: {0}".format(Fore.CYAN + wordlist_size + Fore.YELLOW)
-        config += separator
 
         if recursive == True:
             config += separator


### PR DESCRIPTION
```python

 _|. _ _  _  _  _ _|_    v0.3.9
(_||| _) (/_(_|| (_| )

Extensions: php, html, txt, json, htm, xhtml, js | HTTP method: GET | Threads: 12 | Wordlist size: 8721 |
                                                                                                        ^
```