### PR TITLE
Remove dot at the start of the extensions

### DIFF
--- a/lib/core/argument_parser.py
+++ b/lib/core/argument_parser.py
@@ -169,7 +169,7 @@ class ArgumentParser(object):
             ]
         else:
             self.extensions = list(
-                oset([extension.strip() for extension in options.extensions.split(",")])
+                oset([extension.lstrip(' .') for extension in options.extensions.split(",")])
             )
 
         self.useragent = options.useragent


### PR DESCRIPTION
Description
---------------

People who used to use FFUF or GoBuster may do something like this: `-e .php,.html`. This fix will allow dirsearch working normally in that situation