### PR TITLE
Use re instead of pyparsing for "cleaning color"

### DIFF
--- a/lib/view/colors.py
+++ b/lib/view/colors.py
@@ -16,10 +16,9 @@
 #
 #  Author: Mauro Soria
 
-import string
+import re
 
 from colorama import init, Fore, Back, Style
-from pyparsing import Literal, Word, Combine, Optional, Suppress, delimitedList, oneOf
 
 
 BACK_COLORS = {
@@ -50,13 +49,8 @@ STYLES = {
     "normal": ""
 }
 
-# Credit: https://stackoverflow.com/a/2187024/12238982
-_escape_seq = Combine(
-    Literal("\x1b")
-    + "["
-    + Optional(delimitedList(Word(string.digits), ";"))
-    + oneOf(list(string.ascii_letters))
-)
+# Credit: https://stackoverflow.com/a/14693789
+_ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
 init()
 
@@ -76,4 +70,4 @@ def set_color(msg, fore="none", back="none", style="normal"):
 
 
 def clean_color(msg):
-    return Suppress(_escape_seq).transformString(msg)
+    return _ansi_escape.sub("", msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ requests>=2.27.0
 requests_ntlm>=1.1.0
 colorama>=0.4.4
 ntlm_auth>=1.5.0
-pyparsing>=2.4.7
 beautifulsoup4>=4.8.0
 mysql-connector-python>=8.0.20
 psycopg[binary]>=3.0


### PR DESCRIPTION
Description
---------------

The overhead of `pyparsing` is quite high; we can use `re` to implement the `clean_color` function.

I ran a simple benchmark using [hyperfine](https://github.com/sharkdp/hyperfine).

```
Benchmark 1: python use_re.py
  Time (mean ± σ):      48.0 ms ±   3.2 ms    [User: 39.0 ms, System: 8.8 ms]
  Range (min … max):    40.7 ms …  56.8 ms    59 runs

Benchmark 2: python use_pyparsing.py
  Time (mean ± σ):      3.542 s ±  0.088 s    [User: 3.521 s, System: 0.014 s]
  Range (min … max):    3.471 s …  3.770 s    10 runs

Summary
  python use_re.py ran
   73.75 ± 5.27 times faster than python use_pyparsing.py
```

use_re.py
```python
import re

_ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")

def clean_color(msg):
    return _ansi_escape.sub("", msg)

for _ in range(10000):
    msg = "\x1b[1;31m\x1b[40mthis is a message for testing"
    clean_color(msg)
```

use_pyparsing.py
```python
import string
from pyparsing import Combine, Literal, Optional, Suppress, Word, delimitedList, oneOf

_escape_seq = Combine(
    Literal("\x1b")
    + "["
    + Optional(delimitedList(Word(string.digits), ";"))
    + oneOf(list(string.ascii_letters))
)

def clean_color(msg):
    return Suppress(_escape_seq).transformString(msg)

for _ in range(10000):
    msg = "\x1b[1;31m\x1b[40mthis is a message for testing"
    clean_color(msg)
```

Requirements
---------------

- [x] Add your name to `CONTRIBUTORS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
