### PR TITLE
python cleanup

### DIFF
--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -79,7 +79,7 @@ class Dictionary:
         return item in self._items
 
     def __getstate__(self):
-        return (self._items, self._index)
+        return self._items, self._index
 
     def __setstate__(self, state):
         self._items, self._index = state
@@ -151,7 +151,7 @@ class Dictionary:
                         options["overwrite_extensions"]
                         and not line.endswith(options["extensions"] + EXCLUDE_OVERWRITE_EXTENSIONS)
                         # Paths that have queries in wordlist are usually used for exploiting
-                        # diclosed vulnerabilities of services, skip such paths
+                        # disclosed vulnerabilities of services, skip such paths
                         and "?" not in line
                         and "#" not in line
                         and re.search(EXTENSION_RECOGNITION_REGEX, line)

--- a/lib/core/structures.py
+++ b/lib/core/structures.py
@@ -39,7 +39,7 @@ class CaseInsensitiveDict(dict):
             self.__setitem__(key, value)
 
 
-class OrderedSet():
+class OrderedSet:
     def __init__(self, items=[]):
         self._data = dict()
 

--- a/lib/reports/html_report.py
+++ b/lib/reports/html_report.py
@@ -38,11 +38,11 @@ class HTMLReport(FileBaseReport):
 
         for entry in entries:
             status_color_class = ""
-            if entry.status >= 200 and entry.status <= 299:
+            if 200 <= entry.status <= 299:
                 status_color_class = "text-success"
-            elif entry.status >= 300 and entry.status <= 399:
+            elif 300 <= entry.status <= 399:
                 status_color_class = "text-warning"
-            elif entry.status >= 400 and entry.status <= 599:
+            elif 400 <= entry.status <= 599:
                 status_color_class = "text-danger"
 
             results.append(


### PR DESCRIPTION
Description
---------------

`lib/core/dictionary.py` -> fix typo, remove redundant parenthesis since you are returning a tuple anyway
`lib/core/structures.py` -> remove redundant class parenthesis (not needed in python3)
`lib/reports/html_report.py` -> simplify comparison statements