### PR TITLE
Fix PyInstaller: add --paths and --collect-submodules for lib package

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -59,9 +59,21 @@ jobs:
           pyinstaller \
             --onefile \
             --name dirsearch \
+            --paths=. \
+            --collect-submodules=lib \
             --add-data "db:db" \
             --add-data "config.ini:." \
             --add-data "lib/report:lib/report" \
+            --hidden-import=lib \
+            --hidden-import=lib.core \
+            --hidden-import=lib.core.settings \
+            --hidden-import=lib.core.options \
+            --hidden-import=lib.controller \
+            --hidden-import=lib.connection \
+            --hidden-import=lib.parse \
+            --hidden-import=lib.report \
+            --hidden-import=lib.utils \
+            --hidden-import=lib.view \
             --hidden-import=requests \
             --hidden-import=httpx \
             --hidden-import=urllib3 \
@@ -130,9 +142,21 @@ jobs:
           pyinstaller `
             --onefile `
             --name dirsearch `
+            --paths=. `
+            --collect-submodules=lib `
             --add-data "db;db" `
             --add-data "config.ini;." `
             --add-data "lib/report;lib/report" `
+            --hidden-import=lib `
+            --hidden-import=lib.core `
+            --hidden-import=lib.core.settings `
+            --hidden-import=lib.core.options `
+            --hidden-import=lib.controller `
+            --hidden-import=lib.connection `
+            --hidden-import=lib.parse `
+            --hidden-import=lib.report `
+            --hidden-import=lib.utils `
+            --hidden-import=lib.view `
             --hidden-import=requests `
             --hidden-import=httpx `
             --hidden-import=urllib3 `
@@ -200,9 +224,21 @@ jobs:
           pyinstaller \
             --onefile \
             --name dirsearch \
+            --paths=. \
+            --collect-submodules=lib \
             --add-data "db:db" \
             --add-data "config.ini:." \
             --add-data "lib/report:lib/report" \
+            --hidden-import=lib \
+            --hidden-import=lib.core \
+            --hidden-import=lib.core.settings \
+            --hidden-import=lib.core.options \
+            --hidden-import=lib.controller \
+            --hidden-import=lib.connection \
+            --hidden-import=lib.parse \
+            --hidden-import=lib.report \
+            --hidden-import=lib.utils \
+            --hidden-import=lib.view \
             --hidden-import=requests \
             --hidden-import=httpx \
             --hidden-import=urllib3 \
@@ -271,9 +307,21 @@ jobs:
           pyinstaller \
             --onefile \
             --name dirsearch \
+            --paths=. \
+            --collect-submodules=lib \
             --add-data "db:db" \
             --add-data "config.ini:." \
             --add-data "lib/report:lib/report" \
+            --hidden-import=lib \
+            --hidden-import=lib.core \
+            --hidden-import=lib.core.settings \
+            --hidden-import=lib.core.options \
+            --hidden-import=lib.controller \
+            --hidden-import=lib.connection \
+            --hidden-import=lib.parse \
+            --hidden-import=lib.report \
+            --hidden-import=lib.utils \
+            --hidden-import=lib.view \
             --hidden-import=requests \
             --hidden-import=httpx \
             --hidden-import=urllib3 \

--- a/pyinstaller/build.sh
+++ b/pyinstaller/build.sh
@@ -64,9 +64,21 @@ build() {
     $PYTHON_CMD -m PyInstaller \
         --onefile \
         --name dirsearch \
+        --paths=. \
+        --collect-submodules=lib \
         --add-data "db:db" \
         --add-data "config.ini:." \
         --add-data "lib/report:lib/report" \
+        --hidden-import=lib \
+        --hidden-import=lib.core \
+        --hidden-import=lib.core.settings \
+        --hidden-import=lib.core.options \
+        --hidden-import=lib.controller \
+        --hidden-import=lib.connection \
+        --hidden-import=lib.parse \
+        --hidden-import=lib.report \
+        --hidden-import=lib.utils \
+        --hidden-import=lib.view \
         --hidden-import=requests \
         --hidden-import=httpx \
         --hidden-import=urllib3 \


### PR DESCRIPTION
PyInstaller wasn't detecting the local 'lib' package. Added:
- --paths=. to include current directory in Python path
- --collect-submodules=lib to collect all lib submodules
- Explicit hidden imports for lib.* modules

Description
---------------

What will it do?

If this PR will fix an issue, please address it:
Fix #{issue}

Requirements
---------------

- [ ] Add your name to `CONTRIBUTORS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
