### PR TITLE
Remove Oauth2 authentication type

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -100,7 +100,7 @@ class Requester:
         self.headers[key] = value.lstrip()
 
     def set_auth(self, type, credential):
-        if type in ("bearer", "jwt", "oath2"):
+        if type in ("bearer", "jwt"):
             self.session.auth = HTTPBearerAuth(credential)
         else:
             try:

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -56,7 +56,7 @@ CRAWL_ATTRIBUTES = ("action", "cite", "data", "formaction", "href", "longdesc", 
 
 CRAWL_TAGS = ("a", "area", "base", "blockquote", "button", "embed", "form", "frame", "frameset", "html", "iframe", "input", "ins", "noframes", "object", "q", "script", "source")
 
-AUTHENTICATION_TYPES = ("basic", "digest", "bearer", "ntlm", "jwt", "oauth2")
+AUTHENTICATION_TYPES = ("basic", "digest", "bearer", "ntlm", "jwt")
 
 PROXY_SCHEMES = ("http://", "https://", "socks5://", "socks5h://", "socks4://", "socks4a://")
 


### PR DESCRIPTION
The current implementation for Oauth2 authentication is wrong and doesn't work, so temporarily remove it. It might be re-added in the future