### PR TITLE
1341 Issue fix -  reports folder is created (empty) when you specify output flag

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,6 +77,7 @@
 - [huyphan](https://github.com/huyphan)
 - [Sean Wei](https://www.sean.taipei/about-en)
 - [FantasqueX](https://www.github.com/FantasqueX)
+- [ajcriado](https://www.github.com/ajcriado)
 
 Special thanks to all the people who are named here!
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,6 +77,8 @@
 - [huyphan](https://github.com/huyphan)
 - [Sean Wei](https://www.sean.taipei/about-en)
 - [FantasqueX](https://www.github.com/FantasqueX)
+- [Ovi3](https://github.com/Ovi3)
+- [u21h2](https://www.github.com/u21h2)
 - [ajcriado](https://www.github.com/ajcriado)
 
 Special thanks to all the people who are named here!

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -162,7 +162,7 @@ class Controller:
                 )
                 exit(1)
 
-        if options["autosave_report"]:
+        if options["autosave_report"] and not options["output"] :
             self.report_path = options["output_path"] or FileUtils.build_path(
                 SCRIPT_PATH, "reports"
             )


### PR DESCRIPTION
Description
---------------

The reports folder is always created where you execute the app even though you specify output flag because controller.setup method is not handling the options["output"] value, so it creates the folder ("reports" name by default, stored in options["output_path"]) leaving it empty.

I just control if options["output"] comes with value as it is done in controller.setup_reports method

Fix #1341

![1](https://github.com/maurosoria/dirsearch/assets/20457637/62b0904e-7cc5-4fc6-8e76-2b0453463470)
