### PR TITLE
Remove ioerror

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,6 +82,7 @@
 - [Valentijn Scholten](https://www.github.com/valentijnscholten)
 - [ajcriado](https://www.github.com/ajcriado)
 - [archdiote](https://www.github.com/archidote)
+- [jxdv](https://github.com/jxdv)
 
 Special thanks to all the people who are named here!
 

--- a/lib/utils/file.py
+++ b/lib/utils/file.py
@@ -80,7 +80,7 @@ class FileUtils:
         try:
             with open(file_name):
                 pass
-        except IOError:
+        except OSError:
             return False
 
         return True


### PR DESCRIPTION
Description
---------------

Since dirsearch requires >= python 3.7 IOError can be removed since it's been deprecated in python 3.3 and merged into OSError.

Requirements
---------------

- [x] Add your name to `CONTRIBUTERS.md`