### PR TITLE
Check whether pip is installed & Disable CLI output in quiet mode

### DIFF
--- a/dirsearch.py
+++ b/dirsearch.py
@@ -24,7 +24,7 @@ from pkg_resources import DistributionNotFound, VersionConflict
 
 from lib.core.data import options
 from lib.core.exceptions import FailedDependenciesInstallation
-from lib.core.installation import check_dependencies, install_dependencies
+from lib.core.installation import check_pip, install_pip, check_dependencies, install_dependencies
 from lib.core.settings import OPTIONS_FILE
 from lib.parse.config import ConfigParser
 
@@ -38,6 +38,25 @@ def main():
     config.read(OPTIONS_FILE)
 
     if config.safe_getboolean("options", "check-dependencies", False):
+        # Check pip installation
+        try:
+            check_pip()
+        except ImportError:
+            option = input("Pip is not installed.\n"
+                           "Do you want dirsearch to automatically install it? [Y/n] ")
+            
+            if option.lower() == 'y':
+                print("Installing pip...")
+                try:
+                    install_pip()
+                except FailedPipInstallation:
+                    print("Failed to install pip, try doing it manually.")
+                    exit(1)
+            else:
+                print("Failed to start the program, install pip first.")
+                exit(1)
+                
+        # Check dependencies installation
         try:
             check_dependencies()
         except (DistributionNotFound, VersionConflict):

--- a/lib/core/installation.py
+++ b/lib/core/installation.py
@@ -20,6 +20,7 @@
 import subprocess
 import sys
 import pkg_resources
+import requests
 
 from lib.core.exceptions import FailedDependenciesInstallation
 from lib.core.settings import SCRIPT_PATH
@@ -35,11 +36,29 @@ def get_dependencies():
         print("Can't find requirements.txt")
         exit(1)
 
+def check_pip():
+    try:
+        import pip
+    except ImportError as e:
+        raise ImportError("Pip is not installed")
+
+def install_pip():
+    try:
+        # Downloaded pip
+        URL = "https://bootstrap.pypa.io/get-pip.py"
+        response = requests.get(URL)
+        open("get-pip.py", "wb").write(response.content)
+        # Install pip
+        subprocess.check_output(
+            [sys.executable, "get-pip.py"],
+            stderr=subprocess.STDOUT
+        )
+    except:
+        raise FailedPipInstallation
 
 # Check if all dependencies are satisfied
 def check_dependencies():
     pkg_resources.require(get_dependencies())
-
 
 def install_dependencies():
     try:

--- a/lib/view/terminal.py
+++ b/lib/view/terminal.py
@@ -206,7 +206,8 @@ class CLI:
 
 class QuietCLI(CLI):
     def status_report(self, response, full_url):
-        super().status_report(response, True)
+        # super().status_report(response, True)
+        pass
 
     def last_path(*args):
         pass


### PR DESCRIPTION
Description
---------------

What will it do?
- It checks whether `pip` is installed. If not, it asks the user to install it automatically.
- It disables console logs in the quiet mode

If this PR will fix an issue, please address it:
Fix #1246: At first, it should check whether the pip is installed or not before doing the automated installation of dirsearch dependencies
Fix #1230: Option to disable CLI output

Requirements
---------------

- [ ] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
