### PR TITLE
Document native source builds and harden XML parsing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@ Requirements
 
 - [ ] Add your name to `CONTRIBUTORS.md`
 - [ ] If this is a new feature, then please add some additional information about it to `CHANGELOG.md`
+- [ ] PR text, comments, and committed files do not disclose private infrastructure details such as internal hostnames, machine names, SSH targets, IPs, regions, private paths, runner names, or operational topology

--- a/.github/workflows/pyinstaller-linux.yml
+++ b/.github/workflows/pyinstaller-linux.yml
@@ -69,10 +69,7 @@ jobs:
         run: |
           rustup default stable
           python -m pip install --only-binary=:all: maturin
-          mkdir -p dist/native-wheels
-          python -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-          python -m pip install dist/native-wheels/*.whl
-          python -c "import dirsearch_native"
+          python scripts/build_native.py --out dist/native-wheels
 
       - name: Build Linux binary
         run: python -m PyInstaller --clean pyinstaller/dirsearch.spec

--- a/.github/workflows/pyinstaller-macos-intel.yml
+++ b/.github/workflows/pyinstaller-macos-intel.yml
@@ -56,10 +56,7 @@ jobs:
         run: |
           rustup default stable
           python -m pip install --only-binary=:all: maturin
-          mkdir -p dist/native-wheels
-          python -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-          python -m pip install dist/native-wheels/*.whl
-          python -c "import dirsearch_native"
+          python scripts/build_native.py --out dist/native-wheels
 
       - name: Build macOS Intel binary
         run: python -m PyInstaller --clean pyinstaller/dirsearch.spec

--- a/.github/workflows/pyinstaller-macos-silicon.yml
+++ b/.github/workflows/pyinstaller-macos-silicon.yml
@@ -56,10 +56,7 @@ jobs:
         run: |
           rustup default stable
           python -m pip install --only-binary=:all: maturin
-          mkdir -p dist/native-wheels
-          python -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-          python -m pip install dist/native-wheels/*.whl
-          python -c "import dirsearch_native"
+          python scripts/build_native.py --out dist/native-wheels
 
       - name: Build macOS Silicon binary
         run: python -m PyInstaller --clean pyinstaller/dirsearch.spec

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -60,10 +60,7 @@ jobs:
         run: |
           rustup default stable
           python -m pip install --only-binary=:all: maturin
-          mkdir -p dist/native-wheels
-          python -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-          python -m pip install dist/native-wheels/*.whl
-          python -c "import dirsearch_native"
+          python scripts/build_native.py --out dist/native-wheels
 
       - name: Build Windows binary
         run: python -m PyInstaller --clean pyinstaller/dirsearch.spec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,4 +58,8 @@ Recent history favors short imperative commits such as `Fix async SSL classifica
 Do not use automation-specific prefixes such as `codex/` in branch names or `[codex]` in PR titles. Use plain descriptive branch names and PR titles that fit the project history.
 
 ## Security & Configuration Tips
-Do not commit secrets, session artifacts, local virtualenv files, or cloud benchmark artifacts. DigitalOcean tokens must stay in environment variables such as `DIGITALOCEAN_ACCESS_TOKEN`; never write them into scripts, result files, or docs. If you change dependencies, keep `requirements.txt`, `requirements/runtime.txt`, and packaging metadata aligned. If you add runtime files or imports, verify both `pyinstaller/dirsearch.spec` and GitHub Actions workflows still bundle them.
+Do not commit secrets, session artifacts, local virtualenv files, or cloud benchmark artifacts. DigitalOcean tokens must stay in environment variables such as `DIGITALOCEAN_ACCESS_TOKEN`; never write them into scripts, result files, or docs.
+
+Never include private infrastructure details in commits, docs, PR bodies, PR comments, issues, or release notes. This includes internal hostnames, machine names, SSH targets, provider account details, regions, IP addresses, private paths, runner names, or operational topology. When validation used private infrastructure, describe only the generic platform and toolchain, such as "validated on Windows amd64 with Python 3.13 and MSVC Rust."
+
+If you change dependencies, keep `requirements.txt`, `requirements/runtime.txt`, and packaging metadata aligned. If you add runtime files or imports, verify both `pyinstaller/dirsearch.spec` and GitHub Actions workflows still bundle them.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ RUN python -m pip install --upgrade pip setuptools wheel \
         && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
         && . "$HOME/.cargo/env" \
         && python -m pip install --only-binary=:all: maturin \
-        && python -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels \
-        && python -m pip install dist/native-wheels/*.whl \
-        && python -c "import dirsearch_native" \
+        && python scripts/build_native.py --out dist/native-wheels \
         && python -m pip uninstall -y maturin \
         && rm -rf dist/native-wheels native/target "$HOME/.cargo" "$HOME/.rustup" \
         && apt-get purge -y --auto-remove build-essential curl \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ cd dirsearch
 python3 dirsearch.py -u https://example.com -e php,html,js
 ```
 
+You can also install the latest Python stack directly from GitHub with pip:
+
+```sh
+pip3 install git+https://github.com/maurosoria/dirsearch.git
+dirsearch -u https://example.com -e php,html,js
+```
+
+The Rust native backend is opt-in for source installs; see [Installation](docs/installation.md) for the native build steps.
+
 Pre-built PyInstaller binaries and portable folder archives are available on the [Releases page](https://github.com/maurosoria/dirsearch/releases).
 
 ## Documentation

--- a/docs/building.md
+++ b/docs/building.md
@@ -33,6 +33,8 @@ Requirements:
 - PyInstaller 6.20.0.
 - Rust and maturin when building `native-rust`.
 
+Native Rust builds use `scripts/build_native.py` to build one wheel, install that exact wheel path, and verify `import dirsearch_native`. This avoids shell-specific wildcard behavior on Windows and keeps Docker, PyInstaller, and portable builds on the same path. The native wheel is packaged with `requires-python >=3.14` and PyO3 `cp313-abi3`, the highest stable ABI feature available in PyO3 0.24 for Python 3.14 release builds.
+
 Build the current platform:
 
 ```sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Supported Platforms
 
-dirsearch runs on Python 3.11-3.14 and is distributed as source, Docker image, PyInstaller binary, or portable folder.
+dirsearch runs on Python 3.11-3.14 and is distributed as source, installable from GitHub with pip, Docker image, PyInstaller binary, or portable folder. Release-equivalent native builds use Python 3.14.
 
 | Platform | Architecture | PyInstaller | Portable folder |
 |----------|--------------|-------------|-----------------|
@@ -25,8 +25,162 @@ python3 dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q
 ## Other Install Methods
 
 - ZIP archive: [Download the master branch](https://github.com/maurosoria/dirsearch/archive/master.zip).
+- GitHub with pip, Python stack: `pip3 install git+https://github.com/maurosoria/dirsearch.git`.
 - Docker: `docker pull ghcr.io/maurosoria/dirsearch:v0.5.0-rc1-async`.
 - Kali Linux: `sudo apt-get install dirsearch` (deprecated).
+
+## Choose an Install Path
+
+- Use release artifacts when you do not want to compile anything. Single-file PyInstaller binaries and portable archives with bundled dependencies are available for Windows x64, Linux x64, Linux ARM64, macOS Intel, and macOS Apple Silicon.
+- Use `pip install git+https://github.com/maurosoria/dirsearch.git` when you want the Python stack from the current GitHub source. This does not compile the Rust native backend.
+- Use the native source build steps when you want `--request-backend native` and `--wordlist-backend native` from a source checkout.
+- Use the `native-rust` release artifact when you want the Rust backend without installing a Rust toolchain.
+
+## Platform Setup
+
+### Ubuntu and Debian, amd64 or arm64
+
+Install prerequisites for the Python stack:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y git ca-certificates python3 python3-venv python3-pip
+python3 -m venv ~/.venvs/dirsearch
+. ~/.venvs/dirsearch/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch --version
+```
+
+Add these packages before building the native Rust backend:
+
+```sh
+sudo apt-get install -y build-essential curl python3-dev
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+. "$HOME/.cargo/env"
+```
+
+Use Linux `x64` release assets on amd64 and Linux `arm64` release assets on ARM64/aarch64.
+
+### Red Hat and Fedora, amd64 or arm64
+
+Install prerequisites for the Python stack:
+
+```sh
+sudo dnf install -y git ca-certificates python3 python3-pip
+python3 -m venv ~/.venvs/dirsearch
+. ~/.venvs/dirsearch/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch --version
+```
+
+Add these packages before building the native Rust backend:
+
+```sh
+sudo dnf install -y gcc gcc-c++ make curl python3-devel
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+. "$HOME/.cargo/env"
+```
+
+If your distribution splits Python by minor version, install the matching `python3.x-devel` package for the interpreter used by the virtual environment. Use Linux `x64` release assets on amd64 and Linux `arm64` release assets on ARM64/aarch64.
+
+### macOS 26, Apple Silicon or Intel, with Homebrew
+
+Install prerequisites for the Python stack:
+
+```sh
+brew install python git
+python3 -m venv ~/.venvs/dirsearch
+. ~/.venvs/dirsearch/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch --version
+```
+
+Add these tools before building the native Rust backend:
+
+```sh
+xcode-select --install
+brew install rust
+```
+
+Use macOS `silicon` release assets on Apple Silicon and macOS `intel` release assets on Intel.
+
+### macOS 26, Apple Silicon or Intel, without Homebrew
+
+Install Apple's command line tools, Python 3.11 or newer from python.org, and Rust from rustup:
+
+```sh
+xcode-select --install
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+. "$HOME/.cargo/env"
+python3 -m venv ~/.venvs/dirsearch
+. ~/.venvs/dirsearch/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch --version
+```
+
+Use the same virtual environment for the native Rust build steps below.
+
+### Windows 10 and 11, x64
+
+For no-compile installs, download the Windows x64 PyInstaller `.exe` or portable `.zip` from the Releases page. The portable archive bundles dependencies and can be preferable when antivirus software flags PyInstaller bootloaders.
+
+For the Python stack, install Python 3.11 or newer for x64 and Git for Windows, then run PowerShell:
+
+```powershell
+py -3 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch --version
+```
+
+Before building the native Rust backend, install Microsoft C++ Build Tools with the Desktop development with C++ workload and a Windows SDK, then install Rust through rustup. If `winget` is unavailable, download and run `rustup-init.exe` from rustup.rs.
+
+```powershell
+winget install --id Rustlang.Rustup -e
+rustup default stable
+python -m pip install maturin
+```
+
+Open a new PowerShell session if `rustup` is not found immediately after installation.
+
+## Native Rust from Source
+
+The GitHub pip command installs the Python stack only. To build the Rust native request and wordlist backends from source, use Python 3.14, install Rust and `maturin`, then build the native wheel from a clone:
+
+```sh
+git clone https://github.com/maurosoria/dirsearch.git --depth 1
+cd dirsearch
+python3.14 -m pip install .
+python3.14 -m pip install maturin
+python3.14 scripts/build_native.py --out dist/native-wheels
+dirsearch -u https://example.com -w tests/static/wordlist.txt --request-backend native --wordlist-backend native -q
+```
+
+On Windows PowerShell, use backslashes for local paths:
+
+```powershell
+git clone https://github.com/maurosoria/dirsearch.git --depth 1
+cd dirsearch
+py -3.14 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install .
+python -m pip install maturin
+python scripts\build_native.py --out dist\native-wheels
+dirsearch -u https://example.com -w tests\static\wordlist.txt --request-backend native --wordlist-backend native -q
+```
+
+Without the native wheel, source installs keep the Python request backend and automatic Python wordlist fallback defaults.
+
+Optional MySQL and PostgreSQL report dependencies are separate from the scanner runtime. Install them only when needed:
+
+```sh
+python -m pip install "dirsearch[db] @ git+https://github.com/maurosoria/dirsearch.git"
+```
 
 ## Release Artifacts
 

--- a/lib/utils/mimetype.py
+++ b/lib/utils/mimetype.py
@@ -18,7 +18,6 @@
 
 import re
 import json
-from xml.etree import ElementTree
 
 from lib.core.settings import QUERY_STRING_REGEX
 from lib.utils import safe_xml
@@ -38,7 +37,7 @@ class MimeTypeUtils:
         try:
             safe_xml.fromstring(content)
             return True
-        except (ElementTree.ParseError, safe_xml.UnsafeXML):
+        except (safe_xml.ParseError, safe_xml.UnsafeXML):
             return False
 
     @staticmethod

--- a/lib/utils/safe_xml.py
+++ b/lib/utils/safe_xml.py
@@ -20,7 +20,12 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from xml.etree import ElementTree
+
+from defusedxml import ElementTree
+from defusedxml.common import DefusedXmlException
+
+
+ParseError = ElementTree.ParseError
 
 
 FORBIDDEN_XML_MARKUP = re.compile(br"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
@@ -41,12 +46,18 @@ def reject_unsafe_xml_markup(content: bytes | str) -> bytes | str:
     return content
 
 
-def fromstring(content: bytes | str) -> ElementTree.Element:
+def fromstring(content: bytes | str):
     reject_unsafe_xml_markup(content)
-    return ElementTree.fromstring(content)
+    try:
+        return ElementTree.fromstring(content)
+    except DefusedXmlException as error:
+        raise UnsafeXML("Unsafe XML markup is not supported") from error
 
 
-def parse_file(path: str | Path) -> ElementTree.ElementTree:
+def parse_file(path: str | Path):
     data = Path(path).read_bytes()
     reject_unsafe_xml_markup(data)
-    return ElementTree.ElementTree(ElementTree.fromstring(data))
+    try:
+        return ElementTree.parse(path)
+    except DefusedXmlException as error:
+        raise UnsafeXML("Unsafe XML markup is not supported") from error

--- a/lib/utils/schemedet.py
+++ b/lib/utils/schemedet.py
@@ -32,7 +32,8 @@ def detect_scheme(host, port):
 
     try:
         conn.connect((host, port))
-        conn.close()
         return "https"
     except Exception:
         return "http"
+    finally:
+        conn.close()

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 indexmap = "2.7"
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.24", features = ["extension-module", "abi3-py313"] }
 rayon = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
 regex = "1.11"

--- a/native/README.md
+++ b/native/README.md
@@ -21,6 +21,10 @@ python3.14 -m pip install maturin
 python3.14 scripts/build_native.py --out dist/native-wheels
 ```
 
+The helper installs the exact built wheel and verifies `import dirsearch_native`.
+Release-equivalent native wheels target Python 3.14 and PyO3's `cp313-abi3`
+stable ABI.
+
 The benchmark summary for this backend is in
 [`docs/native-backend-benchmarks.md`](../docs/native-backend-benchmarks.md).
 

--- a/native/README.md
+++ b/native/README.md
@@ -17,9 +17,8 @@ and not-found callbacks authoritative. Native regex matching uses Rust's
 Build locally with a Rust toolchain and maturin:
 
 ```sh
-python3 -m pip install maturin
-python3 -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-python3 -m pip install dist/native-wheels/*.whl
+python3.14 -m pip install maturin
+python3.14 scripts/build_native.py --out dist/native-wheels
 ```
 
 The benchmark summary for this backend is in

--- a/native/pyproject.toml
+++ b/native/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "dirsearch-native"
+version = "0.1.0"
+description = "Rust native backend for dirsearch"
+requires-python = ">=3.14"
+license = "GPL-2.0-only"
+classifiers = [
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Rust",
+]
+
+[tool.maturin]
+manifest-path = "Cargo.toml"

--- a/pyinstaller/README.md
+++ b/pyinstaller/README.md
@@ -55,9 +55,8 @@ Install Rust and maturin before building:
 
 ```bash
 rustup default stable
-python3 -m pip install --only-binary=:all: maturin
-python3 -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-python3 -m pip install dist/native-wheels/*.whl
+python3.14 -m pip install --only-binary=:all: maturin
+python3.14 scripts/build_native.py --out dist/native-wheels
 ```
 
 ### macOS Code Signing

--- a/pyinstaller/build.sh
+++ b/pyinstaller/build.sh
@@ -54,10 +54,7 @@ build_native() {
         rustup default stable
     fi
     "$PYTHON_CMD" -m pip install --only-binary=:all: maturin
-    mkdir -p dist/native-wheels
-    "$PYTHON_CMD" -m maturin build --release --manifest-path native/Cargo.toml --out dist/native-wheels
-    "$PYTHON_CMD" -m pip install dist/native-wheels/*.whl
-    "$PYTHON_CMD" -c "import dirsearch_native"
+    "$PYTHON_CMD" scripts/build_native.py --out dist/native-wheels
 }
 
 build_stack() {

--- a/pyinstaller/dirsearch.spec
+++ b/pyinstaller/dirsearch.spec
@@ -43,6 +43,7 @@ hidden_imports += [
     'mysql.connector',
     'psycopg',
     'defusedcsv',
+    'defusedxml',
     'requests_toolbelt',
     'httpx_ntlm',
     'h11',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Pinned versions to prevent supply chain attacks
-# Last updated: 2026-04-29
+# Last updated: 2026-05-30
 PySocks==1.7.1
 Jinja2==3.1.6
 pyopenssl==26.1.0
@@ -9,6 +9,7 @@ colorama==0.4.6
 ntlm-auth==1.5.0
 beautifulsoup4==4.14.3
 defusedcsv==3.0.0
+defusedxml==0.7.1
 requests-toolbelt==1.0.0
 setuptools==82.0.1
 httpx==0.28.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -7,6 +7,7 @@ colorama==0.4.6
 ntlm-auth==1.5.0
 beautifulsoup4==4.14.3
 defusedcsv==3.0.0
+defusedxml==0.7.1
 requests-toolbelt==1.0.0
 httpx==0.28.1
 httpx-ntlm==1.4.0

--- a/scripts/build_native.py
+++ b/scripts/build_native.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(command: list[str], cwd: Path | None = None) -> None:
+    print("+ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def clean_wheel_dir(wheel_dir: Path) -> None:
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    for wheel in wheel_dir.glob("*.whl"):
+        wheel.unlink()
+
+
+def resolve_python(value: str) -> Path:
+    candidate = Path(value)
+    if candidate.exists() or len(candidate.parts) > 1:
+        return candidate.resolve()
+
+    resolved = shutil.which(value)
+    if resolved:
+        return Path(resolved).resolve()
+
+    return candidate
+
+
+def build_native(args: argparse.Namespace) -> Path:
+    python = resolve_python(args.python)
+    manifest = Path(args.manifest_path).resolve()
+    wheel_dir = Path(args.out).resolve()
+    clean_wheel_dir(wheel_dir)
+
+    command = [
+        str(python),
+        "-m",
+        "maturin",
+        "build",
+        "--release",
+        "--locked",
+        "--manifest-path",
+        str(manifest),
+        "--out",
+        str(wheel_dir),
+    ]
+    if args.target_dir:
+        command.extend(["--target-dir", str(Path(args.target_dir).resolve())])
+
+    run(command, cwd=PROJECT_ROOT)
+
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        names = ", ".join(wheel.name for wheel in wheels) or "none"
+        raise RuntimeError(f"Expected exactly one native wheel in {wheel_dir}; found {names}")
+
+    return wheels[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build and install dirsearch_native")
+    parser.add_argument("--python", default=sys.executable, help="Python executable to install into")
+    parser.add_argument(
+        "--manifest-path",
+        default=PROJECT_ROOT / "native" / "Cargo.toml",
+        type=Path,
+        help="Path to native/Cargo.toml",
+    )
+    parser.add_argument(
+        "--out",
+        default=PROJECT_ROOT / "dist" / "native-wheels",
+        type=Path,
+        help="Directory for the built native wheel",
+    )
+    parser.add_argument(
+        "--target-dir",
+        type=Path,
+        help="Optional Cargo target directory, useful for read-only source trees",
+    )
+    parser.add_argument(
+        "--keep-target",
+        action="store_true",
+        help="Keep the Cargo target directory after a successful build",
+    )
+    args = parser.parse_args()
+
+    wheel = build_native(args)
+    python = resolve_python(args.python)
+    run([str(python), "-m", "pip", "install", str(wheel)])
+    run([str(python), "-c", "import dirsearch_native"])
+
+    if not args.keep_target:
+        target_dir = Path(args.target_dir).resolve() if args.target_dir else PROJECT_ROOT / "native" / "target"
+        shutil.rmtree(target_dir, ignore_errors=True)
+
+    print(f"Native wheel installed: {wheel}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_native.py
+++ b/scripts/build_native.py
@@ -94,6 +94,7 @@ def main() -> None:
 
     wheel = build_native(args)
     python = resolve_python(args.python)
+    # Install the exact wheel path so Windows PowerShell never passes "*.whl" literally.
     run([str(python), "-m", "pip", "install", str(wheel)])
     run([str(python), "-c", "import dirsearch_native"])
 

--- a/scripts/build_portable.py
+++ b/scripts/build_portable.py
@@ -187,24 +187,16 @@ def install_dependencies(python: Path, app: Path, stack: str) -> None:
     if stack == "native-rust":
         run([str(python), "-m", "pip", "install", "--only-binary=:all:", "maturin"])
         wheel_dir = app.parent / "native-wheels"
-        wheel_dir.mkdir(exist_ok=True)
         run(
             [
                 str(python),
-                "-m",
-                "maturin",
-                "build",
-                "--release",
-                "--manifest-path",
-                str(app / "native" / "Cargo.toml"),
+                str(app / "scripts" / "build_native.py"),
+                "--python",
+                str(python),
                 "--out",
                 str(wheel_dir),
             ]
         )
-        wheels = sorted(wheel_dir.glob("*.whl"))
-        if not wheels:
-            raise RuntimeError("maturin did not produce a native wheel")
-        run([str(python), "-m", "pip", "install", str(wheels[-1])])
         run([str(python), "-m", "pip", "uninstall", "-y", "maturin"])
         shutil.rmtree(wheel_dir, ignore_errors=True)
         shutil.rmtree(app / "native" / "target", ignore_errors=True)

--- a/tests/utils/test_schemedet.py
+++ b/tests/utils/test_schemedet.py
@@ -24,5 +24,6 @@ from lib.utils.schemedet import detect_scheme
 class TestSchemedet(TestCase):
     def test_detect_scheme(self):
         self.assertEqual(detect_scheme(DUMMY_DOMAIN, 443), "https", "Incorrect scheme detected")
+        # These ports intentionally exercise the failed TLS probe fallback.
         self.assertEqual(detect_scheme(DUMMY_DOMAIN, 80), "http", "Incorrect scheme detected")
         self.assertEqual(detect_scheme(DUMMY_DOMAIN, 1234), "http", "Incorrect scheme detected")


### PR DESCRIPTION
## Summary
- Document GitHub-backed pip installs, no-compile release artifact choices, and the separate `maturin` flow for the Rust native backend.
- Add `native/pyproject.toml` and route native release builds through `scripts/build_native.py`, which installs the exact built wheel and verifies `import dirsearch_native`.
- Switch XML parsing helpers back to `defusedxml`, keep explicit unsafe-markup rejection, and package `defusedxml` for runtime and PyInstaller builds.
- Close scheme-detection sockets on both successful HTTPS probes and expected fallback-to-HTTP failures.
- Add repository and PR-template guidance to prevent private infrastructure disclosure in public project text.

## Why
The project is not distributed through PyPI, but pip can install the Python package directly from GitHub. The Rust native backend is opt-in and needs explicit source-build instructions and a stable wheel-building path.

Using `defusedxml` is worth keeping because `safe_xml` is used for untrusted Nmap/mimetype XML parsing. The local pre-scan still catches encoded `DOCTYPE`/`ENTITY` payloads early, while `defusedxml` adds parser-level protection for XML features we should not process.

The `ResourceWarning` seen during full test validation came from `test_schemedet` intentionally probing non-TLS ports to exercise the expected HTTP fallback path. The behavior remains expected, but `detect_scheme` now closes the wrapped socket in a `finally` block so the fallback does not leave an unclosed socket warning behind.

Private validation environments should be described only by generic platform and toolchain. The PR template and agent guidelines now explicitly block internal hostnames, machine names, SSH targets, IPs, regions, private paths, runner names, and operational topology from commits, docs, PR text, comments, issues, and release notes.

## Validation
- `.venv/bin/python -m unittest tests.utils.test_schemedet tests.utils.test_safe_xml tests.utils.test_mimetype tests.parse.test_nmap`
- `.venv/bin/python -m unittest tests.connection.test_requester tests.connection.test_dns tests.core.test_scanner`
- `.venv/bin/python testing.py`
- `cargo test`
- Confirmed in Docker with Rust installed that `python -m pip install "git+https://github.com/maurosoria/dirsearch.git"` installs `dirsearch v0.5.0` but does not provide `dirsearch_native`.
- Built a clean archive of this PR in Docker using `maturin --manifest-path /src/native/Cargo.toml --target-dir /tmp/native-target`; the wheel was `dirsearch_native-0.1.0-cp39-abi3-manylinux_2_34_x86_64.whl`.
- Installed both wheels in the Docker virtualenv, verified `import dirsearch`, `import dirsearch_native`, and `dirsearch --version`.
- Ran a Linux native smoke scan: `dirsearch -u https://example.com -w /src/tests/static/wordlist.txt --request-backend native --wordlist-backend native -q`.
- Validated the Windows native build on Windows amd64 with Python 3.13 and the MSVC Rust toolchain; the build produced `dirsearch_native-0.1.0-cp39-abi3-win_amd64.whl`.
- Installed the Windows native wheel, verified `imports=ok`, `dirsearch v0.5.0`, and ran a native backend smoke scan successfully.
- Ran `pip --dry-run` for `dirsearch[db] @ git+https://github.com/maurosoria/dirsearch.git` and confirmed MySQL/PostgreSQL extras resolve.
- Searched README/docs/native for stale PyPI install references.