### PR TITLE
Lock requirements.txt to prevent supply chain attacks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,18 @@
-PySocks>=1.7.1
-Jinja2>=3.0.0
-defusedxml>=0.7.0
-pyopenssl>=21.0.0
-requests>=2.27.0
-requests_ntlm>=1.3.0
-colorama>=0.4.4
-ntlm_auth>=1.5.0
-beautifulsoup4>=4.8.0
-mysql-connector-python>=8.0.20
-psycopg[binary]>=3.0
-defusedcsv>=2.0.0
-requests-toolbelt>=1.0.0
-setuptools>=66.0.0
-httpx>=0.27.2
-httpx-ntlm>=1.4.0
+# Pinned versions to prevent supply chain attacks
+# Last updated: 2026-01-13
+PySocks==1.7.1
+Jinja2==3.1.6
+defusedxml==0.7.1
+pyopenssl==25.3.0
+requests==2.32.5
+requests-ntlm==1.3.0
+colorama==0.4.6
+ntlm-auth==1.5.0
+beautifulsoup4==4.14.3
+mysql-connector-python==9.5.0
+psycopg[binary]==3.3.2
+defusedcsv==3.0.0
+requests-toolbelt==1.0.0
+setuptools==80.9.0
+httpx==0.28.1
+httpx-ntlm==1.4.0


### PR DESCRIPTION
Pin all dependencies to exact versions instead of minimum versions to prevent package takeover attacks. This ensures that builds are reproducible and that malicious package updates cannot be automatically pulled in.

Description
---------------

What will it do?

If this PR will fix an issue, please address it:
Fix #{issue}

Requirements
---------------

- [ ] Add your name to `CONTRIBUTORS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
