### PR TITLE
Move files log to one folder for all sub domain urls

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -20,7 +20,6 @@ import os
 import gc
 import time
 import re
-import sys
 
 from urllib.parse import urlparse
 

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -20,6 +20,7 @@ import os
 import gc
 import time
 import re
+import sys
 
 from urllib.parse import urlparse
 
@@ -60,7 +61,7 @@ from lib.reports.plain_text_report import PlainTextReport
 from lib.reports.simple_report import SimpleReport
 from lib.reports.xml_report import XMLReport
 from lib.reports.sqlite_report import SQLiteReport
-from lib.utils.common import get_valid_filename, lstrip_once
+from lib.utils.common import get_valid_filename, lstrip_once, parse_domain
 from lib.utils.file import FileUtils
 from lib.utils.pickle import pickle, unpickle
 from lib.utils.schemedet import detect_scheme
@@ -368,11 +369,13 @@ class Controller:
                 if not parsed.netloc:
                     parsed = urlparse(f"//{self.targets[0]}")
 
-                filename = get_valid_filename(f"{parsed.path}_")
+                root_domain = parse_domain(self.targets[0])
+
+                filename = get_valid_filename(f"{parsed.netloc}_{parsed.path}_")
                 filename += time.strftime("%y-%m-%d_%H-%M-%S")
                 filename += f".{self.get_output_extension()}"
                 directory_path = FileUtils.build_path(
-                    self.report_path, get_valid_filename(f"{parsed.scheme}_{parsed.netloc}")
+                    self.report_path, root_domain
                 )
 
             output_file = FileUtils.get_abs_path((FileUtils.build_path(directory_path, filename)))

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -18,6 +18,7 @@
 
 from ipaddress import IPv4Network, IPv6Network
 from urllib.parse import quote, urljoin
+from tld import get_tld
 
 from lib.core.settings import (
     INVALID_CHARS_FOR_WINDOWS_FILENAME, INSECURE_CSV_CHARS,
@@ -98,3 +99,10 @@ def merge_path(url, path):
     parts[-1] = path
 
     return "/".join(parts)
+
+def parse_domain(full_domain):
+    try:
+        parsed = get_tld(full_domain, as_object=True)
+        return parsed.fld
+    except:
+        return 'unknown.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ colorama>=0.4.4
 ntlm_auth>=1.5.0
 pyparsing>=2.4.7
 beautifulsoup4>=4.8.0
+tld>=0.12.6


### PR DESCRIPTION
Description
---------------

Hello,

When I run this command

> cat sub-domains.txt |  python3 dirsearch.py --exclude-status 404,503

There are many files in different folder for each subdomain, so I want to create root domain then move all logs file to this folder

Current output log file: 
> /home/user/tmp/dirsearch/reports/https_sub.domain.com/__22-09-12_09-37-31.txt
> /home/user/tmp/dirsearch/reports/https_sub1.domain.com/__22-09-12_09-37-31.txt

New output log file: 
> /home/user/tmp/dirsearch/reports/domain.com/sub.domain.com___22-09-12_09-42-25.txt
> /home/user/tmp/dirsearch/reports/domain.com/sub1.domain.com___22-09-12_09-42-25.txt

Requirements
---------------

- [ ] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
