### PR TITLE
Speed up the wordlist generator by "avoiding dot"

### DIFF
--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -85,6 +85,7 @@ class Dictionary(object):
         reext = re.compile('\%ext\%', re.IGNORECASE)
         reextdot = re.compile('\.\%ext\%', re.IGNORECASE)
         result = []
+        append = result.append
 
         # Enable to use multiple dictionaries at once
         for dictFile in self.dictionaryFiles:
@@ -103,7 +104,7 @@ class Dictionary(object):
                         entry = reext.sub(extension, line)
 
                         quote = self.quote(entry)
-                        result.append(quote)
+                        append(quote)
 
                 # If forced extensions is used and the path is not a directory ... (terminated by /)
                 # process line like a forced extension.
@@ -113,24 +114,24 @@ class Dictionary(object):
                     for extension in self._extensions:
                         # Why? check https://github.com/maurosoria/dirsearch/issues/70
                         if extension.strip() == '':
-                            result.append(quoted)
+                            append(quoted)
                         else:
-                            result.append(quoted + ('' if self._noDotExtensions else '.') + extension)
+                            append(quoted + ('' if self._noDotExtensions else '.') + extension)
 
                     if quoted.strip() not in ['']:
-                        result.append(quoted)
-                        result.append(quoted + "/")
+                        append(quoted)
+                        append(quoted + "/")
 
                 # Append line unmodified.
                 else:
-                    result.append(self.quote(line))
+                    append(self.quote(line))
 
         # Adding suffixes for finding backups etc
         if self._suffixes:
             for res in list(result):
                 if not res.rstrip().endswith("/"):
                     for suff in self._suffixes:
-                        result.append(res + suff)
+                        append(res + suff)
 
 
         # oset library provides inserted ordered and unique collection.


### PR DESCRIPTION
Read from a blog post! 

**First solution:**

```python
def timer():
     start_time = time.time()
     for x in range(500000):
         test.append(x)
     print(time.time() - start_time)
``` 
Results:

```python
>>> timer()
0.07306313514709473
>>> timer()
0.08280205726623535
>>> timer()
0.07710886001586914
```
**Second solution:**

```python
 def timer():
     start_time = time.time()
     append = test.append
     for x in range(500000):
          append(x)
     print(time.time() - start_time)
```
Results:

```python
>>> timer()
0.047969818115234375
>>> timer()
0.04876255989074707
>>> timer()
0.04903578758239746
```

It faster by twice