### PR TITLE
Allow dirseach to find endpoints exposing jwks files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,6 +72,7 @@
 - [junmoka](https://github.com/junmoka)
 - [Akshay Ravi](https://www.linkedin.com/in/c09yc47/)
 - [kosyan62](https://https://github.com/kosyan62)
+- [Maxence Zolnieurck](https://github.com/mxcezl)
 
 Special thanks to all the people who are named here!
 

--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -5774,6 +5774,8 @@ JTAExtensionsSamples/TransactionTracker
 JTAExtensionsSamples/TransactionTracker/
 juju/
 junit/
+jwks.json
+jwks.jwt
 jwsdir
 k
 kadmin


### PR DESCRIPTION
Description
---------------

**What will it do?**

Allow dirseach to find endpoints exposing jwks files / data.

jwks.jwt & jwks.json files stores JSON Web Key Sets which can leak sensitive data such as public / private keys.

Requirements
---------------

- [X] Add your name to `CONTRIBUTERS.md`

 Sources
---------------

- [IBM](https://www.ibm.com/docs/en/sva/10.0.5?topic=applications-jwks)
- [Reach Five](https://developer.reachfive.com/docs/jwks.html)
- [Connect2Id](https://connect2id.com/products/server/docs/api/jwk-set)