### PR TITLE
Remove PyPI installation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ cd dirsearch
 python3 dirsearch.py -u https://example.com -e php,html,js
 ```
 
-You can also install it from PyPI:
-
-```sh
-pip3 install dirsearch
-dirsearch -u https://example.com -e php,html,js
-```
-
 Pre-built PyInstaller binaries and portable folder archives are available on the [Releases page](https://github.com/maurosoria/dirsearch/releases).
 
 ## Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Supported Platforms
 
-dirsearch runs on Python 3.11-3.14 and is distributed as source, PyPI package, Docker image, PyInstaller binary, or portable folder.
+dirsearch runs on Python 3.11-3.14 and is distributed as source, Docker image, PyInstaller binary, or portable folder.
 
 | Platform | Architecture | PyInstaller | Portable folder |
 |----------|--------------|-------------|-----------------|
@@ -25,7 +25,6 @@ python3 dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q
 ## Other Install Methods
 
 - ZIP archive: [Download the master branch](https://github.com/maurosoria/dirsearch/archive/master.zip).
-- PyPI: `pip3 install dirsearch` or `pip install dirsearch`.
 - Docker: `docker pull ghcr.io/maurosoria/dirsearch:v0.5.0-rc1-async`.
 - Kali Linux: `sudo apt-get install dirsearch` (deprecated).
 


### PR DESCRIPTION
## Summary
- Remove the PyPI install block from the README quick start.
- Stop listing PyPI as a supported distribution method in the installation guide.

## Why
The project is not currently distributed through PyPI, so the docs should not direct users to `pip install dirsearch`.

## Follow-up
- #1559 documents the GitHub-backed pip install command.

## Validation
- Searched for remaining PyPI install references in README and docs.
- Confirmed remaining `pypi` matches are only `.pypirc` entries in bundled wordlists.