### PR TITLE
Add 'livewire/update' to dicc.txt

### DIFF
--- a/db/dicc.txt
+++ b/db/dicc.txt
@@ -5954,6 +5954,7 @@ listinfo
 lists
 lists/
 lists/config
+livewire/update
 LiveUser_Admin/
 lk/
 llms.txt


### PR DESCRIPTION
Description
---------------

Add Laravel `/livewire/update` endpoint.

It relates with the RCE vuln with the CVE-2025-54068: Livewire remote command execution through unmarshaling

Reference
---------------
https://www.synacktiv.com/en/publications/livewire-remote-command-execution-through-unmarshaling


Requirements
---------------

- [ ] Add your name to `CONTRIBUTORS.md` - No need already contributed before.
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md` - N/A
