### PR TITLE
docs: fix simple typo, enumuration -> enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Features
 - Extensions excluding
 - Reporting (Plain text, JSON, XML, Markdown, CSV)
 - Recursive brute forcing
-- Target enumuration from an IP range
+- Target enumeration from an IP range
 - Sub-directories brute forcing
 - Force extensions
 - HTTP and SOCKS proxy support


### PR DESCRIPTION
There is a small typo in README.md.

Should read `enumeration` rather than `enumuration`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md