### PR TITLE
Important bug fix

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -70,7 +70,11 @@ class Requester(object):
         elif parsed.scheme not in ["https", "http"]:
             raise RequestException({"message": "Unsupported URL scheme: {0}".format(parsed.scheme)})
 
-        self.basePath = parsed.path.lstrip("/")
+        if parsed.path.startswith("/"):
+            self.basePath = parsed.path[1:]
+        else:
+            self.basePath = parsed.path
+
         self.basePath = urllib.parse.quote(self.basePath, safe=":/~?%&+-=$!@^*()[]{}<>;'\"|\\,._")
         self.protocol = parsed.scheme
         self.host = parsed.netloc.split(":")[0]
@@ -149,7 +153,7 @@ class Requester(object):
                     elif self.proxy:
                         proxy = {"https": self.proxy, "http": self.proxy}
 
-                url = "{0}/{1}".format(self.url, self.basePath).rstrip("/")
+                url = "{0}/{1}".format(self.url, self.basePath)
 
                 if not url.endswith("/"):
                     url += "/"

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -281,7 +281,8 @@ class Controller(object):
                 if line.lstrip().startswith("#"):
                     continue
 
-                line = line.lstrip("/")
+                if line.startswith("/"):
+                    line = line[1:]
 
                 # Classic dirsearch blacklist processing (with %EXT% keyword)
                 if "%ext%" in line.lower():

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -108,7 +108,8 @@ class Dictionary(object):
                 if line.lstrip().startswith("#"):
                     continue
 
-                line = line.lstrip("/")
+                if line.startswith("/"):
+                    line = line[1:]
 
                 if self._noExtension:
                     line = line[0] + line[1:].split(".")[0]

--- a/lib/output/cli_output.py
+++ b/lib/output/cli_output.py
@@ -93,7 +93,7 @@ class CLIOutput(object):
         finally:
             contentLength = FileUtils.size_human(size)
 
-        showPath = "/" + self.basePath.lstrip("/") + path
+        showPath = "/" + self.basePath + path
 
         if full_url:
             parsed = urllib.parse.urlparse(self.target)

--- a/lib/output/print_output.py
+++ b/lib/output/print_output.py
@@ -78,7 +78,7 @@ class PrintOutput(object):
         finally:
             contentLength = FileUtils.size_human(size)
 
-        showPath = "/" + self.basePath.lstrip("/") + path
+        showPath = "/" + self.basePath + path
 
         parsed = urllib.parse.urlparse(self.target)
         showPath = "{0}://{1}{2}".format(parsed.scheme, parsed.netloc, showPath)


### PR DESCRIPTION
Description
-------------

Python `strip(char)` behavior:

```
>>> path = '/admin/'
>>> path.lstrip('/')
'admin/'
>>> path = '///admin///'  # Admin panel bypass
>>> path.lstrip('/')
'admin///'
>>>
```

This will lead to a big problem when brute-force an URL like this: `https://example.com///admin///`

AND HERE, is the fix =)