### PR TITLE
Don't add / when force extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ index.asp
 index.aspx
 ```
 
-- For wordlists without *%EXT%* (like [SecLists](https://github.com/danielmiessler/SecLists)), you need to use the **-f | --force-extensions** switch to append extensions to every word in the wordlists, as well as the "/". And for entries in the wordlist that you do not want to force, you can add *%NOFORCE%* at the end of them so dirsearch won't append any extension.
+- For wordlists without *%EXT%* (like [SecLists](https://github.com/danielmiessler/SecLists)), you need to use the **-f | --force-extensions** switch to append extensions to every word in the wordlists. And for entries in the wordlist that you do not want to force, you can add *%NOFORCE%* at the end of them so dirsearch won't append any extension.
 
 Example:
 
@@ -118,7 +118,6 @@ Passing extensions "php" and "html" with the **-f**/**--force-extensions** flag 
 admin
 admin.php
 admin.html
-admin/
 home
 home.php
 home.html

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -149,7 +149,6 @@ class Dictionary(object):
                             result.append(quoted + "." + extension)
 
                     result.append(quoted)
-                    result.append(quoted + "/")
 
                 # Append line unmodified.
                 else:


### PR DESCRIPTION
Description
---------------

From a user, he said that the wordlist is too big when using the `-f` flag: 200k -> 600k. I think that we don't need to add the slash when forcing extensions, if the users want to brute-force with the slash, they can use `--suffixes`. 

In a normal case (from my experience), if you hit `folder`, then it will redirect you to `folder/` and we will know `folder/` exists, but hitting `folder/` most of the times won't give you an interesting response.