### PR TITLE
Update dicc.txt

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -1354,6 +1354,8 @@
 .zshrc
 .zuul.yaml
 .zuul.yml
+api/1
+api/v1/1
 0
 0.htpasswd
 0.php


### PR DESCRIPTION
Hello Team,

From our recent assessment, we have found that developers are using these "api/1, api/v1/1" paths and files to backup their source code and other internal files. These paths were not available in Dirsearch.
