### PR TITLE
Disable Insecure HTTPS warning

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -21,13 +21,10 @@ import random
 import socket
 import time
 import urllib.parse
-import thirdparty.requests as requests
 
+import thirdparty.requests as requests
 from .request_exception import *
 from .response import *
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 class Requester(object):

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -21,10 +21,13 @@ import random
 import socket
 import time
 import urllib.parse
-
 import thirdparty.requests as requests
+
 from .request_exception import *
 from .response import *
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 class Requester(object):

--- a/thirdparty/__init__.py
+++ b/thirdparty/__init__.py
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 pass

--- a/thirdparty/requests/__init__.py
+++ b/thirdparty/requests/__init__.py
@@ -45,6 +45,8 @@ import chardet
 import warnings
 from .exceptions import RequestsDependencyWarning
 
+urllib3.disable_warnings()
+
 
 def check_compatibility(urllib3_version, chardet_version):
     urllib3_version = urllib3_version.split('.')


### PR DESCRIPTION
Description
---------------

Since 2017, `urllib3` not a part of `requests` anymore. That is why my update for the `requests` module created the `InsecureRequestWarning` message