### PR TITLE
fix the bug 'Invalid headers in the raw request'

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,6 +68,7 @@
 - [godspeedcurry](https://github.com/godspeedcurry)
 - [0x08](https://github.com/its0x08)
 - [Weltolk](https://github.com/Weltolk)
+- [jerryxucy](https://github.com/chengyaox)
 
 Special thanks to all the people who are named here!
 

--- a/lib/parse/headers.py
+++ b/lib/parse/headers.py
@@ -31,6 +31,10 @@ class HeadersParser:
         elif isinstance(headers, dict):
             self.str = self.dict_to_str(headers)
             self.dict = self.str_to_dict(self.str)
+        elif isinstance(headers, list):
+            self.headers = self.list_to_dict(headers)
+            self.str = self.dict_to_str(self.headers)
+            self.dict = self.headers
 
         self.headers = CaseInsensitiveDict(self.dict)
 
@@ -50,6 +54,18 @@ class HeadersParser:
             return
 
         return NEW_LINE.join(f"{key}: {value}" for key, value in headers.items())
+
+    @staticmethod
+    def list_to_dict(headers):
+        if not headers:
+            return {}
+
+        headers_dict = {}
+        for values in headers:
+            key, value = values.split(":",1)
+            headers_dict[key.strip()] =  value.strip()
+
+        return headers_dict
 
     def __iter__(self):
         return iter(self.headers.items())


### PR DESCRIPTION
Description
---------------

What will it do?
When Using dirsearch today I found a bug when trying to use raw type
my raw file looks like below:
```GET / HTTP/2
Host: XXXXXXXXXXXX
Cookie: XXXXXXXXXXX
User-Agent: XXXXXXXXX
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3
Accept-Encoding: gzip, deflate
Dnt: 1
```
It looks as same as the example provided but when runing with the following command
`python3 dirsearch.py --raw=file --scheme https `
it jump out the error message
`Invalid headers in the raw request`

After debug the program I found that when the _headers_ variable pass to the _HeaderParser_ object the type of the _headers_ is list. While _HeaderParser_ can only handle str and dict.

Thus, I add a static method in _headers.py_ to handle the list object.
 

