### PR TITLE
Option to Disable Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Updating ...
 - Debug mode
 - Several updates
 - Multiple bugfixes
+- Disable colored output
 
 ---------
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,4 @@
 - [ColdFusionX](https://github.com/ColdFusionX)
 - [gdattacker](https://github.com/gauravdrago)
 - [chowmean](http://chowmean.github.io/)
+- [wdahlenburg](https://github.com/wdahlenburg)

--- a/default.conf
+++ b/default.conf
@@ -8,6 +8,7 @@ exclude-subdirs = %%ff/
 save-logs-home = False
 full-url = False
 quiet-mode = False
+color = True
 # headers-file = headers.txt
 # include-status = 200,301
 # exclude-status = 500,502

--- a/dirsearch.py
+++ b/dirsearch.py
@@ -36,9 +36,9 @@ class Program(object):
         self.arguments = ArgumentParser(self.script_path)
 
         if self.arguments.quiet:
-            self.output = PrintOutput()
+            self.output = PrintOutput(self.arguments.color)
         else:
-            self.output = CLIOutput()
+            self.output = CLIOutput(self.arguments.color)
 
         self.controller = Controller(self.script_path, self.arguments, self.output)
 

--- a/lib/core/argument_parser.py
+++ b/lib/core/argument_parser.py
@@ -289,6 +289,7 @@ class ArgumentParser(object):
         self.jsonOutputFile = options.jsonOutputFile
         self.xmlOutputFile = options.xmlOutputFile
         self.markdownOutputFile = options.markdownOutputFile
+        self.color = options.color
         self.delay = options.delay
         self.timeout = options.timeout
         self.ip = options.ip
@@ -360,7 +361,7 @@ class ArgumentParser(object):
         )
 
         self.includeStatusCodes = config.safe_get("general", "include-status", None)
-
+        self.color = config.safe_getboolean("general", "color", True)
         self.excludeStatusCodes = config.safe_get("general", "exclude-status", None)
         self.excludeSizes = config.safe_get("general", "exclude-sizes", None)
         self.excludeTexts = config.safe_get("general", "exclude-texts", None)
@@ -478,6 +479,8 @@ You can change the dirsearch default configurations (default extensions, timeout
                            help='Maximal response length', metavar='LENGTH')
         general.add_option('--scan-subdirs', help='Scan subdirectories of the given URL[s] (separated by commas)', action='store',
                            dest='scanSubdirs', default=None, metavar='SUBDIRS')
+        general.add_option('--no-color', help='Return the results with colored output', action='store_false',
+                           dest='color', default=True, metavar='COLOR')
         general.add_option('--exclude-subdirs', help='Exclude the following subdirectories during recursive scan (separated by commas)',
                            action='store', dest='excludeSubdirs', default=self.excludeSubdirs, metavar='SUBDIRS')
         general.add_option('-i', '--include-status', help='Show only included status codes, separated by commas (Example: 301,500)',

--- a/lib/output/cli_output.py
+++ b/lib/output/cli_output.py
@@ -30,7 +30,7 @@ if sys.platform in ["win32", "msys"]:
 
 
 class CLIOutput(object):
-    def __init__(self):
+    def __init__(self, color):
         init()
         self.lastLength = 0
         self.lastOutput = ""
@@ -39,6 +39,7 @@ class CLIOutput(object):
         self.blacklists = {}
         self.basePath = None
         self.errors = 0
+        self.color = color
 
     def inLine(self, string):
         self.erase()
@@ -105,23 +106,25 @@ class CLIOutput(object):
             showPath,
         )
 
-        if status == 200:
-            message = Fore.GREEN + message + Style.RESET_ALL
+        if self.color:
+            if status == 200:
+                message = Fore.GREEN + message + Style.RESET_ALL
 
-        elif status == 401:
-            message = Fore.YELLOW + message + Style.RESET_ALL
+            elif status == 401:
+                message = Fore.YELLOW + message + Style.RESET_ALL
 
-        elif status == 403:
-            message = Fore.BLUE + message + Style.RESET_ALL
+            elif status == 403:
+                message = Fore.BLUE + message + Style.RESET_ALL
 
-        elif status == 500:
-            message = Fore.RED + message + Style.RESET_ALL
+            elif status == 500:
+                message = Fore.RED + message + Style.RESET_ALL
 
         # Check if redirect
-        elif status in [301, 302, 303, 307, 308] and "location" in [
+        if status in [301, 302, 303, 307, 308] and "location" in [
             h.lower() for h in response.headers
         ]:
-            message = Fore.CYAN + message + Style.RESET_ALL
+            if self.color:
+                message = Fore.CYAN + message + Style.RESET_ALL
             message += "  ->  {0}".format(response.headers["location"])
 
         if addedToQueue:
@@ -165,13 +168,15 @@ class CLIOutput(object):
             message += Style.RESET_ALL
             self.newLine(message)
 
-    def warning(self, reason):
+    def warning(self, message):
         with self.mutex:
-            message = Style.BRIGHT + Fore.YELLOW + reason + Style.RESET_ALL
+            if self.color:
+                message = Style.BRIGHT + Fore.YELLOW + message + Style.RESET_ALL
             self.newLine(message)
 
-    def header(self, text):
-        message = Style.BRIGHT + Fore.MAGENTA + text + Style.RESET_ALL
+    def header(self, message):
+        if self.color:
+            message = Style.BRIGHT + Fore.MAGENTA + message + Style.RESET_ALL
         self.newLine(message)
 
     def config(
@@ -183,30 +188,55 @@ class CLIOutput(object):
         wordlist_size,
         method,
     ):
-        separator = Fore.MAGENTA + " | " + Fore.YELLOW
 
-        config = Style.BRIGHT + Fore.YELLOW
-        config += "Extensions: {0}".format(Fore.CYAN + extensions + Fore.YELLOW)
-        config += separator
+        if self.color:
+            separator = Fore.MAGENTA + " | " + Fore.YELLOW
 
-        config += "HTTP method: {0}".format(Fore.CYAN + method.upper() + Fore.YELLOW)
-        config += separator
-
-        if prefixes != '':
-            config += 'Prefixes: {0}'.format(Fore.CYAN + prefixes + Fore.YELLOW)
+            config = Style.BRIGHT + Fore.YELLOW
+            config += "Extensions: {0}".format(Fore.CYAN + extensions + Fore.YELLOW)
             config += separator
 
-        if suffixes != '':
-            config += 'Suffixes: {0}'.format(Fore.CYAN + suffixes + Fore.YELLOW)
+            config += "HTTP method: {0}".format(Fore.CYAN + method.upper() + Fore.YELLOW)
             config += separator
 
-        config += "Threads: {0}".format(Fore.CYAN + threads + Fore.YELLOW)
-        config += separator
-        config += "Wordlist size: {0}".format(Fore.CYAN + wordlist_size + Fore.YELLOW)
+            if prefixes != '':
+                config += 'Prefixes: {0}'.format(Fore.CYAN + prefixes + Fore.YELLOW)
+                config += separator
 
-        config += Style.RESET_ALL
+            if suffixes != '':
+                config += 'Suffixes: {0}'.format(Fore.CYAN + suffixes + Fore.YELLOW)
+                config += separator
 
-        self.newLine(config)
+            config += "Threads: {0}".format(Fore.CYAN + threads + Fore.YELLOW)
+            config += separator
+            config += "Wordlist size: {0}".format(Fore.CYAN + wordlist_size + Fore.YELLOW)
+
+            config += Style.RESET_ALL
+
+            self.newLine(config)
+        else:
+            separator = " | "
+
+            config = "Extensions: {0}".format(extensions)
+            config += separator
+
+            config += "HTTP method: {0}".format(method.upper())
+            config += separator
+
+            if prefixes != '':
+                config += 'Prefixes: {0}'.format(prefixes)
+                config += separator
+
+            if suffixes != '':
+                config += 'Suffixes: {0}'.format(suffixes)
+                config += separator
+
+            config += "Threads: {0}".format(threads)
+            config += separator
+            config += "Wordlist size: {0}".format(wordlist_size)
+
+            self.newLine(config)
+
 
     def setTarget(self, target):
         if not target.endswith("/"):
@@ -216,10 +246,12 @@ class CLIOutput(object):
 
         self.target = target
 
-        config = Style.BRIGHT + Fore.YELLOW
-        config += "\nTarget: {0}\n".format(Fore.CYAN + target + Fore.YELLOW)
-        config += Style.RESET_ALL
-
+        if self.color:
+            config = Style.BRIGHT + Fore.YELLOW
+            config += "\nTarget: {0}\n".format(Fore.CYAN + target + Fore.YELLOW)
+            config += Style.RESET_ALL
+        else:
+            config = "\nTarget: {0}\n".format(target)
         self.newLine(config)
 
     def outputFile(self, target):

--- a/lib/output/print_output.py
+++ b/lib/output/print_output.py
@@ -28,13 +28,14 @@ if sys.platform in ["win32", "msys"]:
 
 
 class PrintOutput(object):
-    def __init__(self):
+    def __init__(self, color):
         init()
         self.mutex = threading.Lock()
         self.blacklists = {}
         self.mutexCheckedPaths = threading.Lock()
         self.basePath = None
         self.errors = 0
+        self.color = color
 
     def header(self, text):
         pass
@@ -86,23 +87,25 @@ class PrintOutput(object):
             status, contentLength.rjust(6, " "), showPath
         )
 
-        if status == 200:
-            message = Fore.GREEN + message + Style.RESET_ALL
+        if self.color:
+            if status == 200:
+                message = Fore.GREEN + message + Style.RESET_ALL
 
-        elif status == 401:
-            message = Fore.YELLOW + message + Style.RESET_ALL
+            elif status == 401:
+                message = Fore.YELLOW + message + Style.RESET_ALL
 
-        elif status == 403:
-            message = Fore.BLUE + message + Style.RESET_ALL
+            elif status == 403:
+                message = Fore.BLUE + message + Style.RESET_ALL
 
-        elif status == 500:
-            message = Fore.RED + message + Style.RESET_ALL
+            elif status == 500:
+                message = Fore.RED + message + Style.RESET_ALL
 
         # Check if redirect
-        elif status in [301, 302, 307] and "location" in [
+        if status in [301, 302, 307] and "location" in [
             h.lower() for h in response.headers
         ]:
-            message = Fore.CYAN + message + Style.RESET_ALL
+            if self.color:
+                message = Fore.CYAN + message + Style.RESET_ALL
             message += "  ->  {0}".format(response.headers["location"])
 
         if addedToQueue:


### PR DESCRIPTION
Description
---------------

The standard output is excellent for visually determining valid content vs 400-500 errors. 

Attempting to programmatically use the output is difficult due to the colors. This PR adds the --no-color flag to intentionally disable colors from output. By default colored output is still enabled.

Both the CLIOutput and PrintOutput classes were modified to reflect this parameter.

Example:

```python3 ./dirsearch.py -u https://example.com/ -q --no-color```

I may want to apply a quick filter for all of the 200 status codes that come back. With the --no-color option I can more easily use regex:

```python3 ./dirsearch.py -u https://example.com/ -q --no-color | grep "^200"```

---------------
