### PR TITLE
suppress CancelledError

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -330,7 +330,7 @@ class Controller:
         if not port:
             port = STANDARD_PORTS.get(parsed.scheme, None)
         elif not 0 < port < 65536:
-            raise InvalidURLException(f"Invalid port number: {port}")            
+            raise InvalidURLException(f"Invalid port number: {port}")
 
         if options["ip"]:
             cache_dns(parsed.hostname, port, options["ip"])

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -277,7 +277,7 @@ class Controller:
                     self.fuzzer.start()
                     self.process()
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError):
                 pass
 
             finally:


### PR DESCRIPTION
Description
---------------

When moving on to the next directory scan, the `CancelledError` from the previous scan needs to be suppressed.
