### PR TITLE
Fixed dirsearch from adding dirs to queue when recursive arg is not specified

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,6 +55,7 @@
 - [Isla Mukheef](https://github.com/IslaMukheef)
 - [Dodain](https://github.com/Dodain)
 - [Binit Ghimire](https://github.com/TheBinitGhimire)
+- [Knowledge-Wisdom-Understanding](https://github.com/Knowledge-Wisdom-Understanding)
 
 Special thanks for all the people who had helped dirsearch so far!
 

--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ Special thanks to these people:
 - @chowmean
 - @dodain
 - @TheBinitGhimire
+- @Knowledge-Wisdom-Understanding
 
 
 #### Want to join the team? Feel free to submit any pull request that you can. If you don't know how to code, you can support us by updating the wordlist or the documentation. Giving feedback or a new feature suggestion is also a good way to help us improve this tool

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -536,7 +536,7 @@ class Controller(object):
                         if subdir == path.path + "/":
                             pathIsInScanSubdirs = True
 
-                if not self.recursive and not pathIsInScanSubdirs and "?" not in path.path:
+                if self.recursive and not pathIsInScanSubdirs and "?" not in path.path:
                     if path.response.redirect:
                         addedToQueue = self.addRedirectDirectory(path)
 


### PR DESCRIPTION
Description
---------------
Fixed dirsearch from adding dirs to queue when recursive arg is not specified

Why this PR? What will it do?
This PR will prevent dirsearch from adding found directories to the queue when the recursive argument is not specified.

If this PR will fix an issue, please address it:
Fix #{issue} I don't think there is an open issue for this yet, the fix was only 1 line that needed to be updated.
I can create an issue for this if need be.

Currently, in the master branch, I've noticed that dirsearch was adding a bunch of found dirs to the queue even though the -r
 --recursive option was not specified on the command line which can make dirsearch take forever on a non-recursive crawl.

