### PR TITLE
Smarter recursion

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -523,10 +523,7 @@ class Controller(object):
                         if subdir == path.path + "/":
                             pathIsInScanSubdirs = True
 
-                if not pathIsInScanSubdirs:
-                    if not self.recursive:
-                        pass
-
+                if not self.recursive and not pathIsInScanSubdirs and "?" not in path.path:
                     elif path.response.redirect:
                         addedToQueue = self.addRedirectDirectory(path)
 


### PR DESCRIPTION
Description
---------------

Something like this shouldn't be added into `directories`:

```
/+CSCOT+/oem-customization?app=AnyConnect&platform=..&resource-type=..&name=%2bCSCOE%2b/portal_inc.lua&type=oem
```

Otherwise, dirsearch will scan this:

```
/+CSCOT+/oem-customization?app=AnyConnect&platform=..&resource-type=..&name=%2bCSCOE%2b/portal_inc.lua&type=oem/FUZZING
```