### PR TITLE
set_target before we parse the URL and then use self.url

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -374,7 +374,9 @@ class Controller:
                 directory_path = self.setup_batch_reports()
                 filename = "BATCH." + self.get_output_extension()
             else:
-                parsed = urlparse(options["urls"][0])
+                self.set_target(options["urls"][0])
+
+                parsed = urlparse(self.url)
 
                 if not parsed.netloc:
                     parsed = urlparse(f"//{options['urls'][0]}")


### PR DESCRIPTION
# Description

What will it do?

If this PR will fix an issue, please address it:
https://github.com/maurosoria/dirsearch/issues/1357

# Recreate issue

Without the fix run:
`dirsearch "--url=scanme.nmap.org"`

Report will be generated at:
`/reports/_scanme.nmap.org/__24-04-30_15-05-07.txt`

With fix run and the report will be stored at:
`/reports/http_scanme.nmap.org/__24-04-30_15-05-07.txt`
