### PR TITLE
update docker tag to python:3-alpine and reduced image to 80MB (was 1GB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3
-MAINTAINER greenmind.sec@gmail.com
-RUN apt-get update -y
-RUN apt-get install python3-pip -y
+
+FROM python:3-alpine
+LABEL maintainer="wfnintr@null.net"
 WORKDIR /root
-ADD . .
-WORKDIR /root/
-RUN chmod +x dirsearch.py
-ENTRYPOINT ["/root/dirsearch.py"]
+RUN apk add --no-cache --virtual .depends git 
+RUN git clone https://github.com/maurosoria/dirsearch.git
+RUN apk del .depends
+WORKDIR /root/dirsearch
+ENTRYPOINT ["./dirsearch.py"]
 CMD ["--help"]


### PR DESCRIPTION
The base `python:3-alpine` image tag is only 42.7MB whereas the current default `python:3` tag is 882MB

The current dockerfile when built comes out to a big 1.03GB.

I suggest building with alpine instead and it reduces the image to 80.4MB. 

Tested and works.
