### PR TITLE
Fixed the "elif" without "if" Traceback issue!

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,6 +53,7 @@
 - [Alex Leahu](https://github.com/alxjsn)
 - [act1on3](https://github.com/act1on3)
 - [Isla Mukheef](https://github.com/IslaMukheef)
+- [Binit Ghimire](https://github.com/TheBinitGhimire)
 
 Special thanks for all the people who had helped dirsearch so far!
 

--- a/README.md
+++ b/README.md
@@ -559,5 +559,6 @@ Special thanks to these people:
 - @ColdFusionX
 - @gdattacker
 - @chowmean
+- @TheBinitGhimire
 
 #### Want to join the team? Feel free to submit any pull request that you can. If you don't know how to code, you can support us by updating the wordlist or the documentation. Giving feedback or a new feature suggestion is also the good way to help us improve this tool

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -529,7 +529,7 @@ class Controller(object):
                             pathIsInScanSubdirs = True
 
                 if not self.recursive and not pathIsInScanSubdirs and "?" not in path.path:
-                    elif path.response.redirect:
+                    if path.response.redirect:
                         addedToQueue = self.addRedirectDirectory(path)
 
                     else:


### PR DESCRIPTION
Description
---------------
Hello there,

On [Line 532](https://github.com/maurosoria/dirsearch/blob/master/lib/controller/controller.py#L532) of [/lib/controller/controller.py](https://github.com/maurosoria/dirsearch/blob/master/lib/controller/controller.py), there was an `elif` statement, without the presence of any `if` statement, due to which the following Traceback used to appear:
```
Traceback (most recent call last):
  File "/usr/local/bin/dirsearch", line 28, in <module>
    from lib.controller import Controller
  File "/home/binit/Desktop/tools/dirsearch/lib/controller/__init__.py", line 1, in <module>
    from .controller import *  # noqa: F401
  File "/home/binit/Desktop/tools/dirsearch/lib/controller/controller.py", line 532
    elif path.response.redirect:
    ^
SyntaxError: invalid syntax
```

Through this Pull Request, I am resolving this issue with the replacement of the `elif` statement with `if` statement.

---------------

 * I have added my name in the Contributors section in README.md and CONTRIBUTERS.md.

I am looking forward to seeing this PR being reviewed soon.

Thanks,
@TheBinitGhimire