### PR TITLE
fix bug in #1430

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -202,6 +202,7 @@ class Fuzzer(BaseFuzzer):
         self.setup_scanners()
         self.setup_threads()
         self.play()
+        self._quit_event.clear()
 
         for thread in self._threads:
             thread.start()


### PR DESCRIPTION
Following @shelld3v's suggestion, let’s use `signal.signal()` consistently for handling the pause logic.