### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+certifi>=2020.11.8
+chardet<3.1.0
+urllib3<=1.25
+cryptography>1.3.4


### PR DESCRIPTION
Description
---------------

Adding a requirements.txt file to include dependencies. 

A fresh download of dirsearch can ensure it has the proper packages by running the following:
```pip3 install -r requirements.txt```

The dependencies were meant to match the code in https://github.com/maurosoria/dirsearch/blob/master/thirdparty/requests/__init__.py

Feel free to bump any of the versions or add dependencies if I missed some.
