### PR TITLE
Updated code to remove InsecureRequestWarning  due to python3 . 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,7 +59,7 @@
 - [catmandx](https://github.com/catmandx)
 - [Kyle Nweeia](https://github.com/kyle-nweeia)
 - [Xib3rR4dAr](https://github.com/Xib3rR4dAr)
-
+- [oaktree](https://github.com/git-oaktree)
 Special thanks for all the people who had helped dirsearch so far!
 
 ### How can I help the project?


### PR DESCRIPTION
Description
---------------
Added import of two libraries: 
requests
urllib3
 
import InsecureReqeustWarning from requests.packages.urllib3

Disabled warning 


---------------

 * Add your name to `CONTRIBUTERS.md`
 * If this is a new feature, then please add some additional information about it to `CHANGELOG.md`


Thank you very much for helping dirsearch become a better tool!!! :heart:
