### PR TITLE
Mitigate Vue.js self-XSS in HTML Template

### DIFF
--- a/lib/reports/html_report.py
+++ b/lib/reports/html_report.py
@@ -33,7 +33,7 @@ class HTMLReport(FileBaseReport):
         template = env.get_template('html_report_template.html')
 
         metadata = {
-            "command": " ".join(sys.argv),
+            "command": self.get_command(),
             "date": time.ctime()
         }
         results = []
@@ -62,6 +62,13 @@ class HTMLReport(FileBaseReport):
                 })
 
         return template.render(metadata=metadata, results=results)
+
+    def get_command(self):
+        command = " ".join(sys.argv)
+        if '[[' in command or ']]' in command:
+            return 'Dirsearch'
+        else:
+            return command
 
     def save(self):
         self.file.seek(0)


### PR DESCRIPTION
Description
---------------

I came across [Portswigger's research on Vue.js XSS payloads](https://portswigger.net/web-security/cross-site-scripting/cheat-sheet#vuejs-reflected) and wanted to ensure that Dirsearch's html template wasn't vulnerable to them. I created a fake report with all payloads in every field. 

Fortunately the `| tojson` call within the template seems to mitigate this in any server returnable field.

I did observe that it's possible to get self-xss through the command line arguments. An example is adding the following header to the dirsearch syntax with the html report format:

`-H "X-Foo: [[constructor.constructor('alert(1)')()]]"`

This will pop an alert when the html file is opened in a browser.

This patch remediates this by returning `Dirsearch` as the command whenever `[[` or `]]` are seen in the command line arguments. These characters are set as the [Vue.js delimiters](https://github.com/maurosoria/dirsearch/blob/master/lib/reports/templates/html_report_template.html#L41). I'm open to changing the default command output to anything else.

An alternate patch could be to use lengthier delimiters in the template file and block on those. 
