### PR TITLE
New update: %NOFORCE% in the wordlist

### DIFF
--- a/lib/core/ArgumentParser.py
+++ b/lib/core/ArgumentParser.py
@@ -378,7 +378,7 @@ class ArgumentParser(object):
                              action='store', dest='suffixes', default=None)
 
         dictionary.add_option('-f', '--force-extensions',
-                              help='Force extensions for every wordlist entry',
+                              help='Force extensions for every wordlist entry. Add %NOFORCE% at the end of the endpoint that you do not want to force in the wordlist',
                               action='store_true', dest='forceExtensions', default=self.forceExtensions)
         dictionary.add_option('--nd', '--no-dot-extensions',
                               help='Don\'t add a \'.\' character before extensions', action='store_true',

--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -81,8 +81,9 @@ class Dictionary(object):
     """
 
     def generate(self):
-        reext = re.compile('\%ext\%', re.IGNORECASE)
-        reextdot = re.compile('\.\%ext\%', re.IGNORECASE)
+        reext = re.compile('\%ext\%', re.IGNORECASE).sub
+        reextdot = re.compile('\.\%ext\%', re.IGNORECASE).sub
+        renoforce = re.compile('\%noforce\%', re.IGNORECASE).sub
         result = []
 
         # Enable to use multiple dictionaries at once
@@ -94,22 +95,24 @@ class Dictionary(object):
                     continue
 
                 # Classic dirsearch wordlist processing (with %EXT% keyword)
-                if '%ext%' in line.lower():
+                if "%ext%" in line.lower():
+                    line = renoforce("", line)
+                    
                     for extension in self._extensions:
                         if self._noDotExtensions:
-                            newline = reextdot.sub(extension, line)
+                            newline = reextdot(extension, line)
 
                         else:
                             newline = line
                             
-                        newline = reext.sub(extension, newline)
+                        newline = reext(extension, newline)
 
                         quote = self.quote(newline)
                         result.append(quote)
 
                 # If forced extensions is used and the path is not a directory ... (terminated by /)
                 # process line like a forced extension.
-                elif self._forcedExtensions and not line.rstrip().endswith("/"):
+                elif self._forcedExtensions and not line.rstrip().endswith("/") and not "%noforce%" in line.lower():
                     quoted = self.quote(line)
 
                     for extension in self._extensions:
@@ -123,8 +126,10 @@ class Dictionary(object):
                         result.append(quoted)
                         result.append(quoted + "/")
 
-                # Append line unmodified.
+                # Append line unmodified. Also if the line is having the %NOFORCE% keyword
                 else:
+                    line = renoforce("", line)
+                    
                     result.append(self.quote(line))
 
         # Adding suffixes for finding backups etc


### PR DESCRIPTION
Sometimes, the wordlist contains endpoints of open source projects or something like that, example: `phpMyAdmin.php`, `SiteServer/Admin/commerce/foundation/DSN.asp`. These endpoints should not be forced since there won't be anything like `phpMyAdmin.php.jsp`. Using %NOFORCE%, the hacker can reduce a lot of trash endpoints from the force mode.