### PR TITLE
Replace setup.py with pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install codespell flake8 -r requirements.txt
+    - name: Packaging smoke test
+      run: |
+        python -m pip install .
+        dirsearch --version
+        python tests/check_packaged_install.py
     - name: Test
       run: |
         python3 dirsearch.py -w ./tests/static/wordlist.txt -u https://example.com -o "tmp_report.{extension}" -O json,xml,plain,csv,md,sqlite,html --force-recursive -R 3 --full-url -q

--- a/.github/workflows/pyinstaller-linux.yml
+++ b/.github/workflows/pyinstaller-linux.yml
@@ -45,48 +45,7 @@ jobs:
 
       - name: Build Linux binary
         run: |
-          pyinstaller \
-            --onefile \
-            --name dirsearch \
-            --paths=. \
-            --collect-submodules=lib \
-            --add-data "db:db" \
-            --add-data "config.ini:." \
-            --add-data "lib/report:lib/report" \
-            --hidden-import=lib \
-            --hidden-import=lib.core \
-            --hidden-import=lib.core.settings \
-            --hidden-import=lib.core.options \
-            --hidden-import=lib.controller \
-            --hidden-import=lib.connection \
-            --hidden-import=lib.parse \
-            --hidden-import=lib.report \
-            --hidden-import=lib.utils \
-            --hidden-import=lib.view \
-            --hidden-import=requests \
-            --hidden-import=httpx \
-            --hidden-import=urllib3 \
-            --hidden-import=charset_normalizer \
-            --hidden-import=certifi \
-            --hidden-import=PySocks \
-            --hidden-import=socks \
-            --hidden-import=jinja2 \
-            --hidden-import=defusedxml \
-            --hidden-import=OpenSSL \
-            --hidden-import=ntlm_auth \
-            --hidden-import=requests_ntlm \
-            --hidden-import=bs4 \
-            --hidden-import=colorama \
-            --hidden-import=defusedcsv \
-            --hidden-import=httpx_ntlm \
-            --hidden-import=httpcore \
-            --hidden-import=h11 \
-            --hidden-import=anyio \
-            --hidden-import=sniffio \
-            --hidden-import=socksio \
-            --strip \
-            --clean \
-            dirsearch.py
+          pyinstaller --clean pyinstaller/dirsearch.spec
 
       - name: Rename binary
         run: mv dist/dirsearch dist/dirsearch-linux-amd64-${{ matrix.variant.name }}

--- a/.github/workflows/pyinstaller-macos-intel.yml
+++ b/.github/workflows/pyinstaller-macos-intel.yml
@@ -45,48 +45,7 @@ jobs:
 
       - name: Build macOS Intel binary
         run: |
-          pyinstaller \
-            --onefile \
-            --name dirsearch \
-            --paths=. \
-            --collect-submodules=lib \
-            --add-data "db:db" \
-            --add-data "config.ini:." \
-            --add-data "lib/report:lib/report" \
-            --hidden-import=lib \
-            --hidden-import=lib.core \
-            --hidden-import=lib.core.settings \
-            --hidden-import=lib.core.options \
-            --hidden-import=lib.controller \
-            --hidden-import=lib.connection \
-            --hidden-import=lib.parse \
-            --hidden-import=lib.report \
-            --hidden-import=lib.utils \
-            --hidden-import=lib.view \
-            --hidden-import=requests \
-            --hidden-import=httpx \
-            --hidden-import=urllib3 \
-            --hidden-import=charset_normalizer \
-            --hidden-import=certifi \
-            --hidden-import=PySocks \
-            --hidden-import=socks \
-            --hidden-import=jinja2 \
-            --hidden-import=defusedxml \
-            --hidden-import=OpenSSL \
-            --hidden-import=ntlm_auth \
-            --hidden-import=requests_ntlm \
-            --hidden-import=bs4 \
-            --hidden-import=colorama \
-            --hidden-import=defusedcsv \
-            --hidden-import=httpx_ntlm \
-            --hidden-import=httpcore \
-            --hidden-import=h11 \
-            --hidden-import=anyio \
-            --hidden-import=sniffio \
-            --hidden-import=socksio \
-            --strip \
-            --clean \
-            dirsearch.py
+          pyinstaller --clean pyinstaller/dirsearch.spec
 
       - name: Rename binary
         run: mv dist/dirsearch dist/dirsearch-macos-intel-${{ matrix.variant.name }}

--- a/.github/workflows/pyinstaller-macos-silicon.yml
+++ b/.github/workflows/pyinstaller-macos-silicon.yml
@@ -45,48 +45,7 @@ jobs:
 
       - name: Build macOS Silicon binary
         run: |
-          pyinstaller \
-            --onefile \
-            --name dirsearch \
-            --paths=. \
-            --collect-submodules=lib \
-            --add-data "db:db" \
-            --add-data "config.ini:." \
-            --add-data "lib/report:lib/report" \
-            --hidden-import=lib \
-            --hidden-import=lib.core \
-            --hidden-import=lib.core.settings \
-            --hidden-import=lib.core.options \
-            --hidden-import=lib.controller \
-            --hidden-import=lib.connection \
-            --hidden-import=lib.parse \
-            --hidden-import=lib.report \
-            --hidden-import=lib.utils \
-            --hidden-import=lib.view \
-            --hidden-import=requests \
-            --hidden-import=httpx \
-            --hidden-import=urllib3 \
-            --hidden-import=charset_normalizer \
-            --hidden-import=certifi \
-            --hidden-import=PySocks \
-            --hidden-import=socks \
-            --hidden-import=jinja2 \
-            --hidden-import=defusedxml \
-            --hidden-import=OpenSSL \
-            --hidden-import=ntlm_auth \
-            --hidden-import=requests_ntlm \
-            --hidden-import=bs4 \
-            --hidden-import=colorama \
-            --hidden-import=defusedcsv \
-            --hidden-import=httpx_ntlm \
-            --hidden-import=httpcore \
-            --hidden-import=h11 \
-            --hidden-import=anyio \
-            --hidden-import=sniffio \
-            --hidden-import=socksio \
-            --strip \
-            --clean \
-            dirsearch.py
+          pyinstaller --clean pyinstaller/dirsearch.spec
 
       - name: Rename binary
         run: mv dist/dirsearch dist/dirsearch-macos-silicon-${{ matrix.variant.name }}

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -45,47 +45,7 @@ jobs:
 
       - name: Build Windows binary
         run: |
-          pyinstaller `
-            --onefile `
-            --name dirsearch `
-            --paths=. `
-            --collect-submodules=lib `
-            --add-data "db;db" `
-            --add-data "config.ini;." `
-            --add-data "lib/report;lib/report" `
-            --hidden-import=lib `
-            --hidden-import=lib.core `
-            --hidden-import=lib.core.settings `
-            --hidden-import=lib.core.options `
-            --hidden-import=lib.controller `
-            --hidden-import=lib.connection `
-            --hidden-import=lib.parse `
-            --hidden-import=lib.report `
-            --hidden-import=lib.utils `
-            --hidden-import=lib.view `
-            --hidden-import=requests `
-            --hidden-import=httpx `
-            --hidden-import=urllib3 `
-            --hidden-import=charset_normalizer `
-            --hidden-import=certifi `
-            --hidden-import=PySocks `
-            --hidden-import=socks `
-            --hidden-import=jinja2 `
-            --hidden-import=defusedxml `
-            --hidden-import=OpenSSL `
-            --hidden-import=ntlm_auth `
-            --hidden-import=requests_ntlm `
-            --hidden-import=bs4 `
-            --hidden-import=colorama `
-            --hidden-import=defusedcsv `
-            --hidden-import=httpx_ntlm `
-            --hidden-import=httpcore `
-            --hidden-import=h11 `
-            --hidden-import=anyio `
-            --hidden-import=sniffio `
-            --hidden-import=socksio `
-            --clean `
-            dirsearch.py
+          pyinstaller --clean pyinstaller/dirsearch.spec
 
       - name: Rename binary
         run: mv dist/dirsearch.exe dist/dirsearch-windows-x64-${{ matrix.variant.name }}.exe

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,5 @@
+from .dirsearch import main
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,11 @@
 #  Author: Mauro Soria
 
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+requires = ["setuptools>=66.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "dirsearch"
-version = "0.4.3"
 description = "Advanced web path scanner"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -40,37 +39,13 @@ classifiers = [
     "Topic :: Security",
     "Programming Language :: Python :: 3.9",
 ]
-dependencies = [
-    "PySocks>=1.7.1",
-    "Jinja2>=3.1.6",
-    "defusedxml>=0.7.1",
-    "pyopenssl>=25.3.0",
-    "requests>=2.32.5",
-    "requests-ntlm>=1.3.0",
-    "colorama>=0.4.6",
-    "ntlm-auth>=1.5.0",
-    "beautifulsoup4>=4.12.0",
-    "mysql-connector-python>=9.0.0",
-    "psycopg[binary]>=3.3.0",
-    "defusedcsv>=3.0.0",
-    "requests-toolbelt>=1.0.0",
-    "setuptools>=64.0.0",
-    "httpx>=0.28.0",
-    "httpx-ntlm>=1.4.0",
-]
+dynamic = ["version", "dependencies"]
 
 [project.scripts]
 dirsearch = "dirsearch.dirsearch:main"
 
 [project.urls]
 Homepage = "https://github.com/maurosoria/dirsearch"
-
-[tool.setuptools]
-packages = {find = {}}
-
-[tool.setuptools.package-data]
-"*" = ["*"]
-"db" = ["*"]
 
 [tool.codespell]
 skip = ".git,./db/dicc.txt,./static"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Author: Mauro Soria
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dirsearch"
+version = "0.4.3"
+description = "Advanced web path scanner"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "GPL-2.0-only"
+authors = [
+    {name = "Mauro Soria", email = "maurosoria@protonmail.com"},
+]
+keywords = ["infosec", "bug bounty", "pentesting", "security"]
+classifiers = [
+    "Programming Language :: Python",
+    "Environment :: Console",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Operating System :: OS Independent",
+    "Topic :: Security",
+    "Programming Language :: Python :: 3.9",
+]
+dependencies = [
+    "PySocks>=1.7.1",
+    "Jinja2>=3.1.6",
+    "defusedxml>=0.7.1",
+    "pyopenssl>=25.3.0",
+    "requests>=2.32.5",
+    "requests-ntlm>=1.3.0",
+    "colorama>=0.4.6",
+    "ntlm-auth>=1.5.0",
+    "beautifulsoup4>=4.12.0",
+    "mysql-connector-python>=9.0.0",
+    "psycopg[binary]>=3.3.0",
+    "defusedcsv>=3.0.0",
+    "requests-toolbelt>=1.0.0",
+    "setuptools>=64.0.0",
+    "httpx>=0.28.0",
+    "httpx-ntlm>=1.4.0",
+]
+
+[project.scripts]
+dirsearch = "dirsearch.dirsearch:main"
+
+[project.urls]
+Homepage = "https://github.com/maurosoria/dirsearch"
+
+[tool.setuptools]
+packages = {find = {}}
+
+[tool.setuptools.package-data]
+"*" = ["*"]
+"db" = ["*"]
+
+[tool.codespell]
+skip = ".git,./db/dicc.txt,./static"
+
+[tool.flake8]
+count = true
+ignore = "E501,E701,F403,F405,F524,W503"
+show-source = true
+statistics = true

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,3 @@
-# Pinned versions to prevent supply chain attacks
-# Last updated: 2026-01-13
 PySocks==1.7.1
 Jinja2==3.1.6
 defusedxml==0.7.1
@@ -13,6 +11,5 @@ mysql-connector-python==9.4.0
 psycopg[binary]==3.2.13
 defusedcsv==3.0.0
 requests-toolbelt==1.0.0
-setuptools==80.9.0
 httpx==0.28.1
 httpx-ntlm==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,84 @@
 #
 #  Author: Mauro Soria
 
-# NOTE: This file is deprecated. Package metadata is now defined in pyproject.toml.
-# This setup.py is kept for backward compatibility with older pip versions
-# that don't support pyproject.toml-based builds.
+import ast
+import os
+import shutil
+import tempfile
+from pathlib import Path
 
 import setuptools
 
-setuptools.setup()
+
+ROOT = Path(__file__).resolve().parent
+
+# Preserve the historical packaged layout until the repository is reorganized.
+# The built distribution expects a top-level "dirsearch" package that contains
+# the entry module, config.ini, db/, and the lib/ package tree.
+env_dir = tempfile.mkdtemp(prefix="dirsearch-install-")
+package_root = Path(env_dir, "dirsearch")
+shutil.copytree(
+    ROOT,
+    package_root,
+    ignore=shutil.ignore_patterns(
+        ".git",
+        ".github",
+        ".cache",
+        ".venv",
+        "build",
+        "dist",
+        "__pycache__",
+        "*.pyc",
+        "*.pyo",
+        "*.pyd",
+        "tests",
+        "sessions",
+    ),
+)
+
+os.chdir(env_dir)
+
+
+def package_files(directory: Path) -> list[str]:
+    files: list[str] = []
+    for path in sorted(directory.rglob("*")):
+        if path.is_file():
+            files.append(str(path.relative_to(package_root)))
+    return files
+
+
+def read_version(path: Path) -> str:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "VERSION":
+                    value = ast.literal_eval(node.value)
+                    if isinstance(value, str):
+                        return value
+    raise RuntimeError(f"Unable to find VERSION in {path}")
+
+
+def read_requirements(path: Path) -> list[str]:
+    requirements: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        requirement = line.strip()
+        if requirement and not requirement.startswith("#"):
+            requirements.append(requirement)
+    return requirements
+
+
+setuptools.setup(
+    version=read_version(ROOT / "lib/core/settings.py"),
+    install_requires=read_requirements(ROOT / "requirements/runtime.txt"),
+    entry_points={"console_scripts": ["dirsearch=dirsearch.dirsearch:main"]},
+    packages=setuptools.find_packages(exclude=("dirsearch.tests", "dirsearch.tests.*")),
+    package_data={
+        "dirsearch": [
+            "config.ini",
+            *package_files(package_root / "db"),
+        ],
+        "dirsearch.lib.report": ["templates/*.html"],
+    },
+    include_package_data=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,26 @@
-import io
-import os
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Author: Mauro Soria
+
+# NOTE: This file is deprecated. Package metadata is now defined in pyproject.toml.
+# This setup.py is kept for backward compatibility with older pip versions
+# that don't support pyproject.toml-based builds.
+
 import setuptools
-import shutil
-import tempfile
 
-from lib.core.installation import get_dependencies
-from lib.core.settings import VERSION
-
-
-current_dir = os.path.abspath(os.path.dirname(__file__))
-with io.open(os.path.join(current_dir, "README.md"), encoding="utf-8") as fd:
-    desc = fd.read()
-
-env_dir = tempfile.mkdtemp(prefix="dirsearch-install-")
-shutil.copytree(os.path.abspath(os.getcwd()), os.path.join(env_dir, "dirsearch"))
-
-os.chdir(env_dir)
-
-setuptools.setup(
-    name="dirsearch",
-    version=VERSION,
-    author="Mauro Soria",
-    author_email="maurosoria@protonmail.com",
-    description="Advanced web path scanner",
-    long_description=desc,
-    long_description_content_type="text/markdown",
-    url="https://github.com/maurosoria/dirsearch",
-    packages=setuptools.find_packages(),
-    entry_points={"console_scripts": ["dirsearch=dirsearch.dirsearch:main"]},
-    package_data={"dirsearch": ["*", "db/*"]},
-    include_package_data=True,
-    python_requires=">=3.9",
-    install_requires=get_dependencies(),
-    classifiers=[
-        "Programming Language :: Python",
-        "Environment :: Console",
-        "Intended Audience :: Information Technology",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Operating System :: OS Independent",
-        "Topic :: Security",
-        "Programming Language :: Python :: 3.9",
-    ],
-    keywords=["infosec", "bug bounty", "pentesting", "security"],
-)
+setuptools.setup()

--- a/tests/check_packaged_install.py
+++ b/tests/check_packaged_install.py
@@ -1,6 +1,8 @@
 import ast
 import importlib.metadata
 import os
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -19,7 +21,8 @@ def read_source_version() -> str:
 
 
 def main() -> None:
-    os.chdir(tempfile.mkdtemp(prefix="dirsearch-install-check-"))
+    temp_dir = tempfile.mkdtemp(prefix="dirsearch-install-check-")
+    os.chdir(temp_dir)
 
     from dirsearch.lib.core import settings
 
@@ -30,6 +33,11 @@ def main() -> None:
     package_root = Path(settings.__file__).resolve().parents[2]
     assert (package_root / "config.ini").is_file()
     assert (package_root / "db" / "categories" / "common.txt").is_file()
+    subprocess.run(
+        [sys.executable, "-m", "dirsearch", "--version"],
+        cwd=temp_dir,
+        check=True,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/check_packaged_install.py
+++ b/tests/check_packaged_install.py
@@ -1,0 +1,36 @@
+import ast
+import importlib.metadata
+import os
+import tempfile
+from pathlib import Path
+
+
+def read_source_version() -> str:
+    source = Path(__file__).resolve().parents[1] / "lib" / "core" / "settings.py"
+    module = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "VERSION":
+                    value = ast.literal_eval(node.value)
+                    if isinstance(value, str):
+                        return value
+    raise RuntimeError("Unable to locate VERSION in lib/core/settings.py")
+
+
+def main() -> None:
+    os.chdir(tempfile.mkdtemp(prefix="dirsearch-install-check-"))
+
+    from dirsearch.lib.core import settings
+
+    expected_version = read_source_version()
+    installed_version = importlib.metadata.version("dirsearch")
+    assert installed_version == expected_version, (installed_version, expected_version)
+
+    package_root = Path(settings.__file__).resolve().parents[2]
+    assert (package_root / "config.ini").is_file()
+    assert (package_root / "db" / "categories" / "common.txt").is_file()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Migrates from deprecated setup.py to modern pyproject.toml (PEP 621). Fixes broken pip install caused by removed lib.core.installation module. Closes #1537