### PR TITLE
1305 Issue fix - delay applied to all requests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,6 +80,7 @@
 - [Ovi3](https://github.com/Ovi3)
 - [u21h2](https://www.github.com/u21h2)
 - [Valentijn Scholten](https://www.github.com/valentijnscholten)
+- [ajcriado](https://www.github.com/ajcriado)
 
 Special thanks to all the people who are named here!
 

--- a/lib/core/scanner.py
+++ b/lib/core/scanner.py
@@ -17,9 +17,11 @@
 #  Author: Mauro Soria
 
 import re
+import time
 
 from urllib.parse import unquote
 
+from lib.core.data import options
 from lib.core.logger import logger
 from lib.core.settings import (
     REFLECTED_PATH_MARKER,
@@ -52,7 +54,8 @@ class Scanner:
             rand_string(TEST_PATH_LENGTH),
         )
         first_response = self.requester.request(first_path)
-        self.response = first_response
+        self.response = first_response         
+        time.sleep(options["delay"])
 
         duplicate = self.get_duplicate(first_response)
         # Another test was performed before and has the same response as this
@@ -67,6 +70,7 @@ class Scanner:
             rand_string(TEST_PATH_LENGTH, omit=first_path),
         )
         second_response = self.requester.request(second_path)
+        time.sleep(options["delay"])
 
         if first_response.redirect and second_response.redirect:
             self.wildcard_redirect_regex = self.generate_redirect_regex(


### PR DESCRIPTION
Description
---------------

Fix https://github.com/maurosoria/dirsearch/issues/1305 Issue

Delay parameter is not applied to baseline requests so I have changed the Time.sleep call from fuzzer.py to requester.py, where all the requests are made

**Note:** I have moved the delay between baseline requests as @maurosoria requested [here](https://github.com/maurosoria/dirsearch/pull/1349)