### PR TITLE
Fix -b option and proxy settings

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -75,7 +75,9 @@ class Requester(object):
         # Resolve DNS to decrease overhead
         if ip:
             self.ip = ip
-        elif not requestByHostname:
+        # A proxy could have a different DNS that would resolve the name. Therefore, 
+        # resolving the name when using proxy to raise an error is pointless
+        elif not proxy and not proxylist:
             try:
                 self.ip = socket.gethostbyname(self.host)
             except socket.gaierror:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -75,7 +75,7 @@ class Requester(object):
         # Resolve DNS to decrease overhead
         if ip:
             self.ip = ip
-        else:
+        elif not requestByHostname:
             try:
                 self.ip = socket.gethostbyname(self.host)
             except socket.gaierror:
@@ -152,7 +152,7 @@ class Requester(object):
                         proxy = "http://" + proxy
 
                     if proxy.startswith("http:"):
-                        proxies = {"http": proxy}
+                        proxies = {"http": proxy, "https": proxy}
                     elif proxy.startswith("https:"):
                         proxies = {"https": proxy}
                     else:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -75,7 +75,7 @@ class Requester(object):
         # Resolve DNS to decrease overhead
         if ip:
             self.ip = ip
-        # A proxy could have a different DNS that would resolve the name. Therefore, 
+        # A proxy could have a different DNS that would resolve the name. Therefore,
         # resolving the name when using proxy to raise an error is pointless
         elif not proxy and not proxylist:
             try:


### PR DESCRIPTION
Description
---------------

Currently, the -b option is not respected, this can cause trouble when using a proxy that will do the resolution itself and your DNS cannot resolute the target.
Moreover, the proxy configuration is incorrectly set, the 'http' is the proxy for the 'http' targets whereas the 'https' is for 'https' targets whether or not the proxy is using http or https.

If this PR will fix an issue, please address it:
My quick search did not gave any issue existing for this, too lazy to create one
