### PR TITLE
fix decode() encoding is None error

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,6 +64,7 @@
 - [Dipak Panchal](https://instagram.com/th3.d1p4k)
 - [Ivan Fedotov](https://github.com/qumusabel)
 - [Manuel Poisson](https://github.com/ManuelPOISSON)
+- [XinRoom](https://github.com/XinRoom)
 
 Special thanks to all the people who are named here!
 

--- a/lib/core/path.py
+++ b/lib/core/path.py
@@ -25,7 +25,7 @@ class Path(object):
         self.path = path
         self.status = status
         self.redirect = response.redirect
-        self.body = response.body.decode(encoding_type) if encoding_type!=None else response.body.decode()
+        self.body = response.body.decode(encoding_type)
         self.length = response.length
         self.response = response
 

--- a/lib/core/path.py
+++ b/lib/core/path.py
@@ -25,7 +25,7 @@ class Path(object):
         self.path = path
         self.status = status
         self.redirect = response.redirect
-        self.body = response.body.decode(encoding_type)
+        self.body = response.body.decode(encoding_type) if encoding_type!=None else response.body.decode()
         self.length = response.length
         self.response = response
 

--- a/lib/utils/fmt.py
+++ b/lib/utils/fmt.py
@@ -25,6 +25,9 @@ def safequote(string):
 
 
 def get_encoding_type(content):
+    if not content:
+        return "utf-8"
+
     return detect(content)["encoding"]
 
 


### PR DESCRIPTION
fix "TypeError: decode() argument 'encoding' must be str, not None" error

Description
---------------

When response.body is not data, `detect(response.body)["encoding"]` will is None. ( For example, use command -m head )

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Program Files\Python38\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
  File "C:\Program Files\Python38\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "D:\dirsearch\lib\core\fuzzer.py", line 235, in thread_proc
    result = Path(path=path, status=status, response=response)
  File "D:\dirsearch\lib\core\path.py", line 28, in __init__
    self.body = response.body.decode(encoding_type) if response.body != "" else ""
TypeError: decode() argument 'encoding' must be str, not None
```

We can only use it when encoding_type is not None.

`self.body = response.body.decode(encoding_type) if encoding_type!=None else response.body.decode()`

Requirements
---------------

- [ ] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
