### PR TITLE
Fix #304

### DIFF
--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -98,11 +98,11 @@ class Dictionary(object):
                 if '%ext%' in line.lower():
                     for extension in self._extensions:
                         if self._noDotExtensions:
-                            line = reextdot.sub(extension, line)
+                            entry = reextdot.sub(extension, line)
 
-                        line = reext.sub(extension, line)
+                        entry = reext.sub(extension, line)
 
-                        quote = self.quote(line)
+                        quote = self.quote(entry)
                         result.append(quote)
 
                 # If forced extensions is used and the path is not a directory ... (terminated by /)


### PR DESCRIPTION
dirsearch created a loop to add all the extensions into the entry:

```python
for extension in self._extensions:
```

But you accidentally edited the entry after the first time:

```python
if self._noDotExtensions:
    line = reextdot.sub(extension, line)

line = reext.sub(extension, line)
```

That removed the `%EXT%` and caused the bug 🤕 