### PR TITLE
dicc: added html2pdf

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -5307,6 +5307,7 @@ html/config.rb
 html/js/misc/swfupload//swfupload.swf
 html/js/misc/swfupload/swfupload.swf
 html/js/misc/swfupload/swfupload_f9.swf
+html2pdf
 htmlcov/
 htmldb
 htpasswd


### PR DESCRIPTION
Description
---------------

Added `html2pdf` to the wordlist. This might be a typical path for pdf generators.

Requirements
---------------

- [ ] Add your name to `CONTRIBUTERS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
