### PR TITLE
Patch Dirsearch failing with -q flag 

### DIFF
--- a/lib/output/print_output.py
+++ b/lib/output/print_output.py
@@ -118,7 +118,7 @@ class PrintOutput(object):
         with self.mutex:
             self.newLine(message)
 
-    def lastPath(self, path, index, length, currentJob, allJobs):
+    def lastPath(self, path, index, length, currentJob, allJobs, rate):
         pass
 
     def addConnectionError(self):


### PR DESCRIPTION
Description
---------------

The `-q` flag which silences the headers and extra output is currently causing dirsearch to throw a bunch of errors.

I was seeing the following error being thrown:

```
Traceback (most recent call last):
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "dirsearch/lib/core/fuzzer.py", line 233, in thread_proc
    callback(result)
  File "dirsearch/lib/controller/controller.py", line 603, in notFoundCallback
    self.output.lastPath(path, self.index, len(self.dictionary), self.currentJob, self.allJobs, self.fuzzer.rate)
TypeError: lastPath() takes 6 positional arguments but 7 were given
```

The rate parameter was being included in cli_output.py, but was missing in print_output.py. This patch is intended to fix this bug.