### PR TITLE
Do not add '/' when '-f' is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Wordlists (IMPORTANT)
 **Summary:**
   - Wordlist is a text file, each line is a path.
   - About extensions, unlike other tools, dirsearch only replaces the `%EXT%` keyword with extensions from **-e** flag.
-  - For wordlists without `%EXT%` (like [SecLists](https://github.com/danielmiessler/SecLists)), **-f | --force-extensions** switch is required to append extensions to every word in wordlist, as well as the `/`.
+  - For wordlists without `%EXT%` (like [SecLists](https://github.com/danielmiessler/SecLists)), **-f | --force-extensions** switch is required to append extensions to every word in wordlist.
   - To apply your extensions to wordlist entries that have extensions already, use **-O** | **--overwrite-extensions** (Note: some extensions are excluded from being overwritted such as *.log*, *.json*, *.xml*, ... or media extensions like *.jpg*, *.png*)
   - To use multiple wordlists, you can separate your wordlists with commas. Example: `wordlist1.txt,wordlist2.txt`.
 

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -142,8 +142,6 @@ class Dictionary:
                         and "." not in line
                         and not line.endswith("/")
                     ):
-                        wordlist.add(line + "/")
-
                         for extension in options["extensions"]:
                             wordlist.add(f"{line}.{extension}")
                     # Overwrite unknown extensions with selected ones (but also keep the origin)


### PR DESCRIPTION
Description
---------------

Currently `-f` does not only append extensions to paths but "/" as well. This unnecessarily generates a huge number of entries, and users can't get rid of this behavior no matter what. So, I decided to remove it, considering that users still can append slash if they want with `--suffixes`.