### PR TITLE
Remove useless --ip option

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -75,7 +75,7 @@ class Requester(object):
         self.host = parsed.netloc.split(":")[0]
 
         # resolve DNS to decrease overhead
-        if not self.requestByHostname:
+        if not requestByHostname:
             try:
                 self.ip = socket.gethostbyname(self.host)
             except socket.gaierror:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -75,11 +75,10 @@ class Requester(object):
         self.host = parsed.netloc.split(":")[0]
 
         # resolve DNS to decrease overhead
-        if not requestByHostname:
-            try:
-                self.ip = socket.gethostbyname(self.host)
-            except socket.gaierror:
-                raise RequestException({"message": "Couldn't resolve DNS"})
+        try:
+            self.ip = socket.gethostbyname(self.host)
+        except socket.gaierror:
+            raise RequestException({"message": "Couldn't resolve DNS"})
 
         # If no port specified, set default (80, 443)
         try:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -45,7 +45,6 @@ class Requester(object):
         maxRetries=5,
         delay=0,
         timeout=20,
-        ip=None,
         proxy=None,
         proxylist=None,
         redirect=False,
@@ -76,9 +75,7 @@ class Requester(object):
         self.host = parsed.netloc.split(":")[0]
 
         # resolve DNS to decrease overhead
-        if ip:
-            self.ip = ip
-        else:
+        if not self.requestByHostname:
             try:
                 self.ip = socket.gethostbyname(self.host)
             except socket.gaierror:

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -170,7 +170,6 @@ class Controller(object):
                             maxRetries=self.arguments.maxRetries,
                             delay=self.arguments.delay,
                             timeout=self.arguments.timeout,
-                            ip=self.arguments.ip,
                             proxy=self.arguments.proxy,
                             proxylist=self.arguments.proxylist,
                             redirect=self.arguments.redirect,

--- a/lib/core/argument_parser.py
+++ b/lib/core/argument_parser.py
@@ -281,7 +281,6 @@ class ArgumentParser(object):
         self.markdownOutputFile = options.markdownOutputFile
         self.delay = options.delay
         self.timeout = options.timeout
-        self.ip = options.ip
         self.maxRetries = options.maxRetries
         self.recursive = options.recursive
         self.minimumResponseSize = options.minimumResponseSize
@@ -499,8 +498,6 @@ You can change the dirsearch default configurations (default extensions, timeout
         connection = OptionGroup(parser, 'Connection Settings')
         connection.add_option('--timeout', action='store', dest='timeout', type='int',
                               default=self.timeout, help='Connection timeout')
-        connection.add_option('--ip', action='store', dest='ip', default=None,
-                              help='Server IP address')
         connection.add_option('-s', '--delay', help='Delay between requests (support float number)', action='store', dest='delay',
                               type='float', default=self.delay)
         connection.add_option('--proxy', action='store', dest='proxy', type='string', default=self.proxy,


### PR DESCRIPTION
Description
---------------

The user can --request-by-hostname rather than find the hidden IP address and use with --ip