### PR TITLE
Handle absolute-form targets in raw requests

### DIFF
--- a/lib/parse/rawrequest.py
+++ b/lib/parse/rawrequest.py
@@ -18,10 +18,23 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 from lib.core.exceptions import InvalidRawRequest
 from lib.core.logger import logger
 from lib.parse.headers import HeadersParser
 from lib.utils.file import File
+
+
+def _target_from_request_line(path: str, host: str) -> str:
+    parsed = urlsplit(path)
+    if parsed.scheme and parsed.netloc:
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        host = parsed.netloc
+
+    return host + path
 
 
 def parse_raw(raw_file: str) -> tuple[list[str], str, dict[str, str], str | None]:
@@ -47,4 +60,4 @@ def parse_raw(raw_file: str) -> tuple[list[str], str, dict[str, str], str | None
         logger.exception(e)
         raise InvalidRawRequest("The raw request is formatively invalid")
 
-    return [host + path], method, dict(headers), body
+    return [_target_from_request_line(path, host)], method, dict(headers), body

--- a/testing.py
+++ b/testing.py
@@ -52,6 +52,7 @@ from tests.core.test_scanner import TestScanner  # noqa: F401
 from tests.core.test_wordlist_backend import TestWordlistBackend  # noqa: F401
 from tests.parse.test_config import TestConfigParser  # noqa: F401
 from tests.parse.test_headers import TestHeadersParser  # noqa: F401
+from tests.parse.test_rawrequest import TestRawRequestParser  # noqa: F401
 from tests.parse.test_url import TestURLParsers  # noqa: F401
 from tests.utils.test_common import TestCommonUtils  # noqa: F401
 from tests.utils.test_crawl import TestCrawl  # noqa: F401

--- a/tests/parse/test_rawrequest.py
+++ b/tests/parse/test_rawrequest.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from lib.parse.rawrequest import parse_raw
+
+
+class TestRawRequestParser(TestCase):
+    def _write_raw_request(self, directory: str, raw_request: str) -> str:
+        request_file = Path(directory, "request.txt")
+        request_file.write_bytes(raw_request.encode("utf-8"))
+        return str(request_file)
+
+    def test_origin_form_request_target(self):
+        with TemporaryDirectory() as directory:
+            request_file = self._write_raw_request(
+                directory,
+                "GET /admin HTTP/1.1\r\n"
+                "Host: example.com\r\n"
+                "\r\n",
+            )
+
+            urls, method, headers, body = parse_raw(request_file)
+
+        self.assertEqual(urls, ["example.com/admin"])
+        self.assertEqual(method, "GET")
+        self.assertEqual(headers, {"host": "example.com"})
+        self.assertEqual(body, "")
+
+    def test_absolute_form_request_target(self):
+        with TemporaryDirectory() as directory:
+            request_file = self._write_raw_request(
+                directory,
+                "GET http://example.com/admin?debug=true HTTP/1.1\r\n"
+                "Host: proxy.local\r\n"
+                "\r\n",
+            )
+
+            urls, method, headers, body = parse_raw(request_file)
+
+        self.assertEqual(urls, ["example.com/admin?debug=true"])
+        self.assertEqual(method, "GET")
+        self.assertEqual(headers, {"host": "proxy.local"})
+        self.assertEqual(body, "")


### PR DESCRIPTION
## Summary
- handle absolute-form request targets in raw request files, such as `GET http://example.com/admin HTTP/1.1`
- preserve query strings while using the absolute-form authority instead of prepending the `Host` header
- add raw request parser coverage and include it in the legacy `testing.py` runner

## Validation
- `python -m unittest tests.parse.test_rawrequest tests.parse.test_url tests.parse.test_headers -v`
- `python -m flake8 lib/parse/rawrequest.py tests/parse/test_rawrequest.py testing.py`
- `python testing.py` was also run locally; the raw request tests passed, but this Windows/Python 3.14 run still reports an unrelated async requester path-preservation failure where the local test server receives no async requests.
