### PR TITLE
fix: Jinja2 autoescape to avoid `XSS` and `XXE`

### DIFF
--- a/lib/reports/html_report.py
+++ b/lib/reports/html_report.py
@@ -32,7 +32,7 @@ class HTMLReport(FileBaseReport):
         file_loader = FileSystemLoader(
             os.path.dirname(os.path.realpath(__file__)) + "/templates/"
         )
-        env = Environment(loader=file_loader)
+        env = Environment(loader=file_loader, autoescape=True)
 
         template = env.get_template("html_report_template.html")
 

--- a/lib/reports/xml_report.py
+++ b/lib/reports/xml_report.py
@@ -19,8 +19,8 @@
 import time
 import sys
 
-from xml.dom import minidom
-from xml.etree import ElementTree as ET
+from defusedxml.dom import minidom
+from defusedxml import ElementTree as ET
 
 from lib.core.decorators import locked
 from lib.core.settings import DEFAULT_ENCODING

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ requests_ntlm>=1.1.0
 colorama>=0.4.4
 ntlm_auth>=1.5.0
 pyparsing>=3.0.6
+defusexml


### PR DESCRIPTION
Description
---------------

What will it do?

It will turn auto escape for html reports to avoid possible XSS and use defusedxml instead of xml to avoid XEE

Requirements 
---------------

- [x] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
