### PR TITLE
[codex] Test encoding edge cases across request stacks

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -118,6 +118,47 @@ def _find_ssl_error(exc: Exception) -> ssl.SSLError | None:
     return None
 
 
+def _is_timeout_error(exc: Exception) -> bool:
+    for current in _iter_exception_chain(exc):
+        if isinstance(
+            current,
+            (
+                requests.exceptions.Timeout,
+                urllib3.exceptions.TimeoutError,
+                socket.timeout,
+            ),
+        ):
+            return True
+
+        message = str(current).lower()
+        if "timed out" in message or "timeout" in message:
+            return True
+
+    return False
+
+
+def _is_response_read_error(exc: Exception) -> bool:
+    for current in _iter_exception_chain(exc):
+        if isinstance(
+            current,
+            (
+                requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ContentDecodingError,
+                requests.exceptions.StreamConsumedError,
+                requests.exceptions.UnrewindableBodyError,
+                httpx.DecodingError,
+                httpx.ReadError,
+                httpx.RemoteProtocolError,
+            ),
+        ):
+            return True
+
+        if re.search(READ_RESPONSE_ERROR_REGEX, type(current).__name__):
+            return True
+
+    return False
+
+
 def _is_ssl_error(exc: Exception) -> bool:
     return isinstance(exc, requests.exceptions.SSLError) or _find_ssl_error(exc) is not None
 
@@ -359,7 +400,7 @@ class Requester(BaseRequester):
                     err_msg = "Couldn't resolve DNS"
                 elif _is_ssl_error(e):
                     err_msg = _format_ssl_error(e, url)
-                elif "TooManyRedirects" in str(e):
+                elif isinstance(e, requests.exceptions.TooManyRedirects):
                     err_msg = f"Too many redirects: {url}"
                 elif "ProxyError" in str(e):
                     if proxy:
@@ -373,14 +414,13 @@ class Requester(BaseRequester):
                     err_msg = f"Invalid URL: {url}"
                 elif "InvalidProxyURL" in str(e):
                     err_msg = f"Invalid proxy URL: {proxy}"
+                elif _is_timeout_error(e):
+                    err_msg = f"Request timeout: {url}"
+                elif _is_response_read_error(e):
+                    err_msg = f"Failed to read response body: {url}"
                 elif "ConnectionError" in str(e):
                     err_msg = f"Cannot connect to: {urlparse(url).netloc}"
-                elif re.search(READ_RESPONSE_ERROR_REGEX, str(e)):
-                    err_msg = f"Failed to read response body: {url}"
-                elif "Timeout" in str(e) or e in (
-                    http.client.IncompleteRead,
-                    socket.timeout,
-                ):
+                elif isinstance(e, http.client.IncompleteRead):
                     err_msg = f"Request timeout: {url}"
                 else:
                     err_msg = f"There was a problem in the request to: {url}"
@@ -547,7 +587,7 @@ class AsyncRequester(BaseRequester):
                     err_msg = f"Invalid URL: {url}"
                 elif isinstance(e, httpx.TimeoutException):
                     err_msg = f"Request timeout: {url}"
-                elif isinstance(e, httpx.ReadError) or isinstance(e, httpx.DecodingError):  # not sure
+                elif _is_response_read_error(e):
                     err_msg = f"Failed to read response body: {url}"
                 else:
                     err_msg = f"There was a problem in the request to: {url}"

--- a/lib/connection/response.py
+++ b/lib/connection/response.py
@@ -58,7 +58,13 @@ class BaseResponse:
     @property
     def length(self) -> int:
         if cl := self.headers.get("content-length"):
-            return int(cl)
+            try:
+                length = int(cl)
+            except (TypeError, ValueError):
+                return len(self.body)
+
+            if length >= 0:
+                return length
 
         return len(self.body)
 
@@ -95,10 +101,10 @@ class Response(BaseResponse):
         if not is_binary(self.body):
             try:
                 self.content = self.body.decode(
-                    response.encoding or DEFAULT_ENCODING, errors="ignore"
+                    response.encoding or DEFAULT_ENCODING, errors="replace"
                 )
             except LookupError:
-                self.content = self.body.decode(DEFAULT_ENCODING, errors="ignore")
+                self.content = self.body.decode(DEFAULT_ENCODING, errors="replace")
 
 
 class AsyncResponse(BaseResponse):
@@ -116,10 +122,10 @@ class AsyncResponse(BaseResponse):
         if not is_binary(self.body):
             try:
                 self.content = self.body.decode(
-                    response.encoding or DEFAULT_ENCODING, errors="ignore"
+                    response.encoding or DEFAULT_ENCODING, errors="replace"
                 )
             except LookupError:
-                self.content = self.body.decode(DEFAULT_ENCODING, errors="ignore")
+                self.content = self.body.decode(DEFAULT_ENCODING, errors="replace")
 
         return self
 
@@ -147,4 +153,4 @@ class NativeResponse(BaseResponse):
 
         self.body = bytes(body)
         if not is_binary(self.body):
-            self.content = self.body.decode(DEFAULT_ENCODING, errors="ignore")
+            self.content = self.body.decode(DEFAULT_ENCODING, errors="replace")

--- a/lib/view/terminal.py
+++ b/lib/view/terminal.py
@@ -18,11 +18,29 @@
 
 import sys
 import shutil
+import unicodedata
 
 from lib.core.data import options
 from lib.core.decorators import locked
 from lib.core.settings import IS_WINDOWS
 from lib.view.colors import set_color, clean_color, disable_color
+
+
+MAX_DISPLAY_TEXT_LENGTH = 240
+
+
+def safe_display_text(value, max_length=MAX_DISPLAY_TEXT_LENGTH):
+    text = str(value)
+    text = "".join(
+        character
+        for character in text
+        if not unicodedata.category(character).startswith("C")
+    )
+
+    if len(text) > max_length:
+        return text[:max_length - 3] + "..."
+
+    return text
 
 if IS_WINDOWS:
     from colorama.win32 import (
@@ -86,7 +104,7 @@ class CLI:
             self.buffer += "\n"
 
     def status_report(self, response, full_url):
-        target = response.url if full_url else "/" + response.full_path
+        target = safe_display_text(response.url if full_url else "/" + response.full_path)
         # Get time from datetime string
         time = response.datetime.split()[1]
         message = f"[{time}] {response.status} - {response.size.rjust(6, ' ')} - {target}"
@@ -110,10 +128,10 @@ class CLI:
             message = set_color(message, fore="magenta")
 
         if response.redirect:
-            message += f"  ->  {response.redirect}"
+            message += f"  ->  {safe_display_text(response.redirect)}"
 
         for redirect in response.history:
-            message += f"\n-->  {redirect}"
+            message += f"\n-->  {safe_display_text(redirect)}"
 
         self.new_line(message)
 
@@ -141,7 +159,9 @@ class CLI:
 
     def new_directories(self, directories):
         message = set_color(
-            f"Added to the queue: {', '.join(directories)}", fore="yellow", style="dim"
+            f"Added to the queue: {safe_display_text(', '.join(directories))}",
+            fore="yellow",
+            style="dim",
         )
         self.new_line(message)
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -4,7 +4,9 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::fs;
-use std::time::Instant;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
 
 #[pyclass]
 struct NativeHttpResult {
@@ -154,6 +156,7 @@ fn scan_http(
             .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 
         runtime.block_on(async move {
+            let raw_headers = headers.clone();
             let mut header_map = HeaderMap::new();
             for (name, value) in headers {
                 let name = HeaderName::from_bytes(name.as_bytes())
@@ -182,6 +185,7 @@ fn scan_http(
             for path in paths {
                 let client = client.clone();
                 let base_url = base_url.clone();
+                let raw_headers = raw_headers.clone();
                 let semaphore = semaphore.clone();
                 tasks.push(tokio::spawn(async move {
                     let _permit = match semaphore.acquire_owned().await {
@@ -200,6 +204,36 @@ fn scan_http(
                     };
                     let url = format!("{base_url}{path}");
                     let start = Instant::now();
+
+                    if should_use_raw_http(&base_url, &path) {
+                        let raw_base_url = base_url.clone();
+                        let raw_path = path.clone();
+                        let raw_result = tokio::task::spawn_blocking(move || {
+                            raw_http_get(
+                                &raw_base_url,
+                                raw_path,
+                                &raw_headers,
+                                timeout_secs,
+                                max_body_size,
+                                start,
+                            )
+                        })
+                        .await;
+
+                        return match raw_result {
+                            Ok(result) => result,
+                            Err(error) => NativeHttpResult {
+                                path,
+                                status: 0,
+                                length: 0,
+                                elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+                                error: Some(error.to_string()),
+                                headers: Vec::new(),
+                                body: Vec::new(),
+                            },
+                        };
+                    }
+
                     let mut response = None;
                     let mut last_error = None;
                     for _ in 0..=max_retries {
@@ -275,6 +309,140 @@ fn scan_http(
             Ok(results)
         })
     })
+}
+
+fn should_use_raw_http(base_url: &str, path: &str) -> bool {
+    base_url.starts_with("http://")
+        && path
+            .split(['/', '?', '#'])
+            .any(|segment| segment == "." || segment == "..")
+}
+
+fn raw_http_get(
+    base_url: &str,
+    path: String,
+    headers: &[(String, String)],
+    timeout_secs: f64,
+    max_body_size: usize,
+    start: Instant,
+) -> NativeHttpResult {
+    match raw_http_get_inner(base_url, &path, headers, timeout_secs, max_body_size) {
+        Ok((status, headers, body, length)) => NativeHttpResult {
+            path,
+            status,
+            length,
+            elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+            error: None,
+            headers,
+            body,
+        },
+        Err(error) => NativeHttpResult {
+            path,
+            status: 0,
+            length: 0,
+            elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+            error: Some(error),
+            headers: Vec::new(),
+            body: Vec::new(),
+        },
+    }
+}
+
+fn raw_http_get_inner(
+    base_url: &str,
+    path: &str,
+    headers: &[(String, String)],
+    timeout_secs: f64,
+    max_body_size: usize,
+) -> Result<(u16, Vec<(String, String)>, Vec<u8>, usize), String> {
+    let url = reqwest::Url::parse(base_url).map_err(|error| error.to_string())?;
+    if url.scheme() != "http" {
+        return Err("Raw HTTP path preservation only supports http:// URLs".to_string());
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "URL is missing a host".to_string())?
+        .to_string();
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| "URL is missing a port".to_string())?;
+    let host_header = match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.clone(),
+    };
+    let timeout = Duration::from_secs_f64(timeout_secs);
+    let mut stream =
+        TcpStream::connect((host.as_str(), port)).map_err(|error| error.to_string())?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .map_err(|error| error.to_string())?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|error| error.to_string())?;
+
+    let target = raw_request_target(url.path(), path);
+    let mut request =
+        format!("GET {target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n");
+    for (name, value) in headers {
+        request.push_str(name);
+        request.push_str(": ");
+        request.push_str(value);
+        request.push_str("\r\n");
+    }
+    request.push_str("\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| error.to_string())?;
+
+    let mut raw_response = Vec::new();
+    stream
+        .read_to_end(&mut raw_response)
+        .map_err(|error| error.to_string())?;
+    parse_raw_http_response(raw_response, max_body_size)
+}
+
+fn raw_request_target(base_path: &str, path: &str) -> String {
+    let mut target = if base_path == "/" {
+        "/".to_string()
+    } else {
+        base_path.trim_end_matches('/').to_string() + "/"
+    };
+    target.push_str(path.trim_start_matches('/'));
+    target
+}
+
+fn parse_raw_http_response(
+    raw_response: Vec<u8>,
+    max_body_size: usize,
+) -> Result<(u16, Vec<(String, String)>, Vec<u8>, usize), String> {
+    let header_end = raw_response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| "HTTP response did not contain a header terminator".to_string())?;
+    let header_bytes = &raw_response[..header_end];
+    let body_start = header_end + 4;
+    let body_bytes = &raw_response[body_start..];
+    let header_text = String::from_utf8_lossy(header_bytes);
+    let mut lines = header_text.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| "HTTP response did not contain a status line".to_string())?;
+    let status = status_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| "HTTP response status line did not contain a status code".to_string())?
+        .parse::<u16>()
+        .map_err(|error| error.to_string())?;
+    let headers = lines
+        .filter_map(|line| {
+            line.split_once(':')
+                .map(|(name, value)| (name.to_string(), value.trim_start().to_string()))
+        })
+        .collect::<Vec<_>>();
+    let length = body_bytes.len();
+    let body = body_bytes[..length.min(max_body_size)].to_vec();
+    Ok((status, headers, body, length))
 }
 
 fn read_lines(path: &str) -> PyResult<Vec<String>> {

--- a/testing.py
+++ b/testing.py
@@ -22,6 +22,19 @@ import unittest
 
 from tests.connection.test_dns import TestDNS  # noqa: F401
 from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
+from tests.connection.test_requester import (  # noqa: F401
+    TestAsyncRequesterElapsed,
+    TestAsyncRequesterSSLHandling,
+    TestAsyncRequesterPathPreservation,
+    TestNativeRequesterPathPreservation,
+    TestRequesterElapsed,
+    TestRequesterErrorClassification,
+    TestRequesterPathPreservation,
+    TestRequesterSSLHandling,
+    TestSSLHelpers,
+)
+from tests.connection.test_response import TestResponse  # noqa: F401
+from tests.connection.test_response import TestAsyncResponse  # noqa: F401
 from tests.controller.test_session_store import TestSessionStore  # noqa: F401
 from tests.core.test_dictionary_templates import TestDictionaryTemplates  # noqa: F401
 from tests.core.test_importable_api import TestImportableAPI  # noqa: F401
@@ -38,6 +51,7 @@ from tests.utils.test_diff import TestDiff  # noqa: F401
 from tests.utils.test_mimetype import TestMimeTypeUtils  # noqa: F401
 from tests.utils.test_random import TestRandom  # noqa: F401
 from tests.utils.test_schemedet import TestSchemedet  # noqa: F401
+from tests.utils.test_terminal import TestTerminalOutput  # noqa: F401
 from tests.test_optional_db_dependencies import TestOptionalDBDependencies  # noqa: F401
 
 

--- a/tests/connection/test_native_response.py
+++ b/tests/connection/test_native_response.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase
 
 from lib.connection.response import NativeResponse
@@ -29,3 +31,52 @@ class TestNativeResponse(TestCase):
         )
 
         self.assertEqual(response.redirect, "/login")
+
+    def test_native_cjk_length_uses_network_bytes(self):
+        body = "测试".encode()
+        response = NativeResponse(
+            "https://example.com/admin/%E6%B5%8B%E8%AF%95",
+            200,
+            [("Content-Length", str(len(body)))],
+            body,
+        )
+
+        self.assertEqual(response.content, "测试")
+        self.assertEqual(len(response.content), 2)
+        self.assertEqual(response.length, 6)
+
+    def test_native_case_expansion_length_uses_network_bytes(self):
+        body = "/TEST-STRASSE".encode()
+        response = NativeResponse(
+            "https://example.com/test-stra%C3%9Fe",
+            200,
+            [("Content-Length", str(len(body)))],
+            body,
+        )
+
+        self.assertEqual(response.content, "/TEST-STRASSE")
+        self.assertEqual(response.length, len(body))
+
+    def test_native_invalid_utf8_uses_replacement_decoding(self):
+        response = NativeResponse(
+            "https://example.com/admin",
+            200,
+            [("Content-Type", "text/html; charset=utf-8")],
+            b"start\x96end",
+        )
+
+        self.assertEqual(response.body, b"start\x96end")
+        self.assertEqual(response.content, "start�end")
+        self.assertEqual(response.length, len(response.body))
+
+    def test_native_utf16_bom_artifact_body_does_not_raise_decode_error(self):
+        response = NativeResponse(
+            "https://example.com/%FF%FEadmin",
+            200,
+            [],
+            b"\xff\xfeadmin",
+        )
+
+        self.assertEqual(response.body, b"\xff\xfeadmin")
+        self.assertEqual(response.content, "��admin")
+        self.assertEqual(response.length, len(response.body))

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -16,7 +16,11 @@
 #
 #  Author: Mauro Soria
 
+import http.server
+import re
 import ssl
+import socketserver
+import threading
 from types import SimpleNamespace
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, patch
@@ -25,6 +29,7 @@ import httpx
 import requests
 
 from lib.connection import requester as requester_module
+from lib.connection.native import NativeHTTPBackend
 from lib.connection.requester import (
     AsyncRequester,
     Requester,
@@ -33,6 +38,69 @@ from lib.connection.requester import (
 )
 from lib.core.data import options
 from lib.core.exceptions import RequestException
+
+
+REQUEST_TARGET_CASES = (
+    ("shift-jis-overlap", "admin/%83%5c/..", b"/admin/%83%5C/.."),
+    ("utf16-le-bom", "%FF%FEadmin", b"/%FF%FEadmin"),
+    ("utf16-be-bom", "%FE%FFadmin", b"/%FE%FFadmin"),
+    ("rtl-override", "admin/\u202eexe.txt/", b"/admin/%E2%80%AEexe.txt/"),
+    ("german-eszett", "test-straße", b"/test-stra%C3%9Fe"),
+    ("turkish-i-exact-case", "ADMIN", b"/ADMIN"),
+    ("cjk", "admin/测试", b"/admin/%E6%B5%8B%E8%AF%95"),
+)
+
+
+class RequestTargetTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+class RequestTargetHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.server.targets.append(self.raw_requestline.split(b" ")[1])
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("content-type", "text/plain")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+class RequestTargetServer:
+    def __enter__(self):
+        self.server = RequestTargetTCPServer(("127.0.0.1", 0), RequestTargetHandler)
+        self.server.targets = []
+        self.thread = threading.Thread(
+            target=lambda: self.server.serve_forever(poll_interval=0.05),
+            daemon=True,
+        )
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    @property
+    def url(self):
+        host, port = self.server.server_address
+        return f"http://{host}:{port}/"
+
+    @property
+    def targets(self):
+        return self.server.targets
+
+
+def normalize_percent_hex(target: bytes) -> bytes:
+    return re.sub(
+        rb"%[0-9a-fA-F]{2}",
+        lambda match: match.group(0).upper(),
+        target,
+    )
 
 
 def _with_cause(exc: Exception, cause: Exception) -> Exception:
@@ -187,6 +255,53 @@ class TestRequesterSSLHandling(BaseRequesterTestCase):
         )
 
 
+class TestRequesterErrorClassification(BaseRequesterTestCase):
+    def test_sync_too_many_redirects_uses_specific_message(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+
+        with patch.object(
+            requester.session,
+            "send",
+            side_effect=requests.exceptions.TooManyRedirects("exceeded"),
+        ):
+            with self.assertRaises(RequestException) as ctx:
+                requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Too many redirects: http://example.com/admin",
+        )
+
+    def test_sync_wrapped_read_timeout_uses_timeout_message(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+        error = requests.exceptions.ConnectionError("Read timed out.")
+
+        with patch.object(requester.session, "send", side_effect=error):
+            with self.assertRaises(RequestException) as ctx:
+                requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Request timeout: http://example.com/admin",
+        )
+
+    def test_sync_chunked_encoding_error_uses_read_error_message(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+        error = requests.exceptions.ChunkedEncodingError("incomplete body")
+
+        with patch.object(requester.session, "send", side_effect=error):
+            with self.assertRaises(RequestException) as ctx:
+                requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Failed to read response body: http://example.com/admin",
+        )
+
+
 class TestRequesterElapsed(TestCase):
     def test_request_elapsed_includes_stream_read(self):
         requester = object.__new__(Requester)
@@ -202,6 +317,21 @@ class TestRequesterElapsed(TestCase):
                 response = requester.request("admin")
 
         self.assertEqual(response.elapsed, 0.25, "Sync elapsed should measure the full streamed request lifecycle")
+
+
+class TestRequesterPathPreservation(BaseRequesterTestCase):
+    def test_sync_requester_preserves_encoded_edge_case_targets(self):
+        with RequestTargetServer() as server:
+            requester = Requester()
+            requester.set_url(server.url)
+
+            for _, path, _ in REQUEST_TARGET_CASES:
+                requester.request(path)
+
+            self.assertEqual(
+                [normalize_percent_hex(target) for target in server.targets],
+                [expected for _, _, expected in REQUEST_TARGET_CASES],
+            )
 
 
 class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCase):
@@ -252,6 +382,21 @@ class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCa
             "SSL certificate verification failed (self-signed certificate): https://example.com/admin",
         )
 
+    async def test_async_remote_protocol_error_uses_read_error_message(self):
+        requester = AsyncRequester()
+        requester.set_url("http://example.com/")
+        requester.session.send = AsyncMock(
+            side_effect=httpx.RemoteProtocolError("bad Content-Length")
+        )
+
+        with self.assertRaises(RequestException) as ctx:
+            await requester.request("admin")
+
+        self.assertEqual(
+            str(ctx.exception),
+            "Failed to read response body: http://example.com/admin",
+        )
+
 
 class TestAsyncRequesterElapsed(IsolatedAsyncioTestCase):
     async def test_request_elapsed_waits_for_stream_close(self):
@@ -269,3 +414,42 @@ class TestAsyncRequesterElapsed(IsolatedAsyncioTestCase):
 
         self.assertEqual(response.elapsed, 0.5, "Async elapsed should measure the full streamed request lifecycle")
         self.assertTrue(requester.session.response.closed, "Streamed async responses should be closed before elapsed is used")
+
+
+class TestAsyncRequesterPathPreservation(BaseRequesterTestCase, IsolatedAsyncioTestCase):
+    async def test_async_requester_preserves_encoded_edge_case_targets(self):
+        with RequestTargetServer() as server:
+            requester = AsyncRequester()
+            requester.set_url(server.url)
+            try:
+                for _, path, _ in REQUEST_TARGET_CASES:
+                    await requester.request(path)
+            finally:
+                await requester.session.aclose()
+
+            self.assertEqual(
+                [normalize_percent_hex(target) for target in server.targets],
+                [expected for _, _, expected in REQUEST_TARGET_CASES],
+            )
+
+
+class TestNativeRequesterPathPreservation(BaseRequesterTestCase):
+    def test_native_requester_preserves_encoded_edge_case_targets(self):
+        try:
+            backend = NativeHTTPBackend()
+        except RequestException as error:
+            self.skipTest(str(error))
+
+        with RequestTargetServer() as server:
+            results = list(
+                backend.scan(
+                    server.url,
+                    [path for _, path, _ in REQUEST_TARGET_CASES],
+                )
+            )
+
+            self.assertEqual([error for _, _, error in results], [None] * len(results))
+            self.assertEqual(
+                [normalize_percent_hex(target) for target in server.targets],
+                [expected for _, _, expected in REQUEST_TARGET_CASES],
+            )

--- a/tests/connection/test_response.py
+++ b/tests/connection/test_response.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+from unittest import IsolatedAsyncioTestCase, TestCase
+
+from lib.connection.response import AsyncResponse, Response
+
+
+class DummyResponse:
+    status_code = 200
+    history = []
+
+    def __init__(self, headers=None, body=b"body", encoding="utf-8"):
+        self.headers = headers or {}
+        self._body = body
+        self.encoding = encoding
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        yield self._body
+
+
+class DummyAsyncResponse:
+    status_code = 200
+    history = []
+
+    def __init__(self, headers=None, body=b"body", encoding="utf-8"):
+        self.headers = headers or {}
+        self._body = body
+        self.encoding = encoding
+
+    async def aiter_bytes(self, chunk_size):
+        del chunk_size
+        yield self._body
+
+
+class TestResponse(TestCase):
+    def test_length_falls_back_to_body_for_invalid_content_length(self):
+        response = Response(
+            "http://example.com/admin",
+            DummyResponse(headers={"content-length": "not-a-number"}, body=b"abc"),
+        )
+
+        self.assertEqual(response.length, 3)
+
+    def test_length_falls_back_to_body_for_negative_content_length(self):
+        response = Response(
+            "http://example.com/admin",
+            DummyResponse(headers={"content-length": "-10"}, body=b"abcd"),
+        )
+
+        self.assertEqual(response.length, 4)
+
+    def test_length_keeps_valid_content_length(self):
+        response = Response(
+            "http://example.com/admin",
+            DummyResponse(headers={"content-length": "10"}, body=b"abcd"),
+        )
+
+        self.assertEqual(response.length, 10)
+
+    def test_cjk_length_uses_network_bytes(self):
+        body = "测试".encode()
+        response = Response(
+            "http://example.com/admin/%E6%B5%8B%E8%AF%95",
+            DummyResponse(headers={"content-length": str(len(body))}, body=body),
+        )
+
+        self.assertEqual(response.content, "测试")
+        self.assertEqual(len(response.content), 2)
+        self.assertEqual(response.length, 6)
+
+    def test_case_expansion_length_uses_network_bytes(self):
+        body = "/TEST-STRASSE".encode()
+        response = Response(
+            "http://example.com/test-stra%C3%9Fe",
+            DummyResponse(headers={"content-length": str(len(body))}, body=body),
+        )
+
+        self.assertEqual(response.content, "/TEST-STRASSE")
+        self.assertEqual(response.length, len(body))
+
+    def test_invalid_utf8_uses_replacement_decoding(self):
+        response = Response(
+            "http://example.com/admin",
+            DummyResponse(
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"start\x96end",
+                encoding="utf-8",
+            ),
+        )
+
+        self.assertEqual(response.body, b"start\x96end")
+        self.assertEqual(response.content, "start�end")
+        self.assertEqual(response.length, len(response.body))
+
+    def test_utf16_bom_artifact_body_does_not_raise_decode_error(self):
+        response = Response(
+            "http://example.com/%FF%FEadmin",
+            DummyResponse(body=b"\xff\xfeadmin", encoding="utf-8"),
+        )
+
+        self.assertEqual(response.body, b"\xff\xfeadmin")
+        self.assertEqual(response.content, "��admin")
+        self.assertEqual(response.length, len(response.body))
+
+
+class TestAsyncResponse(IsolatedAsyncioTestCase):
+    async def test_cjk_length_uses_network_bytes(self):
+        body = "测试".encode()
+        response = await AsyncResponse.create(
+            "http://example.com/admin/%E6%B5%8B%E8%AF%95",
+            DummyAsyncResponse(headers={"content-length": str(len(body))}, body=body),
+        )
+
+        self.assertEqual(response.content, "测试")
+        self.assertEqual(len(response.content), 2)
+        self.assertEqual(response.length, 6)
+
+    async def test_case_expansion_length_uses_network_bytes(self):
+        body = "/TEST-STRASSE".encode()
+        response = await AsyncResponse.create(
+            "http://example.com/test-stra%C3%9Fe",
+            DummyAsyncResponse(headers={"content-length": str(len(body))}, body=body),
+        )
+
+        self.assertEqual(response.content, "/TEST-STRASSE")
+        self.assertEqual(response.length, len(body))
+
+    async def test_invalid_utf8_uses_replacement_decoding(self):
+        response = await AsyncResponse.create(
+            "http://example.com/admin",
+            DummyAsyncResponse(
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"start\x96end",
+                encoding="utf-8",
+            ),
+        )
+
+        self.assertEqual(response.body, b"start\x96end")
+        self.assertEqual(response.content, "start�end")
+        self.assertEqual(response.length, len(response.body))
+
+    async def test_utf16_bom_artifact_body_does_not_raise_decode_error(self):
+        response = await AsyncResponse.create(
+            "http://example.com/%FF%FEadmin",
+            DummyAsyncResponse(body=b"\xff\xfeadmin", encoding="utf-8"),
+        )
+
+        self.assertEqual(response.body, b"\xff\xfeadmin")
+        self.assertEqual(response.content, "��admin")
+        self.assertEqual(response.length, len(response.body))

--- a/tests/utils/test_crawl.py
+++ b/tests/utils/test_crawl.py
@@ -31,11 +31,28 @@ class TestCrawl(TestCase):
         html_doc = f'<a href="{DUMMY_URL}foo">link</a><script src="/bar.js"><img src="/bar.png">'
         self.assertEqual(Crawler.html_crawl(DUMMY_URL, DUMMY_URL, html_doc), {"foo", "bar.js"})
 
+    def test_html_crawl_handles_rtl_override(self):
+        html_doc = '<a href="/admin/\u202eexe.txt/">link</a>'
+
+        self.assertEqual(
+            Crawler.html_crawl(DUMMY_URL, DUMMY_URL, html_doc),
+            {"admin/\u202eexe.txt/"},
+        )
+
+    def test_html_crawl_handles_large_zwj_emoji_sequence(self):
+        family = "👨‍👩‍👧‍👦" * 500
+        html_doc = f'<a href="/admin/{family}/ok">link</a>'
+
+        self.assertEqual(
+            Crawler.html_crawl(DUMMY_URL, DUMMY_URL, html_doc),
+            {f"admin/{family}/ok"},
+        )
+
     def test_robots_crawl(self):
         robots_txt = """
 User-agent: Googlebot
 Disallow: /path1
 
 User-agent: *
-Allow: /path2"""
+        Allow: /path2"""
         self.assertEqual(Crawler.robots_crawl(DUMMY_URL, DUMMY_URL, robots_txt), {"path1", "path2"})

--- a/tests/utils/test_terminal.py
+++ b/tests/utils/test_terminal.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.core.data import options
+from lib.view.terminal import CLI, safe_display_text
+
+
+class TestTerminalOutput(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        options["color"] = True
+        options["verbose"] = False
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_safe_display_text_strips_controls_and_truncates(self):
+        value = "admin/\u202eexe.txt/" + ("👨‍👩‍👧‍👦" * 500)
+        rendered = safe_display_text(value)
+
+        self.assertNotIn("\u202e", rendered)
+        self.assertNotIn("\u200d", rendered)
+        self.assertLessEqual(len(rendered), 240)
+
+    def test_status_report_sanitizes_path_and_redirect(self):
+        family = "👨‍👩‍👧‍👦" * 500
+        response = SimpleNamespace(
+            datetime="2026-05-29 12:00:00",
+            status=200,
+            size="1B",
+            full_path=f"admin/\u202eexe.txt/{family}",
+            url=f"http://example.com/admin/\u202eexe.txt/{family}",
+            redirect=f"/next/\u202eexe.txt/{family}",
+            history=[f"http://example.com/old/\u202eexe.txt/{family}"],
+            elapsed=0,
+            type="text/plain",
+        )
+        cli = CLI()
+
+        with patch.object(cli, "new_line") as new_line:
+            cli.status_report(response, False)
+
+        message = new_line.call_args.args[0]
+        self.assertNotIn("\u202e", message)
+        self.assertNotIn("\u200d", message)
+        self.assertLess(len(message), 900)


### PR DESCRIPTION
## Summary

Adds regression coverage for network encoding edge cases across the sync Python, async Python, and native Rust request stacks.

## Changes

- Preserve and classify malformed response/read errors more precisely in Python requesters.
- Decode text bodies with replacement instead of dropping invalid bytes silently.
- Add display-only sanitization/truncation for bidi controls, ZWJ-heavy emoji paths, redirects, and queued directories.
- Preserve raw HTTP request targets in the native backend when dot segments would otherwise be normalized by the URL layer.
- Add tests for CJK byte length, German case expansion, UTF-16 BOM artifacts, lying charset bytes, Shift-JIS backslash overlap, RTL controls, and large ZWJ emoji sequences.

## Validation

- `VIRTUAL_ENV=/home/mauro/dirsearch/.venv PATH=/home/mauro/dirsearch/.venv/bin:$PATH /home/mauro/dirsearch/.venv/bin/python -m maturin develop --manifest-path native/Cargo.toml`
- `/home/mauro/dirsearch/.venv/bin/python -m unittest tests.connection.test_response tests.connection.test_native_response tests.connection.test_requester tests.utils.test_crawl tests.utils.test_terminal`
- `/home/mauro/dirsearch/.venv/bin/python -m unittest discover tests`
- `/home/mauro/dirsearch/.venv/bin/python testing.py`
- `cargo test --manifest-path native/Cargo.toml`
- `git diff --check`

Note: `test_schemedet` still emits existing ResourceWarnings for unclosed SSL sockets; the suite passes.