### PR TITLE
Add backup file adder code

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -442,6 +442,11 @@ class Controller:
 
         interface.status_report(response, options["full_url"])
 
+        if response.status == 200 and not response.full_path.endswith("/"):
+            backup_extensions = [".bak", "~", ".swp", ".swn", ".tar.gz", ".zip"]
+            for backup_extension in backup_extensions:
+                self.dictionary._items.append(f"{response.full_path}{backup_extension}")
+
         if response.status in options["recursion_status_codes"] and any(
             (
                 options["recursive"],


### PR DESCRIPTION
# Description
Add support such that when a file is found (200 HTTP OK code), additional extensions (related to backup files) are added to the queue

# TODO
Some functionality is done quite ugly, let me know how you want to support it
1. `backup extensions` are hardcoded to a list, should I read it from a file? a config parameter?
2. `_items` is directly accessed, should I add a `Dictionary` func to add items? is it allowed to add to `_items` running it appears to have no ill effect