### PR TITLE
fix: TypeError

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,6 +66,7 @@
 - [Manuel Poisson](https://github.com/ManuelPOISSON)
 - [XinRoom](https://github.com/XinRoom)
 - [godspeedcurry](https://github.com/godspeedcurry)
+- [0x08](https://github.com/its0x08)
 
 Special thanks to all the people who are named here!
 

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -47,7 +47,7 @@ def options():
 
     if opt.raw_file:
         access_file(opt.raw_file, "file with raw request")
-    elif not len(opt.urls):
+    elif not opt.urls:
         print("URL target is missing, try using -u <url>")
         exit(1)
 


### PR DESCRIPTION
Description
---------------

```
 File "/root/.local/lib/python3.10/site-packages/dirsearch/lib/core/options.py", line 50, in options                                                                                                               
    elif not len(opt.urls):                                                                               
TypeError: object of type 'NoneType' has no len()

```
The error was caused because of the usage of the len() for a none type object.
Removing the len() function fixes the problem!

---------------

What will it do?

If this PR will fix an issue, please address it:
Fix #{issue}

Requirements
---------------

- [x] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
