### PR TITLE
Allow dirsearch to use a non-default network interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Support non-default network interface
 
 ## [0.4.3] - October 2nd, 2022
 - Automatically detect the URI scheme (`http` or `https`) if no scheme is provided

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,6 +73,7 @@
 - [Akshay Ravi](https://www.linkedin.com/in/c09yc47/)
 - [kosyan62](https://https://github.com/kosyan62)
 - [Maxence Zolnieurck](https://github.com/mxcezl)
+- [huyphan](https://github.com/huyphan)
 
 Special thanks to all the people who are named here!
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Options:
     --max-rate=RATE     Max requests per second
     --retries=RETRIES   Number of retries for failed requests
     --ip=IP             Server IP address
+    --interface=NETWORK_INTERFACE
+                        Network interface to use
 
   Advanced Settings:
     --crawl             Crawl for new paths in responses

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -450,6 +450,7 @@ def parse_arguments():
         help="Number of retries for failed requests",
     )
     connection.add_option("--ip", action="store", dest="ip", help="Server IP address")
+    connection.add_option("--interface", action="store", dest="network_interface", help="Network interface to use")
 
     # Advanced Settings
     advanced = OptionGroup(parser, "Advanced Settings")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pyparsing>=2.4.7
 beautifulsoup4>=4.8.0
 mysql-connector-python>=8.0.20
 psycopg[binary]>=3.0
+requests-toolbelt>=1.0.0


### PR DESCRIPTION
Description
---------------

This change allows users to configure `dirsearch` to use specific network interface instead of the default one. This is useful for users who have more than one egress interfaces on their machines. 

Requirements
---------------

- [X] Add your name to `CONTRIBUTERS.md`
- [X] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
