### PR TITLE
Use stealth words for wildcard calibration

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -389,15 +389,8 @@ class AsyncFuzzer(BaseFuzzer):
 
     async def setup_scanners(self) -> None:
         # Default scanners (wildcard testers)
-        self.scanners["default"].update(
-            {
-                "index": await AsyncScanner.create(
-                    self._requester, path=self._base_path
-                ),
-                "random": await AsyncScanner.create(
-                    self._requester, path=self._base_path + WILDCARD_TEST_POINT_MARKER
-                ),
-            }
+        self.scanners["default"]["random"] = await AsyncScanner.create(
+            self._requester, path=self._base_path + WILDCARD_TEST_POINT_MARKER
         )
 
         if options["exclude_response"]:

--- a/lib/core/scanner.py
+++ b/lib/core/scanner.py
@@ -29,13 +29,12 @@ from lib.core.data import options
 from lib.core.logger import logger
 from lib.core.settings import (
     REFLECTED_PATH_MARKER,
-    TEST_PATH_LENGTH,
     WILDCARD_TEST_POINT_MARKER,
 )
 from lib.parse.url import clean_path
 from lib.utils.common import replace_path
 from lib.utils.diff import DynamicContentParser, generate_matching_regex
-from lib.utils.random import rand_string
+from lib.utils.random import rand_stealth_word
 
 
 class BaseScanner:
@@ -146,7 +145,7 @@ class Scanner(BaseScanner):
 
         first_path = self.path.replace(
             WILDCARD_TEST_POINT_MARKER,
-            rand_string(TEST_PATH_LENGTH),
+            rand_stealth_word(),
         )
         first_response = self.requester.request(first_path)
         self.response = first_response
@@ -161,7 +160,7 @@ class Scanner(BaseScanner):
 
         second_path = self.path.replace(
             WILDCARD_TEST_POINT_MARKER,
-            rand_string(TEST_PATH_LENGTH, omit=first_path),
+            rand_stealth_word(omit=first_path),
         )
         second_response = self.requester.request(second_path)
         time.sleep(options["delay"])
@@ -216,7 +215,7 @@ class AsyncScanner(BaseScanner):
 
         first_path = self.path.replace(
             WILDCARD_TEST_POINT_MARKER,
-            rand_string(TEST_PATH_LENGTH),
+            rand_stealth_word(),
         )
         first_response = await self.requester.request(first_path)
         self.response = first_response
@@ -232,7 +231,7 @@ class AsyncScanner(BaseScanner):
 
         second_path = self.path.replace(
             WILDCARD_TEST_POINT_MARKER,
-            rand_string(TEST_PATH_LENGTH, omit=first_path),
+            rand_stealth_word(omit=first_path),
         )
         second_response = await self.requester.request(second_path)
         await asyncio.sleep(options["delay"])

--- a/lib/utils/random.py
+++ b/lib/utils/random.py
@@ -16,8 +16,183 @@
 #
 #  Author: Mauro Soria
 
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+import math
 import random
 import string
+
+
+class StealthWordGenerator:
+    separators = ("-", "_")
+    common_directories = frozenset(("admin", "backup", "api", "test"))
+    word_bank = (
+        "cyberfluxion", "luminastra", "aerolithic", "peltorian",
+        "chronometral", "syncorance", "neosphereic", "cryptogenoid",
+        "polysystive", "megastatary", "hyperlogism", "omnitechant",
+        "exovalable", "tectomatence", "quantgraphify", "dynasecize",
+        "vibrmorphate", "plasmnetous", "xenotechity", "mechnomium",
+        "cybermetrical", "lumiphonate", "aerologize", "peltogenable",
+        "chronosystive", "syntechant", "neonomable", "cryptovalence",
+        "polycorant", "megasphereic", "hypernetoid", "omnimatary",
+        "exosecize", "tectgraphate", "quantmorphify", "dynastatous",
+        "vibrmetrity", "plasmfluxium", "xenolithism", "mechnasian",
+        "cybercorance", "luminetence", "aerosystant", "peltotechity",
+        "chrononomium", "synvalism", "neocoroid", "cryptosphereary",
+        "polymathate", "meganetize", "hypersecify", "omnigraphive",
+        "exostatable", "tectmorphance", "quantfluxence", "dynalithant",
+        "vibrmetrent", "plasmphonate", "xenologize", "mechnomify",
+        "cybervalive", "lumicorable", "aerosystance", "peltotechent",
+        "chrononomant", "synvality", "neocorium", "cryptosphereism",
+        "polymathoid", "meganetary", "hypersecate", "omnigraphize",
+        "exostatify", "tectmorphive", "quantfluxable", "dynalithance",
+        "vibrmetrence", "plasmphonant", "xenologent", "mechnomtra",
+        "cyberfluxian", "lumilithic", "aerometral", "peltophonous",
+        "chronographity", "synstatium", "neologism", "polysphereary",
+        "megatronate", "hypermatize", "omnisecify", "exocorive",
+        "tectnetable", "quantvalance", "dynanomence", "vibrtechant",
+        "plasmsysent", "xenonasal", "mechnomous", "cybermetrity",
+        "lumiphonary", "aerographize", "peltostative", "chronologable",
+        "synmorphance", "neogenent", "cryptosphereant", "polytronent",
+        "megamatous", "hypersystic", "omnisecian", "exocoral",
+        "tectnetous", "quantvality", "dynanomium", "vibrtechism",
+        "plasmsysoid", "xenonastive", "mechnomable", "cyberfluxance",
+        "lumilithical", "aerometrous", "peltophonium", "chronography",
+        "synstatize", "neologify", "cryptogenive", "polyspherable",
+        "megatronance", "hypermatence", "omnisecant", "exocorent",
+        "tectnetant", "quantvalent", "dynanomity", "vibrtechium",
+        "plasmsysism", "xenonasoid", "mechnomary", "cyberfluxate",
+        "lumilithize", "aerometrify", "peltophonic", "chronographal",
+        "synstatous", "neologity", "cryptogenium", "polysphereism",
+        "megatronoid", "hypermatary", "omnisecate", "exocortra",
+        "tectnetion", "quantvalian", "dynanomic", "vibrtechal",
+        "plasmsysous", "xenonasity", "cyberfluxize", "lumilithify",
+        "aerometrive", "peltophonable", "chronographance",
+        "synstatence", "neologant", "cryptogenent", "polyspherentra",
+        "megatronion", "hypermatian", "omnisecic",
+    )
+
+    _onsets = (
+        "l", "m", "n", "p", "r", "s", "t", "v", "c",
+        "cl", "cr", "pl", "pr", "st", "tr", "vr",
+    )
+    _nuclei = ("a", "e", "i", "o", "u", "ae", "ai", "ia", "io", "ou")
+    _codas = ("l", "m", "n", "r", "s", "t", "v", "c", "nt", "rn", "st")
+    _suffixes = (
+        "al", "an", "ar", "en", "ic", "in", "or", "um",
+        "ian", "ion", "ium", "ora", "ory",
+    )
+
+    def __init__(
+        self,
+        seed: int | str | bytes | bytearray | None = None,
+        rng: random.Random | None = None,
+    ) -> None:
+        if seed is not None and rng is not None:
+            raise ValueError("seed and rng are mutually exclusive")
+
+        self._rng = rng or random.Random(seed)
+        self._seen = set()
+        self._short_word_bank = tuple(word for word in self.word_bank if len(word) <= 10)
+
+    def generate(self, omit: str | Iterable[str] | None = None) -> str:
+        omitted = self._normalize_omit(omit)
+
+        for _ in range(1000):
+            word_count = self._rng.randint(2, 3)
+            separator = self._rng.choice(self.separators)
+            candidate = self._candidate_from_bank(word_count, separator)
+
+            if not self._is_valid(candidate, omitted):
+                continue
+
+            self._seen.add(candidate)
+            return candidate
+
+        raise RuntimeError("Unable to generate a stealth calibration word")
+
+    def _candidate_from_bank(self, word_count: int, separator: str) -> str:
+        word_bank = self._short_word_bank if word_count == 3 else self.word_bank
+        try:
+            words = self._rng.sample(word_bank, word_count)
+        except ValueError:
+            words = [
+                self._pseudo_word(*(7, 13) if word_count == 2 else (5, 9))
+                for _ in range(word_count)
+            ]
+
+        return separator.join(words)
+
+    def _pseudo_word(self, min_length: int, max_length: int) -> str:
+        for _ in range(100):
+            pieces = [
+                self._rng.choice(self._onsets),
+                self._rng.choice(self._nuclei),
+                self._rng.choice(self._codas),
+            ]
+
+            if self._rng.random() < 0.75:
+                pieces.extend(
+                    (
+                        self._rng.choice(self._onsets),
+                        self._rng.choice(self._nuclei),
+                    )
+                )
+
+            pieces.append(self._rng.choice(self._suffixes))
+            word = "".join(pieces)
+            if min_length <= len(word) <= max_length and word not in self.common_directories:
+                return word
+
+        return "loravian"
+
+    def _is_valid(self, candidate: str, omitted: set[str]) -> bool:
+        if candidate in self._seen or candidate in omitted:
+            return False
+        if not 15 <= len(candidate) <= 30:
+            return False
+        if candidate[0] in self.separators or candidate[-1] in self.separators:
+            return False
+        if "--" in candidate or "__" in candidate or "-_" in candidate or "_-" in candidate:
+            return False
+        if any(
+            not ("a" <= character <= "z" or character in self.separators)
+            for character in candidate
+        ):
+            return False
+        if self._shannon_entropy(candidate) >= 3.95:
+            return False
+
+        words = candidate.replace("_", "-").split("-")
+        return (
+            len(words) in (2, 3)
+            and all(word and word not in self.common_directories for word in words)
+        )
+
+    @staticmethod
+    def _normalize_omit(omit: str | Iterable[str] | None) -> set[str]:
+        if omit is None:
+            return set()
+        if isinstance(omit, str):
+            return {omit}
+        return set(omit)
+
+    @staticmethod
+    def _shannon_entropy(value: str) -> float:
+        length = len(value)
+        return -sum(
+            (count / length) * math.log2(count / length)
+            for count in Counter(value).values()
+        )
+
+
+_stealth_word_generator = StealthWordGenerator()
+
+
+def rand_stealth_word(omit: str | Iterable[str] | None = None) -> str:
+    return _stealth_word_generator.generate(omit=omit)
 
 
 def rand_string(n, omit=None):

--- a/testing.py
+++ b/testing.py
@@ -23,6 +23,7 @@ import unittest
 from tests.connection.test_dns import TestDNS  # noqa: F401
 from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
 from tests.controller.test_session_store import TestSessionStore  # noqa: F401
+from tests.core.test_async_fuzzer import TestAsyncFuzzer  # noqa: F401
 from tests.core.test_dictionary_templates import TestDictionaryTemplates  # noqa: F401
 from tests.core.test_importable_api import TestImportableAPI  # noqa: F401
 from tests.core.test_native_fuzzer import TestNativeFuzzer  # noqa: F401

--- a/tests/core/test_async_fuzzer.py
+++ b/tests/core/test_async_fuzzer.py
@@ -1,0 +1,90 @@
+from unittest import IsolatedAsyncioTestCase
+
+from lib.connection.response import NativeResponse
+from lib.core.data import blacklists, options
+from lib.core.fuzzer import AsyncFuzzer
+
+
+class DummyDictionary:
+    def __init__(self, paths):
+        self.paths = paths
+        self.index = 0
+
+    def __next__(self):
+        if self.index >= len(self.paths):
+            raise StopIteration
+        self.index += 1
+        return self.paths[self.index - 1]
+
+    def __len__(self):
+        return len(self.paths)
+
+
+class DummyAsyncRequester:
+    async def request(self, path):
+        if path in ("", "home.html"):
+            return NativeResponse(
+                f"https://example.com/{path}",
+                200,
+                [("Content-Type", "text/plain")],
+                b"same homepage body",
+            )
+
+        return NativeResponse(
+            f"https://example.com/{path}",
+            404,
+            [("Content-Type", "text/plain")],
+            b"not found",
+        )
+
+
+class TestAsyncFuzzer(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        self.original_blacklists = dict(blacklists)
+        options.update(
+            {
+                "thread_count": 1,
+                "delay": 0,
+                "exclude_response": None,
+                "exclude_status_codes": set(),
+                "include_status_codes": {200},
+                "exclude_sizes": set(),
+                "minimum_response_size": 0,
+                "maximum_response_size": 0,
+                "exclude_texts": [],
+                "exclude_regex": None,
+                "exclude_redirect": None,
+                "filter_threshold": 0,
+                "prefixes": (),
+                "suffixes": (),
+                "extensions": (),
+            }
+        )
+        blacklists.clear()
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+        blacklists.clear()
+        blacklists.update(self.original_blacklists)
+
+    async def test_does_not_filter_response_matching_index_page(self):
+        dictionary = DummyDictionary(["home.html"])
+        matches = []
+        misses = []
+        errors = []
+        fuzzer = AsyncFuzzer(
+            DummyAsyncRequester(),
+            dictionary,
+            match_callbacks=(matches.append,),
+            not_found_callbacks=(misses.append,),
+            error_callbacks=(errors.append,),
+        )
+
+        await fuzzer.start()
+
+        self.assertEqual(dictionary.index, 1)
+        self.assertEqual([response.full_path for response in matches], ["home.html"])
+        self.assertEqual(misses, [])
+        self.assertEqual(errors, [])

--- a/tests/utils/test_random.py
+++ b/tests/utils/test_random.py
@@ -16,9 +16,12 @@
 #
 #  Author: Mauro Soria
 
+from collections import Counter
+import math
+import re
 from unittest import TestCase
 
-from lib.utils.random import rand_string
+from lib.utils.random import StealthWordGenerator, rand_string
 
 
 class TestRandom(TestCase):
@@ -27,3 +30,59 @@ class TestRandom(TestCase):
         self.assertEqual(len(rand_string(9)), 9, "Incorrect random string length")
         for x, y in zip(rand_string(5, omit=test_omit), test_omit):
             self.assertNotEqual(x, y, "Random string's characters are not distinct from omit")
+
+    def test_stealth_words_have_low_entropy(self):
+        generator = StealthWordGenerator(seed=1)
+        for _ in range(1000):
+            self.assertLess(self.shannon_entropy(generator.generate()), 4.0)
+
+    def test_stealth_words_do_not_match_common_directories(self):
+        generator = StealthWordGenerator(seed=2)
+        common_directories = {"admin", "backup", "api", "test"}
+
+        for _ in range(10000):
+            value = generator.generate()
+            self.assertNotIn(value, common_directories)
+            self.assertTrue(
+                common_directories.isdisjoint(re.split("[-_]", value))
+            )
+
+    def test_stealth_words_respect_url_format_constraints(self):
+        generator = StealthWordGenerator(seed=3)
+        word_counts = set()
+
+        for _ in range(1000):
+            value = generator.generate()
+            word_counts.add(len(re.split("[-_]", value)))
+            self.assertRegex(value, r"^[a-z]+([-_][a-z]+){1,2}$")
+            self.assertGreaterEqual(len(value), 15)
+            self.assertLessEqual(len(value), 30)
+            self.assertNotIn("--", value)
+            self.assertNotIn("__", value)
+            self.assertNotIn("-_", value)
+            self.assertNotIn("_-", value)
+
+        self.assertEqual(word_counts, {2, 3})
+
+    def test_stealth_words_are_reproducible_with_seed(self):
+        first = StealthWordGenerator(seed=4)
+        second = StealthWordGenerator(seed=4)
+
+        self.assertEqual(
+            [first.generate() for _ in range(50)],
+            [second.generate() for _ in range(50)],
+        )
+
+    def test_stealth_words_honor_omit(self):
+        generator = StealthWordGenerator(seed=5)
+        first = generator.generate()
+
+        self.assertNotEqual(generator.generate(omit=first), first)
+
+    @staticmethod
+    def shannon_entropy(value: str) -> float:
+        length = len(value)
+        return -sum(
+            (count / length) * math.log2(count / length)
+            for count in Counter(value).values()
+        )


### PR DESCRIPTION
## Summary

Replaces high-entropy wildcard calibration tokens with deterministic pseudo-word chains and fixes an async wildcard parity issue.

## Changes

- Adds `StealthWordGenerator` with a precomputed pseudo-word bank, deterministic seed support, URL-safe separators, length constraints, and low-entropy filtering.
- Uses stealth words for sync and async wildcard calibration paths instead of short random alphanumeric strings.
- Keeps `rand_string()` for existing callers.
- Fixes `AsyncFuzzer` so it no longer adds an extra index-page wildcard scanner that sync/native do not use.
- Adds regression tests for entropy, format constraints, deterministic output, common-directory collision avoidance, omitted values, and the async index-page false negative.

## Validation

- `/home/mauro/dirsearch/.venv/bin/python -m unittest tests.utils.test_random tests.core.test_scanner tests.core.test_async_fuzzer`
- `/home/mauro/dirsearch/.venv/bin/python -m unittest discover tests`
- `/home/mauro/dirsearch/.venv/bin/python testing.py`
- `cargo test --manifest-path native/Cargo.toml`
- `git diff --check`

Note: `test_schemedet` still emits existing ResourceWarnings for unclosed SSL sockets; the suite passes.