### PR TITLE
Improve SSL error handling with specific exception types

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -92,6 +92,36 @@ def _is_requests_ssl_error(exc: Exception) -> bool:
     return False
 
 
+def _iter_exception_chain(exc: BaseException) -> Generator[BaseException, None, None]:
+    seen = set()
+    pending = [exc]
+
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+
+        seen.add(id(current))
+        yield current
+
+        for attr in ("__cause__", "__context__"):
+            chained = getattr(current, attr, None)
+            if chained is not None:
+                pending.append(chained)
+
+
+def _find_ssl_error(exc: Exception) -> ssl.SSLError | None:
+    for current in _iter_exception_chain(exc):
+        if isinstance(current, ssl.SSLError):
+            return current
+
+    return None
+
+
+def _is_ssl_error(exc: Exception) -> bool:
+    return isinstance(exc, requests.exceptions.SSLError) or _find_ssl_error(exc) is not None
+
+
 def _format_ssl_error(exc: Exception, url: str = "") -> str:
     """Format SSL error with specific, actionable error messages.
 
@@ -100,20 +130,7 @@ def _format_ssl_error(exc: Exception, url: str = "") -> str:
     diagnose and fix SSL-related issues.
     """
     # Resolve the underlying ssl.SSLError from the exception chain
-    ssl_exc = None
-    if isinstance(exc, ssl.SSLError):
-        ssl_exc = exc
-    else:
-        # Walk the exception chain for wrapped SSL errors
-        for attr in ("__cause__", "__context__"):
-            cause = getattr(exc, attr, None)
-            while cause is not None:
-                if isinstance(cause, ssl.SSLError):
-                    ssl_exc = cause
-                    break
-                cause = getattr(cause, attr, None)
-            if ssl_exc is not None:
-                break
+    ssl_exc = _find_ssl_error(exc)
 
     err_detail = str(ssl_exc or exc)
 
@@ -338,7 +355,7 @@ class Requester(BaseRequester):
 
                 if e == socket.gaierror:
                     err_msg = "Couldn't resolve DNS"
-                elif isinstance(e, ssl.SSLError) or _is_requests_ssl_error(e):
+                elif _is_ssl_error(e):
                     err_msg = _format_ssl_error(e, url)
                 elif "TooManyRedirects" in str(e):
                     err_msg = f"Too many redirects: {url}"
@@ -509,12 +526,12 @@ class AsyncRequester(BaseRequester):
             except Exception as e:
                 logger.exception(e)
 
-                if isinstance(e, httpx.ConnectError):
+                if isinstance(e, httpx.ConnectError) and not _is_ssl_error(e):
                     if str(e).startswith("[Errno -2]"):
                         err_msg = "Couldn't resolve DNS"
                     else:
                         err_msg = f"Cannot connect to: {urlparse(url).netloc}"
-                elif isinstance(e, ssl.SSLError):
+                elif _is_ssl_error(e):
                     err_msg = _format_ssl_error(e, url)
                 elif isinstance(e, httpx.TooManyRedirects):
                     err_msg = f"Too many redirects: {url}"

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -23,7 +23,7 @@ import http.client
 import random
 import re
 import socket
-from ssl import SSLError
+import ssl
 import threading
 import time
 from typing import Any, Generator
@@ -36,6 +36,11 @@ from requests.packages import urllib3
 from requests_ntlm import HttpNtlmAuth
 from httpx_ntlm import HttpNtlmAuth as HttpxNtlmAuth
 from requests_toolbelt.adapters.socket_options import SocketOptionsAdapter
+
+try:
+    from ssl import SSLCertVerificationError
+except ImportError:
+    SSLCertVerificationError = None
 
 from lib.connection.dns import cached_getaddrinfo
 from lib.connection.response import AsyncResponse, Response
@@ -58,6 +63,108 @@ from lib.utils.mimetype import guess_mimetype
 urllib3.disable_warnings(urllib3.exceptions.SecurityWarning)
 # Use custom `socket.getaddrinfo` for `requests` which supports DNS caching
 socket.getaddrinfo = cached_getaddrinfo
+
+
+def _is_requests_ssl_error(exc: Exception) -> bool:
+    """Check if the exception is a requests-wrapped SSL error.
+
+    The requests library wraps ssl.SSLError inside requests.exceptions.SSLError,
+    so we need to inspect the exception chain to detect SSL errors that aren't
+    direct instances of ssl.SSLError.
+    """
+    if isinstance(exc, requests.exceptions.SSLError):
+        return True
+
+    # Check the exception cause chain (PEP 3134)
+    cause = exc.__cause__
+    while cause is not None:
+        if isinstance(cause, ssl.SSLError):
+            return True
+        cause = cause.__cause__
+
+    # Also check __context__ for implicit chaining
+    context = exc.__context__
+    while context is not None:
+        if isinstance(context, ssl.SSLError):
+            return True
+        context = context.__context__
+
+    return False
+
+
+def _format_ssl_error(exc: Exception, url: str = "") -> str:
+    """Format SSL error with specific, actionable error messages.
+
+    Provides detailed error messages based on the specific type of SSL error
+    instead of a generic 'Unexpected SSL error' message. This helps users
+    diagnose and fix SSL-related issues.
+    """
+    # Resolve the underlying ssl.SSLError from the exception chain
+    ssl_exc = None
+    if isinstance(exc, ssl.SSLError):
+        ssl_exc = exc
+    else:
+        # Walk the exception chain for wrapped SSL errors
+        for attr in ("__cause__", "__context__"):
+            cause = getattr(exc, attr, None)
+            while cause is not None:
+                if isinstance(cause, ssl.SSLError):
+                    ssl_exc = cause
+                    break
+                cause = getattr(cause, attr, None)
+            if ssl_exc is not None:
+                break
+
+    err_detail = str(ssl_exc or exc)
+
+    # Certificate verification errors
+    if SSLCertVerificationError is not None and isinstance(ssl_exc, SSLCertVerificationError):
+        if "self signed certificate" in err_detail.lower():
+            msg = f"SSL certificate verification failed (self-signed certificate): {url}"
+        elif "certificate has expired" in err_detail.lower():
+            msg = f"SSL certificate verification failed (certificate expired): {url}"
+        elif "certificate is not yet valid" in err_detail.lower():
+            msg = f"SSL certificate verification failed (certificate not yet valid): {url}"
+        elif "unable to get local issuer certificate" in err_detail.lower():
+            msg = f"SSL certificate verification failed (missing local issuer certificate): {url}"
+        elif "hostname" in err_detail.lower() and "match" in err_detail.lower():
+            msg = f"SSL certificate verification failed (hostname mismatch): {url}"
+        else:
+            msg = f"SSL certificate verification failed: {err_detail}"
+        logger.warning(f"SSL certificate error: {err_detail}")
+        return msg
+
+    # SSL handshake / protocol errors
+    if ssl_exc is not None:
+        err_lib = getattr(ssl_exc, "library", "")
+        err_reason = getattr(ssl_exc, "reason", "")
+
+        if "wrong version" in err_detail.lower() or "unsupported protocol" in err_detail.lower():
+            msg = f"SSL protocol version mismatch: {url}"
+        elif "handshake" in err_detail.lower():
+            msg = f"SSL handshake failed: {url}"
+        elif "no shared cipher" in err_detail.lower() or "no ciphers" in err_detail.lower():
+            msg = f"SSL handshake failed (no shared cipher suites): {url}"
+        elif err_lib == "SSL" and "EOF" in err_detail:
+            msg = f"SSL connection terminated unexpectedly: {url}"
+        elif "CERTIFICATE_VERIFY_FAILED" in err_detail:
+            msg = f"SSL certificate verification failed: {url}"
+        else:
+            msg = f"SSL error ({err_reason or err_lib or 'unknown'}): {err_detail}"
+
+        logger.warning(f"SSL error for {url}: library={err_lib}, reason={err_reason}, detail={err_detail}")
+        return msg
+
+    # Fallback for wrapped SSL errors where we can't get the underlying exception
+    if "CERTIFICATE_VERIFY_FAILED" in err_detail:
+        msg = f"SSL certificate verification failed: {url}"
+    elif "wrong version" in err_detail.lower():
+        msg = f"SSL protocol version mismatch: {url}"
+    else:
+        msg = f"SSL error: {err_detail}"
+
+    logger.warning(f"SSL error for {url}: {err_detail}")
+    return msg
 
 
 class BaseRequester:
@@ -231,8 +338,8 @@ class Requester(BaseRequester):
 
                 if e == socket.gaierror:
                     err_msg = "Couldn't resolve DNS"
-                elif "SSLError" in str(e):
-                    err_msg = "Unexpected SSL error"
+                elif isinstance(e, ssl.SSLError) or _is_requests_ssl_error(e):
+                    err_msg = _format_ssl_error(e, url)
                 elif "TooManyRedirects" in str(e):
                     err_msg = f"Too many redirects: {url}"
                 elif "ProxyError" in str(e):
@@ -407,8 +514,8 @@ class AsyncRequester(BaseRequester):
                         err_msg = "Couldn't resolve DNS"
                     else:
                         err_msg = f"Cannot connect to: {urlparse(url).netloc}"
-                elif isinstance(e, SSLError):
-                    err_msg = "Unexpected SSL error"
+                elif isinstance(e, ssl.SSLError):
+                    err_msg = _format_ssl_error(e, url)
                 elif isinstance(e, httpx.TooManyRedirects):
                     err_msg = f"Too many redirects: {url}"
                 elif isinstance(e, httpx.ProxyError):

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Author: Mauro Soria
+
+import ssl
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import requests
+
+from lib.connection.requester import (
+    AsyncRequester,
+    Requester,
+    _find_ssl_error,
+    _format_ssl_error,
+)
+from lib.core.data import options
+from lib.core.exceptions import RequestException
+
+
+def _with_cause(exc: Exception, cause: Exception) -> Exception:
+    exc.__cause__ = cause
+    return exc
+
+
+def _with_context(exc: Exception, context: Exception) -> Exception:
+    exc.__context__ = context
+    return exc
+
+
+class BaseRequesterTestCase(TestCase):
+    def setUp(self) -> None:
+        self.original_options = dict(options)
+        options["proxies"] = []
+        options["headers"] = {}
+        options["data"] = None
+        options["cert_file"] = None
+        options["key_file"] = None
+        options["network_interface"] = None
+        options["random_agents"] = False
+        options["auth"] = None
+        options["auth_type"] = None
+        options["max_retries"] = 0
+        options["max_rate"] = 0
+        options["thread_count"] = 1
+        options["follow_redirects"] = False
+        options["http_method"] = "GET"
+        options["timeout"] = 1
+        options["proxy_auth"] = None
+
+    def tearDown(self) -> None:
+        options.clear()
+        options.update(self.original_options)
+
+
+class TestSSLHelpers(BaseRequesterTestCase):
+    def test_find_ssl_error_direct(self):
+        ssl_exc = ssl.SSLError("wrong version number")
+        self.assertIs(_find_ssl_error(ssl_exc), ssl_exc)
+
+    def test_find_ssl_error_from_cause(self):
+        ssl_exc = ssl.SSLError("wrong version number")
+        wrapped = _with_cause(httpx.ConnectError("handshake failed"), ssl_exc)
+        self.assertIs(_find_ssl_error(wrapped), ssl_exc)
+
+    def test_find_ssl_error_from_context(self):
+        ssl_exc = ssl.SSLError("wrong version number")
+        wrapped = _with_context(RuntimeError("wrapper"), ssl_exc)
+        self.assertIs(_find_ssl_error(wrapped), ssl_exc)
+
+    def test_format_ssl_error_for_certificate_failure(self):
+        cert_exc = ssl.SSLCertVerificationError(
+            1,
+            "certificate verify failed: self signed certificate",
+        )
+        self.assertEqual(
+            _format_ssl_error(cert_exc, "https://example.com/"),
+            "SSL certificate verification failed (self-signed certificate): https://example.com/",
+        )
+
+
+class TestRequesterSSLHandling(BaseRequesterTestCase):
+    def test_sync_requests_ssl_error_uses_specific_message(self):
+        requester = Requester()
+        requester.set_url("https://example.com/")
+        error = requests.exceptions.SSLError("CERTIFICATE_VERIFY_FAILED")
+
+        with patch.object(requester.session, "send", side_effect=error):
+            with self.assertRaises(RequestException) as ctx:
+                requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "SSL certificate verification failed: https://example.com/admin",
+        )
+
+    def test_sync_wrapped_certificate_error_uses_specific_message(self):
+        requester = Requester()
+        requester.set_url("https://example.com/")
+        cert_exc = ssl.SSLCertVerificationError(
+            1,
+            "certificate verify failed: self signed certificate",
+        )
+        error = _with_cause(requests.exceptions.ConnectionError("boom"), cert_exc)
+
+        with patch.object(requester.session, "send", side_effect=error):
+            with self.assertRaises(RequestException) as ctx:
+                requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "SSL certificate verification failed (self-signed certificate): https://example.com/admin",
+        )
+
+
+class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCase):
+    async def test_async_connect_error_with_ssl_cause_uses_ssl_message(self):
+        requester = AsyncRequester()
+        requester.set_url("https://example.com/")
+        error = _with_cause(
+            httpx.ConnectError("connect failed"),
+            ssl.SSLError("wrong version number"),
+        )
+        requester.session.send = AsyncMock(side_effect=error)
+
+        with self.assertRaises(RequestException) as ctx:
+            await requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "SSL protocol version mismatch: https://example.com/admin",
+        )
+
+    async def test_async_connect_error_without_ssl_cause_stays_connect_error(self):
+        requester = AsyncRequester()
+        requester.set_url("https://example.com/")
+        requester.session.send = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+
+        with self.assertRaises(RequestException) as ctx:
+            await requester.request("admin")
+
+        self.assertEqual(str(ctx.exception), "Cannot connect to: example.com")
+
+    async def test_async_connect_error_with_cert_context_uses_cert_message(self):
+        requester = AsyncRequester()
+        requester.set_url("https://example.com/")
+        cert_exc = ssl.SSLCertVerificationError(
+            1,
+            "certificate verify failed: self signed certificate",
+        )
+        error = _with_context(httpx.ConnectError("connect failed"), cert_exc)
+        requester.session.send = AsyncMock(side_effect=error)
+
+        with self.assertRaises(RequestException) as ctx:
+            await requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "SSL certificate verification failed (self-signed certificate): https://example.com/admin",
+        )


### PR DESCRIPTION
Replace string-based SSL error detection with isinstance checks and provide specific actionable error messages. Closes #1444