### PR TITLE
Problem fix

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -202,7 +202,7 @@ class Fuzzer(object):
                     time.sleep(self.delay)
 
         except StopIteration:
-            return
+            pass
 
         finally:
             self.stopThread()


### PR DESCRIPTION
Description
---------------

I found that if you brute-force with many threads (50 in my test), then at the final of the task, dirsearch will pause 1-3 seconds before complete it. This will fix that!