### PR TITLE
add --urls-only option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Support non-default network interface
 - Remove unused dependencies (urllib3, cryptography, cffi, idna, chardet)
 - Load targets from a Nmap XML report
+- Added --silent option to output only the full URL
 
 ## [0.4.3] - October 2nd, 2022
 - Automatically detect the URI scheme (`http` or `https`) if no scheme is provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Support non-default network interface
 - Remove unused dependencies (urllib3, cryptography, cffi, idna, chardet)
 - Load targets from a Nmap XML report
-- Added --silent option to output only the full URL
+- Added --urls-only option to output only the full URL
 
 ## [0.4.3] - October 2nd, 2022
 - Automatically detect the URI scheme (`http` or `https`) if no scheme is provided

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Options:
                         Show redirects history
     --no-color          No colored output
     -q, --quiet-mode    Quiet mode
+    --silent            Silent mode
 
   Output Settings:
     -o PATH, --output=PATH
@@ -343,6 +344,7 @@ crawl = False
 [view]
 full-url = False
 quiet-mode = False
+silent = Faise
 color = True
 show-redirects-history = False
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Options:
                         Show redirects history
     --no-color          No colored output
     -q, --quiet-mode    Quiet mode
-    --silent            Silent mode
+    --urls-only         Output only the full URLs
 
   Output Settings:
     -o PATH, --output=PATH
@@ -344,7 +344,7 @@ crawl = False
 [view]
 full-url = False
 quiet-mode = False
-silent = Faise
+urls-only = Faise
 color = True
 show-redirects-history = False
 

--- a/config.ini
+++ b/config.ini
@@ -67,6 +67,7 @@ crawl = False
 [view]
 full-url = False
 quiet-mode = False
+silent = False
 color = True
 show-redirects-history = False
 

--- a/config.ini
+++ b/config.ini
@@ -67,7 +67,7 @@ crawl = False
 [view]
 full-url = False
 quiet-mode = False
-silent = False
+urls-only = False
 color = True
 show-redirects-history = False
 

--- a/lib/core/data.py
+++ b/lib/core/data.py
@@ -87,6 +87,7 @@ options = {
     "redirects_history": False,
     "color": True,
     "quiet": False,
+    "silent": False,
     "output_file": None,
     "output_format": None,
     "log_file": None,

--- a/lib/core/data.py
+++ b/lib/core/data.py
@@ -87,7 +87,7 @@ options = {
     "redirects_history": False,
     "color": True,
     "quiet": False,
-    "silent": False,
+    "urls_only": False,
     "output_file": None,
     "output_format": None,
     "log_file": None,

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -355,7 +355,7 @@ def parse_config(opt):
     opt.full_url = opt.full_url or config.safe_getboolean("view", "full-url")
     opt.color = opt.color or config.safe_getboolean("view", "color", True)
     opt.quiet = opt.quiet or config.safe_getboolean("view", "quiet-mode")
-    opt.silent = opt.silent or config.safe_getboolean("view", "silent")
+    opt.urls_only = opt.urls_only or config.safe_getboolean("view", "urls-only")
     opt.redirects_history = opt.redirects_history or config.safe_getboolean(
         "view", "show-redirects-history"
     )

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -355,6 +355,7 @@ def parse_config(opt):
     opt.full_url = opt.full_url or config.safe_getboolean("view", "full-url")
     opt.color = opt.color or config.safe_getboolean("view", "color", True)
     opt.quiet = opt.quiet or config.safe_getboolean("view", "quiet-mode")
+    opt.silent = opt.silent or config.safe_getboolean("view", "silent")
     opt.redirects_history = opt.redirects_history or config.safe_getboolean(
         "view", "show-redirects-history"
     )

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -489,6 +489,9 @@ def parse_arguments():
     view.add_option(
         "-q", "--quiet-mode", action="store_true", dest="quiet", help="Quiet mode"
     )
+    view.add_option(
+        "--silent", action="store_true", dest="silent", help="Silent mode"
+    )
 
     # Output Settings
     output = OptionGroup(parser, "Output Settings")

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -490,7 +490,7 @@ def parse_arguments():
         "-q", "--quiet-mode", action="store_true", dest="quiet", help="Quiet mode"
     )
     view.add_option(
-        "--silent", action="store_true", dest="silent", help="Silent mode"
+        "--urls-only", action="store_true", dest="urls_only", help="Output only the full URLs"
     )
 
     # Output Settings

--- a/lib/view/terminal.py
+++ b/lib/view/terminal.py
@@ -233,4 +233,9 @@ class QuietCLI(CLI):
         pass
 
 
-interface = QuietCLI() if options["quiet"] else CLI()
+class SilentCLI(QuietCLI):
+    def status_report(self, response, _):
+        self.new_line(response.url)
+
+
+interface = SilentCLI() if options["silent"] else QuietCLI() if options["quiet"] else CLI()

--- a/lib/view/terminal.py
+++ b/lib/view/terminal.py
@@ -233,9 +233,9 @@ class QuietCLI(CLI):
         pass
 
 
-class SilentCLI(QuietCLI):
+class URLOnlyCLI(QuietCLI):
     def status_report(self, response, _):
         self.new_line(response.url)
 
 
-interface = SilentCLI() if options["silent"] else QuietCLI() if options["quiet"] else CLI()
+interface = URLOnlyCLI() if options["urls_only"] else QuietCLI() if options["quiet"] else CLI()


### PR DESCRIPTION
Description
---------------

This PR added the `--urls-only` option to make dirsearch output only the `full_url`, which is useful to pipe the output to other tools.

Like: `dirsearch -u http://172.18.0.2:8080 -e html -i 200 --urls-only | httpx-toolkit -title`

Requirements
---------------

- [x] Add your name to `CONTRIBUTORS.md`
- [x] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
