### PR TITLE
[End-of-life] Remove no-dot-extensions option because it's useless

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -26,7 +26,6 @@ lowercase = False
 uppercase = False
 capitalization = False
 force-extensions = False
-no-dot-extensions = False
 # prefixes = .,admin
 # suffixes = ~,.bak
 # wordlist = db/dicc.txt

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -127,8 +127,8 @@ class Controller(object):
             self.arguments.suffixes, self.arguments.prefixes,
             self.arguments.lowercase, self.arguments.uppercase,
             self.arguments.capitalization, self.arguments.forceExtensions,
-            self.arguments.noDotExtensions, self.arguments.excludeExtensions,
-            self.arguments.noExtension, self.arguments.onlySelected
+            self.arguments.excludeExtensions, self.arguments.noExtension,
+            self.arguments.onlySelected
         )
 
         self.allJobs = len(self.urlList) * (len(self.scanSubdirs) if self.scanSubdirs else 1)
@@ -264,7 +264,6 @@ class Controller(object):
 
     def getBlacklists(self):
         reext = re.compile(r'\%ext\%', re.IGNORECASE)
-        reextdot = re.compile(r'\.\%ext\%', re.IGNORECASE)
         blacklists = {}
 
         for status in [400, 403, 500]:
@@ -289,13 +288,7 @@ class Controller(object):
                 # Classic dirsearch blacklist processing (with %EXT% keyword)
                 if "%ext%" in line.lower():
                     for extension in self.arguments.extensions:
-                        if self.arguments.noDotExtensions:
-                            entry = reextdot.sub(extension, line)
-
-                        else:
-                            entry = line
-
-                        entry = reext.sub(extension, entry)
+                        entry = reext.sub(extension, line)
 
                         blacklists[status].append(entry)
 

--- a/lib/core/argument_parser.py
+++ b/lib/core/argument_parser.py
@@ -292,7 +292,6 @@ class ArgumentParser(object):
         self.capitalization = options.capitalization
         self.forceExtensions = options.forceExtensions
         self.data = options.data
-        self.noDotExtensions = options.noDotExtensions
         self.simpleOutputFile = options.simpleOutputFile
         self.plainTextOutputFile = options.plainTextOutputFile
         self.jsonOutputFile = options.jsonOutputFile
@@ -409,7 +408,6 @@ class ArgumentParser(object):
         self.uppercase = config.safe_getboolean("dictionary", "uppercase", False)
         self.capitalization = config.safe_getboolean("dictionary", "capitalization", False)
         self.forceExtensions = config.safe_getboolean("dictionary", "force-extensions", False)
-        self.noDotExtensions = config.safe_getboolean("dictionary", "no-dot-extensions", False)
 
         # Connection
         self.useRandomAgents = config.safe_get(
@@ -465,8 +463,6 @@ information at https://github.com/maurosoria/dirsearch.''')
                               help='Only entries with selected extensions or no extension + directories')
         dictionary.add_option('--remove-extensions', dest='noExtension', action='store_true',
                               help='Remove extensions in all wordlist entries (Example: admin.php -> admin)')
-        dictionary.add_option('--no-dot-extensions', dest='noDotExtensions', default=self.noDotExtensions,
-                              help='Remove the "." character before extensions', action='store_true')
         dictionary.add_option('-U', '--uppercase', action='store_true', dest='uppercase', default=self.uppercase,
                               help='Uppercase wordlist')
         dictionary.add_option('-L', '--lowercase', action='store_true', dest='lowercase', default=self.lowercase,

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -35,7 +35,6 @@ class Dictionary(object):
         uppercase=False,
         capitalization=False,
         forcedExtensions=False,
-        noDotExtensions=False,
         excludeExtensions=[],
         noExtension=False,
         onlySelected=False,
@@ -50,7 +49,6 @@ class Dictionary(object):
         self._suffixes = suffixes
         self._paths = paths
         self._forcedExtensions = forcedExtensions
-        self._noDotExtensions = noDotExtensions
         self._noExtension = noExtension
         self._onlySelected = onlySelected
         self.lowercase = lowercase
@@ -98,9 +96,8 @@ class Dictionary(object):
 
     def generate(self):
         reext = re.compile(r"\%ext\%", re.IGNORECASE).sub
-        reextdot = re.compile(r"\.\%ext\%", re.IGNORECASE).sub
-        reexclude = re.findall
         renoforce = re.compile(r"\%noforce\%", re.IGNORECASE).sub
+        reexclude = re.findall
         custom = []
         result = []
 
@@ -138,13 +135,7 @@ class Dictionary(object):
                 # Classic dirsearch wordlist processing (with %EXT% keyword)
                 if "%ext%" in line.lower():
                     for extension in self._extensions:
-                        if self._noDotExtensions:
-                            newline = reextdot(extension, line)
-
-                        else:
-                            newline = line
-
-                        newline = reext(extension, newline)
+                        newline = reext(extension, line)
 
                         quoted = self.quote(newline)
                         result.append(quoted)
@@ -156,10 +147,10 @@ class Dictionary(object):
 
                     for extension in self._extensions:
                         # Why? Check https://github.com/maurosoria/dirsearch/issues/70
-                        if extension.strip() == '':
+                        if not extension.strip():
                             result.append(quoted)
                         else:
-                            result.append(quoted + ('' if self._noDotExtensions else '.') + extension)
+                            result.append(quoted + "." + extension)
 
                     result.append(quoted)
                     result.append(quoted + "/")


### PR DESCRIPTION
Description
---------------

Since people can now use suffixes and prefixes for this, I decided to end NDE because I think no one is actually using this option and dirsearch is going to be implemented a huge number of new arguments in the near future.

So, let's say "good-bye" to no-dot-extensions.