### PR TITLE
Adding Gateway Actuator to Wordlist

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -2651,6 +2651,7 @@ actuator/events
 actuator/exportRegisteredServices
 actuator/features
 actuator/flyway
+actuator/gateway/routes
 actuator/health
 actuator/healthcheck
 actuator/heapdump
@@ -5532,6 +5533,7 @@ GalleryMenu
 games
 ganglia/
 gateway/
+gateway/routes
 gaza.php
 gb_admin.%EXT%
 gbpass.pl


### PR DESCRIPTION
Description
---------------

Adding the Spring Boot Gateway actuator into the wordlist. Essentially requesting just gateway will return a 404. The gateway/routes endpoint will resolve actual content.

A blog post to reference is here:
https://wya.pl/2021/12/20/bring-your-own-ssrf-the-gateway-actuator/



Requirements
---------------

- [ ] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
