### PR TITLE
Boost wordlist generator

### DIFF
--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -87,7 +87,7 @@ class Dictionary(object):
 
         # Enable to use multiple dictionaries at once
         for dictFile in self.dictionaryFiles:
-            for line in dictFile.getLines():
+            for line in list(dict.fromkeys(dictFile.getLines())):
 
                 # Skip comments
                 if line.lstrip().startswith("#"):
@@ -130,7 +130,6 @@ class Dictionary(object):
                 if not res.rstrip().endswith("/"):
                     for suff in self._suffixes:
                         result.append(res + suff)
-
 
 
         if self.lowercase:

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -24,7 +24,6 @@ import urllib.parse
 import urllib.request
 
 from lib.utils.FileUtils import File
-from thirdparty.oset import *
 
 
 class Dictionary(object):
@@ -133,15 +132,15 @@ class Dictionary(object):
                         result.append(res + suff)
 
 
-        # oset library provides inserted ordered and unique collection.
+
         if self.lowercase:
-            self.entries = list(oset(map(lambda l: l.lower(), result)))
+            self.entries = list(dict.fromkeys(map(lambda l: l.lower(), result)))
             
         elif self.uppercase:
-            self.entries = list(oset(map(lambda l: l.upper(), result)))
+            self.entries = list(dict.fromkeys(map(lambda l: l.upper(), result)))
 
         else:
-            self.entries = list(oset(result))
+            self.entries = list(dict.fromkeys(result))
 
         del result
 


### PR DESCRIPTION
#### Can `dict.fromkeys()` preserve the order?
Yes

```python
>>> from oset import *
>>>
>>> alist = ['l', 'b', 'd', 'a', '1', 'd', '1', '2']
>>> list(oset(alist))
['l', 'b', 'd', 'a', '1', '2']
>>> list(dict.fromkeys(alist))
['l', 'b', 'd', 'a', '1', '2']
```

#### Why we should change from `oset()` to `dict.fromkeys()`?
Boost dirsearch, that's all.

**Comparison:**
```python
>>> from oset import *
[0.00971442184448242 secs]
>>> 
>>> alist = []
>>> for x in range(500000):
...     alist.append(x)
...
>>> 
>>> test1 = list(oset(alist))
[1.609781770706177 secs]
>>> test2 = list(dict.fromkeys(alist))
[0.1053035259246826 secs]
```

**Results:**
- `oset()`: 0.0097 secs + 1.6097 secs = 1.6194 seconds  
=> 1.6 seconds
- `dict.fromkeys()`: 0.1053 seconds 
=> 0.1 seconds

That is when we use a 500,000 endpoints wordlist. Haven't tested with a 1 million endpoints wordlist 🙄 