### PR TITLE
Add Oracle eBusiness vulns

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -6615,7 +6615,12 @@ nwp-content/
 nwp-content/plugins/disqus-comment-system/disqus.php
 nytprof.out
 o
+OA_HTML/BneUploaderService
+OA_HTML/BneViewerXMLService
+OA_HTML/BneDownloadService
+OA_HTML/BneOfflineLOVService
 OA_HTML/OA.jsp
+OA_HTML/ibeCAcpSSOReg.jsp
 oab/
 oauth
 oauth.%EXT%
@@ -9487,6 +9492,7 @@ xml
 xml/
 xml/_common.xml
 xml/common.xml
+xmlpserver/ReportTemplateService
 xmlrpc
 xmlrpc.php
 xmlrpc_server.php


### PR DESCRIPTION
CVE--2022-21587
https://blog.viettelcybersecurity.com/cve-2022-21587-oracle-e-business-suite-unauth-rce/

CVE-2022–21500
https://medium.com/@skdash98/exploitation-of-cve-2022-21500-oracle-e-business-login-panel-that-allowed-me-to-access-all-722adae914c4

CVE-2019-2616
https://github.com/vah13/OracleCVE/blob/master/Oracle%20Business%20Intelligence/XXE/CVE-2019-2616_PoC.txt

Description
---------------

What will it do? Add several Oracle eBusiness vulnerabilities
