### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/lib/core/path.py
+++ b/lib/core/path.py
@@ -25,7 +25,7 @@ class Path(object):
         self.path = path
         self.status = status
         self.redirect = response.redirect
-        self.body = response.body.decode(encoding_type)
+        self.body = response.body.decode(encoding_type, errors="ignore")
         self.length = response.length
         self.response = response
 


### PR DESCRIPTION
fix `UnicodeDecodeError: 'charmap' codec can't decode byte 0xa0 in position 67: character maps to <undefined>` with some image file

Description
---------------

When I request some image file, it prompts undecoded binary. (For example, https://www.google.com/favicon.ico)

```
Exception in thread Thread-9: 0/s       job:1/1  errors:0
Traceback (most recent call last):
  File "D:\env\Python37\lib\threading.py", line 926, in _bootstrap_inner
     self.run()
  File "D:\env\Python37\lib\threading.py", line 870, in run
     self._target(*self._args, **self._kwargs)
  File "D:\Tools\sec\DirBrute\dirsearch-dev\lib\core\fuzzer.py", line 235, in thread_proc
     result = Path(path=path, status=status, response=response)
  File "D:\Tools\sec\DirBrute\dirsearch-dev\lib\core\path.py", line 28, in __init__
    self.body = response.body.decode(encoding_type)
  File "D:\env\Python37\lib\encodings\tis_620.py", line 15, in decode
    return codecs.charmap_decode(input,errors,decoding_table)
UnicodeDecodeError: 'charmap' codec can't decode byte 0xa0 in position 67: character maps to <undefined>
```

It is recommended to ignore the binary that cannot be decoded. Because we don’t need to match these binary files.

`b"abc\xa0".decode(errors="ignore")`
