### PR TITLE
Migrate macOS Intel build to macos-15-large runner

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -197,31 +197,33 @@ jobs:
           retention-days: 30
 
   # ============================================
-  # macOS Intel (x86_64) - Cross-compile from ARM64
+  # macOS Intel (x86_64) - Native Intel runner
   # ============================================
   build-macos-intel:
     name: Build macOS Intel
-    runs-on: macos-15
+    runs-on: macos-15-large
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (x86_64 via Rosetta)
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install dependencies
         run: |
-          # Install x86_64 Python via Rosetta for cross-compilation
-          arch -x86_64 /bin/bash -c "$(curl -fsSL https://www.python.org/ftp/python/${{ env.PYTHON_VERSION }}.0/python-${{ env.PYTHON_VERSION }}.0-macos11.pkg)" || true
-          # Use system Python with arch prefix
-          arch -x86_64 python3 -m pip install --upgrade pip setuptools wheel
-          arch -x86_64 python3 -m pip install -r requirements.txt
-          arch -x86_64 python3 -m pip install pyinstaller==${{ env.PYINSTALLER_VERSION }}
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+          pip install pyinstaller==${{ env.PYINSTALLER_VERSION }}
 
       - name: Build macOS Intel binary
         run: |
-          arch -x86_64 python3 -m PyInstaller \
+          pyinstaller \
             --onefile \
             --name dirsearch \
-            --target-arch x86_64 \
             --paths=. \
             --collect-submodules=lib \
             --add-data "db:db" \
@@ -267,8 +269,8 @@ jobs:
 
       - name: Test macOS Intel binary
         run: |
-          arch -x86_64 ./dist/dirsearch-macos-intel --version
-          arch -x86_64 ./dist/dirsearch-macos-intel --help
+          ./dist/dirsearch-macos-intel --version
+          ./dist/dirsearch-macos-intel --help
 
       - name: Upload macOS Intel artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Replace deprecated macos-13 / broken Rosetta cross-compilation with the new macos-15-large runner which provides native Intel x86_64 support until August 2027.

This eliminates complex arch workarounds and uses the standard setup-python action like other platforms.

Description
---------------

What will it do?

If this PR will fix an issue, please address it:
Fix #{issue}

Requirements
---------------

- [ ] Add your name to `CONTRIBUTORS.md`
- [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
