### PR TITLE
Bug Fix

### DIFF
--- a/lib/core/Dictionary.py
+++ b/lib/core/Dictionary.py
@@ -27,7 +27,7 @@ from lib.utils.FileUtils import File
 class Dictionary(object):
 
 
-    def __init__(self, paths, extensions, suffixes=None, prefixes=None, lowercase=False, uppercase=False, forcedExtensions=False, noDotExtensions=False, excludeExtensions):
+    def __init__(self, paths, extensions, suffixes=None, prefixes=None, lowercase=False, uppercase=False, forcedExtensions=False, noDotExtensions=False, excludeExtensions=[]):
         self.entries = []
         self.currentIndex = 0
         self.condition = threading.Lock()


### PR DESCRIPTION
Fix the following error:

```
Traceback (most recent call last):
  File "./dirsearch.py", line 26, in <module>
    from lib.core import ArgumentParser
  File "/home/serhat/Desktop/dirsearch/lib/core/__init__.py", line 2, in <module>
    from .Dictionary import *
  File "/home/serhat/Desktop/dirsearch/lib/core/Dictionary.py", line 30
    def __init__(self, paths, extensions, suffixes=None, prefixes=None, lowercase=False, uppercase=False, forcedExtensions=False, noDotExtensions=False, excludeExtensions):
                 ^
SyntaxError: non-default argument follows default argument`
``