### PR TITLE
Fix bug of wrong file extension

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -362,7 +362,7 @@ class Controller:
         if options["output_format"] in ("plain", "simple"):
             return "txt"
 
-        return {options["output_format"]}
+        return options["output_format"]
 
     def setup_reports(self):
         """Create report file"""


### PR DESCRIPTION
Description
---------------

Currently when exporting results to certain file format, let's say `json`, `dirsearch` would use the extension `.{'json'}` for the output file. For example:

```
dirsearch --format json -u google.com                                                                                                  
  _|. _ _  _  _  _ _|_    v0.4.3
 (_||| _) (/_(_|| (_| )

Extensions: php, aspx, jsp, html, js | HTTP method: GET | Threads: 25 | Wordlist size: 11714
_23-09-18_14-31-47.json

Output: /home/hphan/dirsearch/reports/_google.com/_23-09-18_14-31-47.{'json'}
```

This change makes sure the correct extension is used. 
