### PR TITLE
[codex] Remove defusedxml dependency

### DIFF
--- a/lib/core/decorators.py
+++ b/lib/core/decorators.py
@@ -22,22 +22,19 @@ import threading
 
 from functools import wraps
 from time import time
-from typing import Any, Callable, TypeVar
-from typing_extensions import ParamSpec
+from typing import Any, Callable, TypeVar, cast
 
 _lock = threading.Lock()
 _cache: dict[int, tuple[float, Any]] = {}
 _cache_lock = threading.Lock()
 
-# https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
-P = ParamSpec("P")
-T = TypeVar("T")
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-def cached(timeout: int | float = 100) -> Callable[..., Any]:
-    def _cached(func: Callable[P, T]) -> Callable[P, T]:
+def cached(timeout: int | float = 100) -> Callable[[F], F]:
+    def _cached(func: F) -> F:
         @wraps(func)
-        def with_caching(*args: P.args, **kwargs: P.kwargs) -> T:
+        def with_caching(*args: Any, **kwargs: Any) -> Any:
             key = id(func)
             for arg in args:
                 key += id(arg)
@@ -54,14 +51,14 @@ def cached(timeout: int | float = 100) -> Callable[..., Any]:
 
             return result
 
-        return with_caching
+        return cast(F, with_caching)
 
     return _cached
 
 
-def locked(func: Callable[P, T]) -> Callable[P, T]:
-    def with_locking(*args: P.args, **kwargs: P.kwargs) -> T:
+def locked(func: F) -> F:
+    def with_locking(*args: Any, **kwargs: Any) -> Any:
         with _lock:
             return func(*args, **kwargs)
 
-    return with_locking
+    return cast(F, with_locking)

--- a/lib/parse/nmap.py
+++ b/lib/parse/nmap.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import defusedxml.ElementTree as ET
+from lib.utils import safe_xml
 
 
 def parse_nmap(file: str) -> list[str]:
-    root = ET.parse(file).getroot()
+    root = safe_xml.parse_file(file).getroot()
     targets = []
     for host in root.iter("host"):
         hostname = (

--- a/lib/utils/mimetype.py
+++ b/lib/utils/mimetype.py
@@ -18,11 +18,10 @@
 
 import re
 import json
-from typing_extensions import LiteralString
-
-from defusedxml import ElementTree
+from xml.etree import ElementTree
 
 from lib.core.settings import QUERY_STRING_REGEX
+from lib.utils import safe_xml
 
 
 class MimeTypeUtils:
@@ -37,12 +36,10 @@ class MimeTypeUtils:
     @staticmethod
     def is_xml(content):
         try:
-            ElementTree.fromstring(content)
+            safe_xml.fromstring(content)
             return True
-        except ElementTree.ParseError:
+        except (ElementTree.ParseError, safe_xml.UnsafeXML):
             return False
-        except Exception:
-            return True
 
     @staticmethod
     def is_query_string(content):
@@ -52,7 +49,7 @@ class MimeTypeUtils:
         return False
 
 
-def guess_mimetype(content) -> LiteralString:
+def guess_mimetype(content) -> str:
     if MimeTypeUtils.is_json(content):
         return "application/json"
     elif MimeTypeUtils.is_xml(content):

--- a/lib/utils/safe_xml.py
+++ b/lib/utils/safe_xml.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Author: Mauro Soria
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+FORBIDDEN_XML_MARKUP = re.compile(br"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
+
+
+class UnsafeXML(ValueError):
+    pass
+
+
+def reject_unsafe_xml_markup(content: bytes | str) -> bytes | str:
+    payload = content.encode("utf-8", errors="ignore") if isinstance(content, str) else content
+    normalized_payload = payload.replace(b"\x00", b"") if b"\x00" in payload else payload
+    if FORBIDDEN_XML_MARKUP.search(payload) or FORBIDDEN_XML_MARKUP.search(
+        normalized_payload
+    ):
+        raise UnsafeXML("XML DTDs and entity declarations are not supported")
+
+    return content
+
+
+def fromstring(content: bytes | str) -> ElementTree.Element:
+    reject_unsafe_xml_markup(content)
+    return ElementTree.fromstring(content)
+
+
+def parse_file(path: str | Path) -> ElementTree.ElementTree:
+    data = Path(path).read_bytes()
+    reject_unsafe_xml_markup(data)
+    return ElementTree.ElementTree(ElementTree.fromstring(data))

--- a/pyinstaller/build.sh
+++ b/pyinstaller/build.sh
@@ -89,7 +89,6 @@ build() {
         --hidden-import=PySocks \
         --hidden-import=socks \
         --hidden-import=jinja2 \
-        --hidden-import=defusedxml \
         --hidden-import=OpenSSL \
         --hidden-import=ntlm_auth \
         --hidden-import=requests_ntlm \

--- a/pyinstaller/dirsearch.spec
+++ b/pyinstaller/dirsearch.spec
@@ -31,7 +31,6 @@ hidden_imports += [
     'socks',
     'jinja2',
     'markupsafe',
-    'defusedxml',
     'OpenSSL',
     'cryptography',
     'ntlm_auth',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # Last updated: 2026-04-29
 PySocks==1.7.1
 Jinja2==3.1.6
-defusedxml==0.7.1
 pyopenssl==26.1.0
 requests==2.33.1
 requests-ntlm==1.3.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,5 @@
 PySocks==1.7.1
 Jinja2==3.1.6
-defusedxml==0.7.1
 pyopenssl==26.1.0
 requests==2.33.1
 requests-ntlm==1.3.0

--- a/tests/parse/test_nmap.py
+++ b/tests/parse/test_nmap.py
@@ -1,8 +1,22 @@
 from unittest import TestCase
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from lib.parse.nmap import parse_nmap
+from lib.utils.safe_xml import UnsafeXML
 
 
 class TestNmapParser(TestCase):
     def test_parse_nmap(self):
         self.assertEqual(parse_nmap("./tests/static/nmap.xml"), ["scanme.nmap.org:80"], "Nmap parser gives unexpected result")
+
+    def test_parse_nmap_rejects_dtd(self):
+        with TemporaryDirectory() as directory:
+            report = Path(directory, "nmap.xml")
+            report.write_text(
+                '<?xml version="1.0"?><!DOCTYPE nmaprun [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><nmaprun />',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(UnsafeXML):
+                parse_nmap(str(report))

--- a/tests/utils/test_mimetype.py
+++ b/tests/utils/test_mimetype.py
@@ -27,5 +27,22 @@ class TestMimeTypeUtils(TestCase):
     def test_is_xml(self):
         self.assertTrue(MimeTypeUtils.is_xml('<?xml version="1.0" encoding="UTF-8"?><foo>bar</foo>'), "Failed to detect XML mimetype")
 
+    def test_is_xml_rejects_dtd(self):
+        self.assertFalse(
+            MimeTypeUtils.is_xml(
+                '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>'
+            ),
+            "XML mimetype detection should reject entity declarations",
+        )
+
+    def test_is_xml_rejects_utf16_dtd(self):
+        payload = (
+            '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>'
+        ).encode("utf-16")
+        self.assertFalse(
+            MimeTypeUtils.is_xml(payload),
+            "XML mimetype detection should reject encoded entity declarations",
+        )
+
     def test_is_query_string(self):
         self.assertTrue(MimeTypeUtils.is_query_string("foo=1&bar=&foobar=2"), "Failed to detect query string")

--- a/tests/utils/test_safe_xml.py
+++ b/tests/utils/test_safe_xml.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from xml.etree import ElementTree
+
+from lib.utils import safe_xml
+from lib.utils.safe_xml import UnsafeXML
+
+
+class TestSafeXML(TestCase):
+    def test_fromstring_parses_valid_xml_string(self):
+        root = safe_xml.fromstring('<root><child name="foo">bar</child></root>')
+
+        self.assertEqual(root.tag, "root")
+        self.assertEqual(root.find("child").get("name"), "foo")
+        self.assertEqual(root.findtext("child"), "bar")
+
+    def test_fromstring_parses_valid_xml_bytes(self):
+        root = safe_xml.fromstring(b'<?xml version="1.0"?><root><child /></root>')
+
+        self.assertEqual(root.tag, "root")
+        self.assertEqual(root.find("child").tag, "child")
+
+    def test_parse_file_parses_valid_xml(self):
+        with TemporaryDirectory() as directory:
+            xml_file = Path(directory, "report.xml")
+            xml_file.write_text("<root><item>ok</item></root>", encoding="utf-8")
+
+            tree = safe_xml.parse_file(xml_file)
+
+        self.assertEqual(tree.getroot().findtext("item"), "ok")
+
+    def test_invalid_xml_still_raises_parse_error(self):
+        with self.assertRaises(ElementTree.ParseError):
+            safe_xml.fromstring("<root>")
+
+    def test_rejects_doctype_declarations(self):
+        with self.assertRaises(UnsafeXML):
+            safe_xml.fromstring('<?xml version="1.0"?><!DOCTYPE root><root />')
+
+    def test_rejects_entity_declarations(self):
+        with self.assertRaises(UnsafeXML):
+            safe_xml.fromstring(
+                '<?xml version="1.0"?><!ENTITY xxe SYSTEM "file:///etc/passwd"><root />'
+            )
+
+    def test_rejects_case_insensitive_unsafe_markup(self):
+        with self.assertRaises(UnsafeXML):
+            safe_xml.fromstring('<?xml version="1.0"?><!doctype root><root />')
+
+    def test_rejects_utf16_unsafe_markup(self):
+        payload = '<?xml version="1.0"?><!DOCTYPE root><root />'.encode("utf-16")
+
+        with self.assertRaises(UnsafeXML):
+            safe_xml.fromstring(payload)
+
+    def test_rejects_utf32_unsafe_markup(self):
+        payload = '<?xml version="1.0"?><!DOCTYPE root><root />'.encode("utf-32")
+
+        with self.assertRaises(UnsafeXML):
+            safe_xml.fromstring(payload)
+
+    def test_parse_file_rejects_unsafe_xml(self):
+        with TemporaryDirectory() as directory:
+            xml_file = Path(directory, "report.xml")
+            xml_file.write_text(
+                '<?xml version="1.0"?><!DOCTYPE root><root />',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(UnsafeXML):
+                safe_xml.parse_file(xml_file)


### PR DESCRIPTION
## Summary

Removes the `defusedxml` runtime dependency and replaces its two uses with a small stdlib-based XML helper.

## Details

- Adds `lib/utils/safe_xml.py`, which uses `xml.etree.ElementTree` after rejecting DTD and entity declarations.
- Updates Nmap XML parsing and MIME XML detection to use the shared helper.
- Removes `defusedxml` from runtime requirements and PyInstaller hidden imports.
- Removes incidental `typing_extensions` usage from runtime code while touching the affected imports.
- Adds direct safe XML tests plus integration coverage for Nmap parsing and MIME XML detection.

## Impact

The CLI can start without `defusedxml` installed, while still rejecting the XML constructs that mattered for XXE-style input. Packaged installs and PyInstaller builds no longer include the unused dependency.

## Validation

- `python3 -m unittest tests.utils.test_safe_xml`
- `python3 -m unittest tests.utils.test_safe_xml tests.parse.test_nmap tests.utils.test_mimetype tests.parse.test_config tests.parse.test_headers tests.core.test_importable_api`
- `python3 -m py_compile lib/utils/safe_xml.py lib/parse/nmap.py lib/utils/mimetype.py lib/core/decorators.py tests/utils/test_safe_xml.py`
- `python3 dirsearch.py -h`
- `python3 dirsearch.py --wordlist-status -w tests/static/wordlist.txt -q`

A broader requester/scanner unittest run was not available in this local environment because `httpx` is not installed.