### PR TITLE
[Help needed] 429 Detector

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -438,7 +438,7 @@ class Controller(object):
                     not self.includeStatusCodes or path.status in self.includeStatusCodes) and (
                     not(self.blacklists.get(path.status)) or path.path not in self.blacklists.get(path.status)
             ) and not (
-                    (self.suppressEmpty and not len(path.response.body)) and not ((
+                    (self.suppressEmpty and not len(path.response.body)) and (
                     self.minimumResponseSize and self.minimumResponseSize > len(path.response.body)) or (
                     self.maximumResponseSize and self.maximumResponseSize < len(path.response.body))
             ):


### PR DESCRIPTION
Description
---------------

Hi everyone, I am trying to create a 429 Detector, to finish one of the ideas I have already thought about for this project. But currently, I am having a problem with this:

```
$ python3 dirsearch.py -E -u localhost:4444

  _|. _ _  _  _  _ _|_    v0.4.0
 (_||| _) (/_(_|| (_| )

Extensions: php, asp, aspx, jsp, html, htm, js | HTTP method: GET | Threads: 20 | Wordlist size: 9990

Error Log: /tmp/dirsearch/logs/errors-20-10-18_13-28-37.log

Target: http://localhost:4444/

Output File: /tmp/dirsearch/reports/localhost/_20-10-18_13-28-37.txt

[13:28:37] Starting:
429 Too Many Requests detected: Server is blocking requests
11.99% (1198/9990) - Last request to: 52e
[stop response from here]
```

Correct:

```
$ python3 dirsearch.py -E -u localhost:4444

  _|. _ _  _  _  _ _|_    v0.4.0
 (_||| _) (/_(_|| (_| )

Extensions: php, asp, aspx, jsp, html, htm, js | HTTP method: GET | Threads: 20 | Wordlist size: 9990

Error Log: /tmp/dirsearch/logs/errors-20-10-18_13-28-37.log

Target: http://localhost:4444/

Output File: /tmp/dirsearch/reports/localhost/_20-10-18_13-28-37.txt

[13:28:37] Starting:
429 Too Many Requests detected: Server is blocking requests
[c]ontinue / [e]xit: e

Canceled by the user
```
 Hope if anyone out there can help to fix this issue. For more information, I think the problem comes from here:

```
    def processPaths(self):
        while True:
            try:
                while not self.fuzzer.wait(0.3):
                    continue
                break

            except (KeyboardInterrupt, SystemExit):
                self.handleInterrupt()
```

Somehow we need to stop this loop, is that correct???