### PR TITLE
Include cmdline args in reports

### DIFF
--- a/lib/reports/json_report.py
+++ b/lib/reports/json_report.py
@@ -18,6 +18,7 @@
 
 import json
 import time
+import sys
 
 from lib.reports import *
 
@@ -35,7 +36,10 @@ class JSONReport(FileBaseReport):
         headerName = "{0}://{1}:{2}/{3}".format(
             self.protocol, self.host, self.port, self.basePath
         )
-        result = {"time": time.ctime(), headerName: []}
+
+        info = {"args": ' '.join(sys.argv), "time": time.ctime()}
+
+        result = {"info": info, headerName: []}
 
         for path, status, contentLength, redirect in self.pathList:
             entry = {

--- a/lib/reports/markdown_report.py
+++ b/lib/reports/markdown_report.py
@@ -18,6 +18,7 @@
 
 from lib.reports import *
 import time
+import sys
 
 
 class MarkdownReport(FileBaseReport):
@@ -35,7 +36,8 @@ class MarkdownReport(FileBaseReport):
             self.protocol, self.host, self.port, self.basePath
         )
 
-        result = "### Time: {0}\n".format(time.ctime())
+        result = "### Args: {0}\n".format(' '.join(sys.argv))
+        result += "### Time: {0}\n".format(time.ctime())
         result += "### Target: {0}\n\n".format(headerName)
         result += "Path | Status | Size | Redirection\n"
         result += "-----|--------|------|------------\n"

--- a/lib/reports/plain_text_report.py
+++ b/lib/reports/plain_text_report.py
@@ -20,6 +20,7 @@ from lib.reports import *
 from lib.utils.file_utils import FileUtils
 
 import time
+import sys
 
 
 class PlainTextReport(FileBaseReport):
@@ -37,7 +38,7 @@ class PlainTextReport(FileBaseReport):
         self.storeData((path, status, contentLength, location))
 
     def generate(self):
-        result = "Time: {0}\n\n".format(time.ctime())
+        result = "# Dirsearch started {0} as: {1}\n\n".format(time.ctime(), ' '.join(sys.argv))
 
         for path, status, contentLength, location in self.pathList:
             result += "{0}  ".format(status)

--- a/lib/reports/xml_report.py
+++ b/lib/reports/xml_report.py
@@ -18,6 +18,7 @@
 
 from lib.reports import *
 import time
+import sys
 
 
 class XMLReport(FileBaseReport):
@@ -37,7 +38,7 @@ class XMLReport(FileBaseReport):
             self.protocol, self.host, self.port, self.basePath
         )
 
-        result += "<time>{0}</time>\n".format(time.ctime())
+        result += "<dirsearchScan args=\"{0}\" time=\"{1}\">\n".format(' '.join(sys.argv), time.ctime())
         result += "<target url=\"{0}\">\n".format(headerName)
 
         for path, status, contentLength, redirect in self.pathList:
@@ -48,5 +49,6 @@ class XMLReport(FileBaseReport):
             result += " </info>\n"
 
         result += "</target>\n"
+        result += "</dirsearchScan>\n"
 
         return result


### PR DESCRIPTION
Description
---------------

This PR includes the cmdline arguments for the json, markdown, plain, and xml reports. This was attempted to be done in a format similar to nmap. This is helpful metadata to include in reports because users can better understand output based on their flags. It's difficult to always remember what filters you used, so automatically including it in reports maintains that info.

The CSV and simple formats were left out. A metadata line could be added to both formats, but I felt like it would be extraneous info/parsing for users wanting these formats. 

The JSON and XML formats were restructured a bit. I'll open up a separate issue, but I think there are some general improvements that could be made to the structure. Feel free to modify or suggest a different structure for this PR.
