### PR TITLE
User bug warning

### DIFF
--- a/lib/core/argument_parser.py
+++ b/lib/core/argument_parser.py
@@ -172,6 +172,9 @@ class ArgumentParser(object):
                 "php", "inc.php", "jsp", "jsf", "asp", "aspx", "do", "action", "cgi",
                 "pl", "html", "htm", "js", "css", "json", "txt", "tar.gz", "tgz"
             ]
+        elif options.extensions == "CHANGELOG.md":
+            print("A weird extension was provided: CHANGELOG.md. Please do not use * as the extension or enclose it in double quotes")
+            exit(0)
         else:
             self.extensions = list(
                 oset([extension.lstrip(' .') for extension in options.extensions.split(",")])


### PR DESCRIPTION
Description
---------------

User bug warning!

Look at this picture and you will know what did I do in the past: ![](https://images.viblo.asia/da4a4751-7695-4039-a8a6-b30a41511448.png)

(More information: `*` will be resolved to files, folders inside `/dirsearch`, like when you use the `ls` command)