### PR TITLE
Print only used extensions

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -246,7 +246,7 @@ class Controller(object):
     def printConfig(self):
 
         self.output.config(
-            ', '.join(self.arguments.extensions),
+            ', '.join(self.dictionary._extensions),
             ', '.join(self.arguments.prefixes),
             ', '.join(self.arguments.suffixes),
             str(self.arguments.threadsCount),

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -55,6 +55,13 @@ class Dictionary(object):
         self.uppercase = uppercase
         self.capitalization = capitalization
         self.dictionaryFiles = [File(path) for path in self.paths]
+
+        # Check if dictionaries don't use dirsearch classic extensions (with %EXT%)
+        if "%ext%" not in "".join(
+            [dictFile.read().lower() for dictFile in self.dictionaryFiles]
+        ) and not forcedExtensions:
+            self._extensions = [""]
+
         self.generate()
 
     @property
@@ -111,6 +118,7 @@ class Dictionary(object):
                 if line.startswith("/"):
                     line = line[1:]
 
+                # Remove extensions after the first character to keep the dot files
                 if self._noExtension:
                     line = line[0] + line[1:].split(".")[0]
 

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -57,9 +57,9 @@ class Dictionary(object):
         self.dictionaryFiles = [File(path) for path in self.paths]
 
         # Check if dictionaries don't use dirsearch classic extensions (with %EXT%)
-        if "%ext%" not in "".join(
-            [dictFile.read().lower() for dictFile in self.dictionaryFiles]
-        ) and not forcedExtensions:
+        if not forcedExtensions and not any(
+            ["%ext%" in dict.read().lower() for dict in self.dictionaryFiles]
+        ):
             self._extensions = [""]
 
         self.generate()


### PR DESCRIPTION
Description
---------------

This PR will help the users have a better understanding of what is happening with their wordlists in the backend. If the user wordlists come from SecLists or something, that doesn't have the classic %EXT% keyword, dirsearch will let the user know that no extension is used. And if there is %EXT%, or the users use --force-extensions, dirsearch will print the extensions.