### PR TITLE
Stream response instead of download into the memory

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -191,15 +191,11 @@ class Requester(object):
                     proxies=proxies,
                     allow_redirects=self.redirect,
                     timeout=self.timeout,
+                    stream=True,
                     verify=False,
                 )
 
-                result = Response(
-                    response.status_code,
-                    response.reason,
-                    response.headers,
-                    response.content,
-                )
+                result = Response(response)
 
                 break
 

--- a/lib/connection/response.py
+++ b/lib/connection/response.py
@@ -21,10 +21,10 @@ class Response(object):
     def __init__(self, response):
         self.status = response.status_code
         self.headers = response.headers
-        self.body = ""
+        self.body = b""
 
         for chunk in response.iter_content(chunk_size=8192):
-            self.body += chunk.decode("iso8859-1")
+            self.body += chunk
 
     def __str__(self):
         return self.body

--- a/lib/connection/response.py
+++ b/lib/connection/response.py
@@ -18,11 +18,13 @@
 
 
 class Response(object):
-    def __init__(self, status, reason, headers, body):
-        self.status = status
-        self.reason = reason
-        self.headers = headers
-        self.body = body
+    def __init__(self, response):
+        self.status = response.status_code
+        self.headers = response.headers
+        self.body = ""
+
+        for chunk in response.iter_content(chunk_size=8192):
+            self.body += chunk.decode("iso8859-1")
 
     def __str__(self):
         return self.body
@@ -46,7 +48,6 @@ class Response(object):
         del self.body
         del self.headers
         del self.status
-        del self.reason
 
     @property
     def redirect(self):


### PR DESCRIPTION
Description
---------------

By default, `requests` downloads the whole response at a time to an object, but if the response is too huge, it will hit the memory painfully. The result of this is dirsearch gets stuck, so I decided to stream response, which means get response data bytes by bytes.

Fix #753