### PR TITLE
Support raw request parsing across API and stacks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@
 - [Xeonacid](https://github.com/Xeonacid)
 - [Valentijn Scholten](https://www.github.com/valentijnscholten)
 - [partoneplay](https://github.com/partoneplay)
+- [xujiantop-crypto](https://github.com/xujiantop-crypto)
 
 
 Special thanks to all the people who are named here!

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -250,6 +250,49 @@ results = DirsearchFuzzer(
 The fuzzer owns the session returned by `session_factory` and closes it after the
 scan.
 
+### Raw Requests
+
+Use `FuzzerConfig.from_raw_request()` when an integration already has an HTTP
+request captured from a proxy, a test fixture, or another scanner:
+
+```python
+from dirsearch import DirsearchFuzzer, FuzzerConfig
+
+raw_request = (
+    b"POST /api/search?debug=true HTTP/1.1\r\n"
+    b"Host: example.com\r\n"
+    b"Content-Type: application/json\r\n"
+    b"\r\n"
+    b'{"q":"admin"}'
+)
+
+config = FuzzerConfig.from_raw_request(
+    raw_request=raw_request,
+    scheme="https",
+    wordlist=["users", "orders"],
+    include_status_codes={200, 401, 403},
+)
+
+results = DirsearchFuzzer(config).run()
+```
+
+`raw_request` accepts `bytes` or `str`. Use `bytes` when the request body must be
+preserved exactly. `raw_file` can be used instead when the request is already on
+disk:
+
+```python
+config = FuzzerConfig.from_raw_request(
+    raw_file="tmp/request.txt",
+    scheme="https",
+    wordlist=["admin", "login"],
+)
+```
+
+Origin-form targets such as `GET /admin HTTP/1.1` use the `Host` header and the
+provided `scheme`. Absolute-form targets such as
+`GET https://example.com/admin HTTP/1.1` use the scheme and authority from the
+request line. Method, headers, query string, and body are carried into the scan.
+
 ## Callbacks and Streaming
 
 Callbacks let agents stream findings while still receiving the final list:

--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -7,6 +7,7 @@ from lib.connection.response import NativeResponse
 from lib.core.data import options
 from lib.core.exceptions import RequestException
 from lib.core.settings import MAX_RESPONSE_SIZE
+from lib.parse.url import append_query_string
 from lib.utils.common import safequote
 
 
@@ -26,9 +27,11 @@ class NativeHTTPBackend:
         self,
         base_url: str,
         paths: Iterable[str],
+        query: str = "",
     ) -> Iterator[tuple[str, NativeResponse | None, RequestException | None]]:
         raw_paths = list(paths)
-        quoted_paths = [safequote(path) for path in raw_paths]
+        request_paths = [append_query_string(path, query) for path in raw_paths]
+        quoted_paths = [safequote(path) for path in request_paths]
         results = self._native.scan_http(
             base_url,
             quoted_paths,

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -55,6 +55,7 @@ from lib.core.settings import (
     SCRIPT_PATH,
 )
 from lib.core.structures import CaseInsensitiveDict
+from lib.parse.url import append_query_string
 from lib.utils.common import safequote
 from lib.utils.file import FileUtils
 from lib.utils.mimetype import guess_mimetype
@@ -228,6 +229,7 @@ def _format_ssl_error(exc: Exception, url: str = "") -> str:
 class BaseRequester:
     def __init__(self) -> None:
         self._url: str = ""
+        self._query: str = ""
         self._rate = 0
         self.proxy_cred = options["proxy_auth"]
         self.headers = CaseInsensitiveDict(options["headers"])
@@ -262,6 +264,12 @@ class BaseRequester:
 
     def set_url(self, url: str) -> None:
         self._url = url
+
+    def set_query(self, query: str) -> None:
+        self._query = query
+
+    def request_path(self, path: str) -> str:
+        return append_query_string(path, getattr(self, "_query", ""))
 
     def set_header(self, key: str, value: str) -> None:
         self.headers[key] = value.lstrip()
@@ -338,7 +346,8 @@ class Requester(BaseRequester):
         self.increase_rate()
 
         err_msg = None
-        url = self._url + safequote(path)
+        request_path = self.request_path(path)
+        url = self._url + safequote(request_path)
 
         # Why using a loop instead of max_retries argument? Check issue #1009
         for _ in range(options["max_retries"] + 1):
@@ -531,7 +540,8 @@ class AsyncRequester(BaseRequester):
         self.increase_rate()
 
         err_msg = None
-        url = self._url + safequote(path)
+        request_path = self.request_path(path)
+        url = self._url + safequote(request_path)
         session = session or self.session
 
         for _ in range(options["max_retries"] + 1):
@@ -545,7 +555,7 @@ class AsyncRequester(BaseRequester):
                     url,
                     headers=self.headers,
                     data=options["data"],
-                    extensions={"target": (url if replay else f"/{safequote(path)}").encode()},
+                    extensions={"target": (url if replay else f"/{safequote(request_path)}").encode()},
                 )
 
                 start_time = time.perf_counter()

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -33,6 +33,9 @@ import httpx
 import requests
 from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth
 from requests.packages import urllib3
+from urllib3 import connection as urllib3_connection
+from urllib3 import connectionpool as urllib3_connectionpool
+from urllib3 import poolmanager as urllib3_poolmanager
 from requests_ntlm import HttpNtlmAuth
 from httpx_ntlm import HttpNtlmAuth as HttpxNtlmAuth
 from requests_toolbelt.adapters.socket_options import SocketOptionsAdapter
@@ -64,6 +67,76 @@ from lib.utils.mimetype import guess_mimetype
 urllib3.disable_warnings(urllib3.exceptions.SecurityWarning)
 # Use custom `socket.getaddrinfo` for `requests` which supports DNS caching
 socket.getaddrinfo = cached_getaddrinfo
+
+_request_target_state = threading.local()
+
+
+def _join_request_target(base_url: str, quoted_path: str) -> str:
+    base_path = urlparse(base_url).path or "/"
+    target = "/" if base_path == "/" else f"{base_path.rstrip('/')}/"
+    return target + quoted_path.lstrip("/")
+
+
+# urllib3 encodes origin-form targets before writing them to the socket. Keep
+# the already-quoted dirsearch target for direct requests so fuzzed characters
+# such as malformed percent escapes and backslashes reach the server unchanged.
+class PathPreservingHTTPConnection(urllib3_connection.HTTPConnection):
+    def request(self, method, url, body=None, headers=None, *args, **kwargs):
+        target = getattr(_request_target_state, "target", None)
+        if target:
+            url = target
+
+        return super().request(method, url, body, headers, *args, **kwargs)
+
+
+class PathPreservingHTTPSConnection(urllib3_connection.HTTPSConnection):
+    def request(self, method, url, body=None, headers=None, *args, **kwargs):
+        target = getattr(_request_target_state, "target", None)
+        if target:
+            url = target
+
+        return super().request(method, url, body, headers, *args, **kwargs)
+
+
+class PathPreservingHTTPConnectionPool(urllib3_connectionpool.HTTPConnectionPool):
+    ConnectionCls = PathPreservingHTTPConnection
+
+
+class PathPreservingHTTPSConnectionPool(urllib3_connectionpool.HTTPSConnectionPool):
+    ConnectionCls = PathPreservingHTTPSConnection
+
+
+class PathPreservingSocketOptionsAdapter(SocketOptionsAdapter):
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3_poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            socket_options=self.socket_options,
+        )
+        self.poolmanager.pool_classes_by_scheme = {
+            "http": PathPreservingHTTPConnectionPool,
+            "https": PathPreservingHTTPSConnectionPool,
+        }
+
+    def request_url(self, request: requests.PreparedRequest, proxies: dict[str, str]) -> str:
+        target = getattr(request, "_dirsearch_request_target", None)
+        if target and not proxies:
+            return target
+
+        return super().request_url(request, proxies)
+
+    def send(self, request, **kwargs):
+        target = getattr(request, "_dirsearch_request_target", None)
+        proxies = kwargs.get("proxies") or {}
+        if not target or proxies:
+            return super().send(request, **kwargs)
+
+        _request_target_state.target = target
+        try:
+            return super().send(request, **kwargs)
+        finally:
+            del _request_target_state.target
 
 
 def _is_requests_ssl_error(exc: Exception) -> bool:
@@ -310,7 +383,7 @@ class Requester(BaseRequester):
         for scheme in ("http://", "https://"):
             self.session.mount(
                 scheme,
-                SocketOptionsAdapter(
+                PathPreservingSocketOptionsAdapter(
                     max_retries=0,
                     pool_maxsize=options["thread_count"],
                     socket_options=self._socket_options,
@@ -347,7 +420,8 @@ class Requester(BaseRequester):
 
         err_msg = None
         request_path = self.request_path(path)
-        url = self._url + safequote(request_path)
+        quoted_request_path = safequote(request_path)
+        url = self._url + quoted_request_path
 
         # Why using a loop instead of max_retries argument? Check issue #1009
         for _ in range(options["max_retries"] + 1):
@@ -381,6 +455,9 @@ class Requester(BaseRequester):
                 )
                 prep = self.session.prepare_request(request)
                 prep.url = url
+                prep._dirsearch_request_target = _join_request_target(
+                    self._url, quoted_request_path
+                )
 
                 start_time = time.perf_counter()
                 origin_response = self.session.send(
@@ -541,7 +618,8 @@ class AsyncRequester(BaseRequester):
 
         err_msg = None
         request_path = self.request_path(path)
-        url = self._url + safequote(request_path)
+        quoted_request_path = safequote(request_path)
+        url = self._url + quoted_request_path
         session = session or self.session
 
         for _ in range(options["max_retries"] + 1):
@@ -555,7 +633,13 @@ class AsyncRequester(BaseRequester):
                     url,
                     headers=self.headers,
                     data=options["data"],
-                    extensions={"target": (url if replay else f"/{safequote(request_path)}").encode()},
+                    extensions={
+                        "target": (
+                            url
+                            if replay
+                            else _join_request_target(self._url, quoted_request_path)
+                        ).encode()
+                    },
                 )
 
                 start_time = time.perf_counter()

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -26,6 +26,7 @@ import signal
 import sys
 import re
 import time
+from types import SimpleNamespace
 from typing import Any
 
 from urllib.parse import urlparse
@@ -47,6 +48,7 @@ from lib.core.exceptions import (
     WordlistLimitError,
 )
 from lib.core.logger import enable_logging, logger
+from lib.core.request_backend import get_native_request_backend_error
 from lib.core.settings import (
     BANNER,
     DEFAULT_HEADERS,
@@ -61,7 +63,7 @@ from lib.core.settings import (
     UNKNOWN,
 )
 from lib.parse.rawrequest import parse_raw
-from lib.parse.url import clean_path, parse_path
+from lib.parse.url import clean_path, ensure_trailing_path_slash, parse_path
 from lib.report.manager import ReportManager
 from lib.utils.common import lstrip_once
 from lib.utils.crawl import Crawler
@@ -273,6 +275,11 @@ class Controller:
             except InvalidRawRequest as e:
                 print(str(e))
                 sys.exit(1)
+
+            if options["request_backend"] == "native":
+                if error := get_native_request_backend_error(SimpleNamespace(**options)):
+                    print(error)
+                    sys.exit(1)
         else:
             options["headers"] = {**DEFAULT_HEADERS, **options["headers"]}
 
@@ -494,8 +501,7 @@ class Controller:
         # If no scheme specified, unset it first
         if "://" not in url:
             url = f'{options["scheme"] or UNKNOWN}://{url}'
-        if not url.endswith("/"):
-            url += "/"
+        url = ensure_trailing_path_slash(url)
 
         parsed = urlparse(url)
         self.base_path = lstrip_once(parsed.path, "/")
@@ -539,6 +545,7 @@ class Controller:
         self.url += "/"
 
         self.requester.set_url(self.url)
+        self.requester.set_query(parsed.query)
 
     def reset_consecutive_errors(self, response: BaseResponse) -> None:
         self.consecutive_errors = 0

--- a/lib/core/api.py
+++ b/lib/core/api.py
@@ -23,7 +23,7 @@ import time
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import requests
 
@@ -31,6 +31,8 @@ from lib.core.exceptions import WordlistLimitError
 from lib.core.settings import DEFAULT_HEADERS, SCRIPT_PATH
 from lib.core.structures import OrderedSet
 from lib.core.wordlist_template import expand_template_line, normalize_placeholders
+from lib.parse.rawrequest import parse_raw_content
+from lib.parse.url import append_query_string, ensure_trailing_path_slash
 from lib.utils.common import safequote
 from lib.utils.file import FileUtils
 
@@ -208,6 +210,51 @@ class FuzzerConfig:
     session_factory: Callable[[], requests.Session] | None = None
     raise_on_error: bool = False
 
+    @classmethod
+    def from_raw_request(
+        cls,
+        *,
+        wordlist: Wordlist | WordlistTemplate | Iterable[str],
+        raw_request: str | bytes | None = None,
+        raw_file: str | None = None,
+        scheme: str = "http",
+        extensions: Iterable[str] = (),
+        timeout: float = 10.0,
+        follow_redirects: bool = False,
+        include_status_codes: Iterable[int] = frozenset(),
+        exclude_status_codes: Iterable[int] = frozenset({404}),
+        verify_tls: bool = False,
+        user_agent: str | None = None,
+        result_predicate: Callable[[FuzzerResult], bool] | None = None,
+        session_factory: Callable[[], requests.Session] | None = None,
+        raise_on_error: bool = False,
+    ) -> FuzzerConfig:
+        if (raw_request is None) == (raw_file is None):
+            raise ValueError("Provide exactly one of raw_request or raw_file")
+
+        if raw_file is not None:
+            raw_request = FileUtils.read_bytes(raw_file)
+
+        request = parse_raw_content(raw_request, scheme=scheme)
+
+        return cls(
+            url=request.url,
+            wordlist=wordlist,
+            extensions=tuple(extensions),
+            headers=request.headers,
+            http_method=request.method,
+            data=request.body,
+            timeout=timeout,
+            follow_redirects=follow_redirects,
+            include_status_codes=frozenset(include_status_codes),
+            exclude_status_codes=frozenset(exclude_status_codes),
+            verify_tls=verify_tls,
+            user_agent=user_agent,
+            result_predicate=result_predicate,
+            session_factory=session_factory,
+            raise_on_error=raise_on_error,
+        )
+
     def __post_init__(self) -> None:
         if not self.url:
             raise ValueError("FuzzerConfig.url is required")
@@ -321,6 +368,7 @@ class DirsearchFuzzer:
 
     @staticmethod
     def _join_url(base_url: str, path: str) -> str:
-        if not base_url.endswith("/"):
-            base_url += "/"
-        return urljoin(base_url, safequote(path))
+        parsed = urlsplit(ensure_trailing_path_slash(base_url))
+        base_url = urlunsplit(parsed._replace(query="", fragment=""))
+
+        return append_query_string(urljoin(base_url, safequote(path)), parsed.query)

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -484,7 +484,11 @@ class NativeFuzzer(Fuzzer):
                 if not paths:
                     break
 
-                for path, response, error in self._native_backend.scan(self._requester._url, paths):
+                for path, response, error in self._native_backend.scan(
+                    self._requester._url,
+                    paths,
+                    getattr(self._requester, "_query", ""),
+                ):
                     if self._quit_event.is_set():
                         break
                     if error is not None:

--- a/lib/parse/rawrequest.py
+++ b/lib/parse/rawrequest.py
@@ -18,33 +18,105 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
+
 from lib.core.exceptions import InvalidRawRequest
 from lib.core.logger import logger
 from lib.parse.headers import HeadersParser
-from lib.utils.file import File
+from lib.utils.file import FileUtils
 
 
-def parse_raw(raw_file: str) -> tuple[list[str], str, dict[str, str], str | None]:
-    with File(raw_file) as fd:
-        raw_content = fd.read()
+HEADER_ENCODING = "iso-8859-1"
+
+
+@dataclass(frozen=True)
+class RawRequest:
+    url: str
+    method: str
+    headers: dict[str, str]
+    body: bytes | None
+
+
+def _raw_bytes(raw_content: str | bytes) -> bytes:
+    if isinstance(raw_content, bytes):
+        return raw_content
+
+    return raw_content.encode()
+
+
+def _split_head_body(raw_content: bytes) -> tuple[bytes, bytes | None]:
+    for separator in (b"\r\n\r\n", b"\n\n"):
+        if separator in raw_content:
+            return raw_content.split(separator, 1)
+
+    return raw_content.strip(b"\r\n"), None
+
+
+def _origin_form_target(target: str, host: str, scheme: str | None) -> str:
+    parsed = urlsplit(target)
+    path = parsed.path if parsed.path.startswith("/") else f"/{parsed.path}"
+
+    if scheme:
+        return urlunsplit((scheme, host, path, parsed.query, ""))
+
+    return host + urlunsplit(("", "", path, parsed.query, ""))
+
+
+def _absolute_form_target(target: str) -> str | None:
+    parsed = urlsplit(target)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path or "/", parsed.query, ""))
+
+
+def _target_from_request_line(
+    target: str,
+    headers: HeadersParser,
+    *,
+    scheme: str | None = None,
+) -> str:
+    absolute_target = _absolute_form_target(target)
+    if absolute_target:
+        return absolute_target
 
     try:
-        head, body = raw_content.split("\n\n", 1)
-    except ValueError:
-        try:
-            head, body = raw_content.split("\r\n\r\n", 1)
-        except ValueError:
-            head = raw_content.strip("\n")
-            body = None
-
-    try:
-        method, path = head.splitlines()[0].split()[:2]
-        headers = HeadersParser("\n".join(head.splitlines()[1:]))
         host = headers.get("host")
     except KeyError:
         raise InvalidRawRequest("Can't find the Host header in the raw request")
+
+    return _origin_form_target(target, host, scheme)
+
+
+def parse_raw_content(
+    raw_content: str | bytes,
+    *,
+    scheme: str | None = None,
+) -> RawRequest:
+    head, body = _split_head_body(_raw_bytes(raw_content))
+
+    try:
+        head_lines = head.splitlines()
+        method, target = head_lines[0].decode(HEADER_ENCODING).split()[:2]
+        headers = HeadersParser(
+            b"\n".join(head_lines[1:]).decode(HEADER_ENCODING)
+        )
+        url = _target_from_request_line(target, headers, scheme=scheme)
     except Exception as e:
+        if isinstance(e, InvalidRawRequest):
+            raise
+
         logger.exception(e)
         raise InvalidRawRequest("The raw request is formatively invalid")
 
-    return [host + path], method, dict(headers), body
+    return RawRequest(url, method, dict(headers), body)
+
+
+def parse_raw(
+    raw_file: str,
+    *,
+    scheme: str | None = None,
+) -> tuple[list[str], str, dict[str, str], bytes | None]:
+    request = parse_raw_content(FileUtils.read_bytes(raw_file), scheme=scheme)
+    return [request.url], request.method, request.headers, request.body

--- a/lib/parse/url.py
+++ b/lib/parse/url.py
@@ -16,6 +16,8 @@
 #
 #  Author: Mauro Soria
 
+from urllib.parse import urlsplit, urlunsplit
+
 from lib.utils.common import lstrip_once
 
 
@@ -40,3 +42,24 @@ def parse_path(value: str) -> str:
         return "/".join(url.split("/")[1:])
     except Exception:
         return lstrip_once(value, "/")
+
+
+def ensure_trailing_path_slash(url: str) -> str:
+    parsed = urlsplit(url)
+    path = parsed.path
+    if not path.endswith("/"):
+        path += "/"
+
+    return urlunsplit(parsed._replace(path=path))
+
+
+def append_query_string(value: str, query: str) -> str:
+    if not query or "?" in value:
+        return value
+
+    path, separator, fragment = value.partition("#")
+    value = f"{path}?{query}"
+    if separator:
+        value += f"#{fragment}"
+
+    return value

--- a/lib/utils/file.py
+++ b/lib/utils/file.py
@@ -102,6 +102,11 @@ class FileUtils:
     def read(file_name):
         return open(file_name, "r").read()
 
+    @staticmethod
+    def read_bytes(file_name):
+        with open(file_name, "rb") as fd:
+            return fd.read()
+
     @classmethod
     def get_files(cls, directory):
         files = []

--- a/lib/utils/mimetype.py
+++ b/lib/utils/mimetype.py
@@ -25,6 +25,13 @@ from lib.utils import safe_xml
 
 class MimeTypeUtils:
     @staticmethod
+    def to_text(content):
+        if isinstance(content, bytes):
+            return content.decode("utf-8", errors="replace")
+
+        return content
+
+    @staticmethod
     def is_json(content):
         try:
             json.loads(content)
@@ -42,6 +49,7 @@ class MimeTypeUtils:
 
     @staticmethod
     def is_query_string(content):
+        content = MimeTypeUtils.to_text(content)
         if re.match(QUERY_STRING_REGEX, content):
             return True
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -642,9 +642,33 @@ fn response_length(headers: &[(String, String)], body_length: usize) -> usize {
 
 fn should_use_raw_http(base_url: &str, path: &str) -> bool {
     base_url.starts_with("http://")
-        && path
-            .split(['/', '?', '#'])
-            .any(|segment| segment == "." || segment == "..")
+        && (has_dot_segment(path) || path.contains('\\') || has_malformed_percent_escape(path))
+}
+
+fn has_dot_segment(path: &str) -> bool {
+    path.split(['/', '?', '#'])
+        .any(|segment| segment == "." || segment == "..")
+}
+
+fn has_malformed_percent_escape(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit()
+            {
+                return true;
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+
+    false
 }
 
 fn raw_http_get(
@@ -923,6 +947,28 @@ mod tests {
 
     fn content_length(value: usize) -> Vec<(String, String)> {
         vec![("Content-Length".to_string(), value.to_string())]
+    }
+
+    #[test]
+    fn raw_http_path_preservation_detects_targets_reqwest_may_rewrite() {
+        assert!(should_use_raw_http(
+            "http://example.com/",
+            "admin%3d..%1\\*"
+        ));
+        assert!(should_use_raw_http("http://example.com/", "admin%3d..%1*"));
+        assert!(should_use_raw_http(
+            "http://example.com/",
+            "admin/%83%5c/.."
+        ));
+        assert!(!should_use_raw_http(
+            "http://example.com/",
+            "admin%20space/%E6%B5%8B%E8%AF%95"
+        ));
+        assert!(!should_use_raw_http("http://example.com/", "admin%3d"));
+        assert!(!should_use_raw_http(
+            "https://example.com/",
+            "admin%3d..%1\\*"
+        ));
     }
 
     #[test]

--- a/testing.py
+++ b/testing.py
@@ -52,6 +52,7 @@ from tests.core.test_scanner import TestScanner  # noqa: F401
 from tests.core.test_wordlist_backend import TestWordlistBackend  # noqa: F401
 from tests.parse.test_config import TestConfigParser  # noqa: F401
 from tests.parse.test_headers import TestHeadersParser  # noqa: F401
+from tests.parse.test_rawrequest import TestRawRequestParser  # noqa: F401
 from tests.parse.test_url import TestURLParsers  # noqa: F401
 from tests.utils.test_common import TestCommonUtils  # noqa: F401
 from tests.utils.test_crawl import TestCrawl  # noqa: F401

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -333,6 +333,15 @@ class TestRequesterPathPreservation(BaseRequesterTestCase):
                 [expected for _, _, expected in REQUEST_TARGET_CASES],
             )
 
+    def test_sync_requester_appends_base_query(self):
+        with RequestTargetServer() as server:
+            requester = Requester()
+            requester.set_url(server.url)
+            requester.set_query("debug=true")
+            requester.request("admin")
+
+            self.assertEqual(server.targets, [b"/admin?debug=true"])
+
 
 class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCase):
     async def test_async_connect_error_with_ssl_cause_uses_ssl_message(self):
@@ -432,6 +441,18 @@ class TestAsyncRequesterPathPreservation(BaseRequesterTestCase, IsolatedAsyncioT
                 [expected for _, _, expected in REQUEST_TARGET_CASES],
             )
 
+    async def test_async_requester_appends_base_query(self):
+        with RequestTargetServer() as server:
+            requester = AsyncRequester()
+            requester.set_url(server.url)
+            requester.set_query("debug=true")
+            try:
+                await requester.request("admin")
+            finally:
+                await requester.session.aclose()
+
+            self.assertEqual(server.targets, [b"/admin?debug=true"])
+
 
 class TestNativeRequesterPathPreservation(BaseRequesterTestCase):
     def test_native_requester_preserves_encoded_edge_case_targets(self):
@@ -453,3 +474,15 @@ class TestNativeRequesterPathPreservation(BaseRequesterTestCase):
                 [normalize_percent_hex(target) for target in server.targets],
                 [expected for _, _, expected in REQUEST_TARGET_CASES],
             )
+
+    def test_native_requester_appends_base_query(self):
+        try:
+            backend = NativeHTTPBackend()
+        except RequestException as error:
+            self.skipTest(str(error))
+
+        with RequestTargetServer() as server:
+            results = list(backend.scan(server.url, ["admin"], "debug=true"))
+
+            self.assertEqual([error for _, _, error in results], [None])
+            self.assertEqual(server.targets, [b"/admin?debug=true"])

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -42,10 +42,18 @@ from lib.core.exceptions import RequestException
 
 REQUEST_TARGET_CASES = (
     ("shift-jis-overlap", "admin/%83%5c/..", b"/admin/%83%5C/.."),
+    ("malformed-percent-backslash-star", "admin%3d..%1\\*", b"/admin%3D..%1\\*"),
     ("utf16-le-bom", "%FF%FEadmin", b"/%FF%FEadmin"),
     ("utf16-be-bom", "%FE%FFadmin", b"/%FE%FFadmin"),
     ("rtl-override", "admin/\u202eexe.txt/", b"/admin/%E2%80%AEexe.txt/"),
     ("german-eszett", "test-straße", b"/test-stra%C3%9Fe"),
+    ("space-and-cjk", "admin space/测试", b"/admin%20space/%E6%B5%8B%E8%AF%95"),
+    ("reserved-punctuation", "admin=..\\*;:@&+$,()", b"/admin=..\\*;:@&+$,()"),
+    (
+        "query-character-encoding",
+        "admin?x=1 y=ñ&raw=%1\\*",
+        b"/admin?x=1%20y=%C3%B1&raw=%1\\*",
+    ),
     ("turkish-i-exact-case", "ADMIN", b"/ADMIN"),
     ("cjk", "admin/测试", b"/admin/%E6%B5%8B%E8%AF%95"),
 )

--- a/tests/core/test_fuzzer_filter_stacks.py
+++ b/tests/core/test_fuzzer_filter_stacks.py
@@ -54,8 +54,9 @@ class DummyNativeRequester:
 
 
 class FilteringNativeBackend:
-    def scan(self, base_url, paths):
+    def scan(self, base_url, paths, query=""):
         del base_url
+        del query
         for path in paths:
             if path == "keep":
                 yield path, stack_response(path, b"keep admin panel"), None

--- a/tests/core/test_importable_api.py
+++ b/tests/core/test_importable_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import threading
 from unittest import TestCase
 
@@ -17,6 +19,7 @@ class APITestHandler(BaseHTTPRequestHandler):
     }
 
     def do_GET(self):
+        self.server.seen.append((self.command, self.path, dict(self.headers), b""))
         if self.path == "/agent-only":
             status, body = (
                 (200, b"agent")
@@ -37,6 +40,26 @@ class APITestHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def do_POST(self):
+        content_length = int(self.headers.get("content-length", 0))
+        request_body = self.rfile.read(content_length)
+        self.server.seen.append((self.command, self.path, dict(self.headers), request_body))
+
+        status, body = (
+            (200, b"raw")
+            if (
+                self.path == "/submit/probe?debug=true"
+                and self.headers.get("x-raw") == "yes"
+                and request_body == b"payload-\xff"
+            )
+            else (404, b"missing")
+        )
+        self.send_response(status)
+        self.send_header("content-type", "text/plain")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def log_message(self, format, *args):
         pass
 
@@ -44,11 +67,14 @@ class APITestHandler(BaseHTTPRequestHandler):
 class LocalHTTPServer:
     def __enter__(self):
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), APITestHandler)
+        self.server.seen = []
         self.thread = threading.Thread(target=self.server.serve_forever)
         self.thread.daemon = True
         self.thread.start()
         host, port = self.server.server_address
         self.url = f"http://{host}:{port}"
+        self.host_header = f"{host}:{port}"
+        self.seen = self.server.seen
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -169,6 +195,66 @@ class TestImportableAPI(TestCase):
             ).run()
 
         self.assertEqual([result.path for result in results], ["agent-only"])
+
+    def test_from_raw_request_runs_with_body_and_query(self):
+        from dirsearch import DirsearchFuzzer, FuzzerConfig
+
+        with LocalHTTPServer() as server:
+            raw_request = (
+                b"POST /submit?debug=true HTTP/1.1\r\n"
+                + f"Host: {server.host_header}\r\n".encode()
+                + b"Content-Type: application/octet-stream\r\n"
+                + b"X-Raw: yes\r\n"
+                + b"\r\n"
+                + b"payload-\xff"
+            )
+            results = DirsearchFuzzer(
+                FuzzerConfig.from_raw_request(
+                    raw_request=raw_request,
+                    scheme="http",
+                    wordlist=["probe"],
+                    include_status_codes={200},
+                )
+            ).run()
+
+        self.assertEqual([result.url for result in results], [f"{server.url}/submit/probe?debug=true"])
+        self.assertEqual(server.seen[-1][0], "POST")
+        self.assertEqual(server.seen[-1][1], "/submit/probe?debug=true")
+        self.assertEqual(server.seen[-1][3], b"payload-\xff")
+
+    def test_from_raw_request_file_uses_absolute_form_target(self):
+        from dirsearch import DirsearchFuzzer, FuzzerConfig
+
+        with LocalHTTPServer() as server, TemporaryDirectory() as directory:
+            request_file = Path(directory, "request.txt")
+            request_file.write_bytes(
+                f"GET {server.url}/ HTTP/1.1\r\n".encode()
+                + b"Host: proxy.local\r\n"
+                + b"X-Agent: yes\r\n"
+                + b"\r\n"
+            )
+            results = DirsearchFuzzer(
+                FuzzerConfig.from_raw_request(
+                    raw_file=str(request_file),
+                    wordlist=["agent-only"],
+                    include_status_codes={200},
+                )
+            ).run()
+
+        self.assertEqual([result.path for result in results], ["agent-only"])
+
+    def test_from_raw_request_requires_one_source(self):
+        from dirsearch import FuzzerConfig
+
+        with self.assertRaises(ValueError):
+            FuzzerConfig.from_raw_request(wordlist=["admin"])
+
+        with self.assertRaises(ValueError):
+            FuzzerConfig.from_raw_request(
+                raw_request=b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+                raw_file="request.txt",
+                wordlist=["admin"],
+            )
 
     def test_raise_on_error_invokes_callback_then_raises(self):
         from dirsearch import DirsearchFuzzer, FuzzerConfig

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -29,8 +29,8 @@ class FakeNativeBackend:
         self.items = items
         self.calls = []
 
-    def scan(self, base_url, paths):
-        self.calls.append((base_url, list(paths)))
+    def scan(self, base_url, paths, query=""):
+        self.calls.append((base_url, list(paths), query))
         yield from self.items
 
 
@@ -111,7 +111,7 @@ class TestNativeFuzzer(TestCase):
         self.assertEqual(matches, [response])
         self.assertEqual(misses, [])
         self.assertEqual(errors, [])
-        self.assertEqual(backend.calls, [("https://example.com/", ["admin"])])
+        self.assertEqual(backend.calls, [("https://example.com/", ["admin"], "")])
 
     def test_native_fuzzer_routes_backend_errors(self):
         error = RequestException("boom")

--- a/tests/parse/test_rawrequest.py
+++ b/tests/parse/test_rawrequest.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from lib.core.exceptions import InvalidRawRequest
+from lib.parse.rawrequest import parse_raw, parse_raw_content
+
+
+class TestRawRequestParser(TestCase):
+    def _write_raw_request(self, directory: str, raw_request: bytes) -> str:
+        request_file = Path(directory, "request.txt")
+        request_file.write_bytes(raw_request)
+        return str(request_file)
+
+    def test_origin_form_request_target(self):
+        with TemporaryDirectory() as directory:
+            request_file = self._write_raw_request(
+                directory,
+                b"GET /admin HTTP/1.1\r\n"
+                b"Host: example.com\r\n"
+                b"\r\n",
+            )
+
+            urls, method, headers, body = parse_raw(request_file)
+
+        self.assertEqual(urls, ["example.com/admin"])
+        self.assertEqual(method, "GET")
+        self.assertEqual(headers, {"host": "example.com"})
+        self.assertEqual(body, b"")
+
+    def test_origin_form_can_use_explicit_scheme(self):
+        request = parse_raw_content(
+            b"GET /admin?debug=true HTTP/1.1\r\n"
+            b"Host: example.com\r\n"
+            b"\r\n",
+            scheme="https",
+        )
+
+        self.assertEqual(request.url, "https://example.com/admin?debug=true")
+
+    def test_absolute_form_request_target(self):
+        request = parse_raw_content(
+            b"GET https://example.com:8443/admin?debug=true HTTP/1.1\r\n"
+            b"Host: proxy.local\r\n"
+            b"\r\n",
+        )
+
+        self.assertEqual(request.url, "https://example.com:8443/admin?debug=true")
+        self.assertEqual(request.method, "GET")
+        self.assertEqual(request.headers, {"host": "proxy.local"})
+        self.assertEqual(request.body, b"")
+
+    def test_absolute_form_does_not_require_host_header(self):
+        request = parse_raw_content(
+            b"GET http://example.com/admin HTTP/1.1\r\n"
+            b"\r\n",
+        )
+
+        self.assertEqual(request.url, "http://example.com/admin")
+        self.assertEqual(request.headers, {})
+
+    def test_body_bytes_are_preserved(self):
+        request = parse_raw_content(
+            b"POST /submit HTTP/1.1\r\n"
+            b"Host: example.com\r\n"
+            b"Content-Type: application/octet-stream\r\n"
+            b"\r\n"
+            b"payload-\xff",
+        )
+
+        self.assertEqual(request.body, b"payload-\xff")
+        self.assertEqual(
+            request.headers,
+            {"host": "example.com", "content-type": "application/octet-stream"},
+        )
+
+    def test_origin_form_requires_host_header(self):
+        with self.assertRaises(InvalidRawRequest):
+            parse_raw_content(b"GET /admin HTTP/1.1\r\n\r\n")

--- a/tests/parse/test_url.py
+++ b/tests/parse/test_url.py
@@ -19,7 +19,7 @@
 from unittest import TestCase
 
 from lib.core.settings import DUMMY_URL
-from lib.parse.url import clean_path, parse_path
+from lib.parse.url import append_query_string, clean_path, ensure_trailing_path_slash, parse_path
 
 
 class TestURLParsers(TestCase):
@@ -40,4 +40,17 @@ class TestURLParsers(TestCase):
             parse_path(f"{DUMMY_URL}foo/bar"),
             "foo/bar",
             "Path parser gives unexpected result",
+        )
+
+    def test_ensure_trailing_path_slash_preserves_query(self):
+        self.assertEqual(
+            ensure_trailing_path_slash("https://example.com/admin?debug=true"),
+            "https://example.com/admin/?debug=true",
+        )
+
+    def test_append_query_string(self):
+        self.assertEqual(append_query_string("admin", "debug=true"), "admin?debug=true")
+        self.assertEqual(
+            append_query_string("admin?existing=true", "debug=true"),
+            "admin?existing=true",
         )


### PR DESCRIPTION
## Summary
- build on the raw absolute-form request idea from #1560 with a byte-safe raw request parser
- preserve absolute-form scheme/authority, explicit ports, query strings, and request bodies across CLI and Python API flows
- preserve encoded request targets across sync, async, and native stacks so existing percent escapes, malformed escapes, backslashes, reserved punctuation, and Unicode/space encoding reach the server consistently
- add `FuzzerConfig.from_raw_request(...)` for library callers and document raw request usage
- keep native backend restrictions explicit for unsupported methods/bodies, while validating raw GET/query and request-target encoding through native-rust
- credit the original contributor in `CONTRIBUTORS.md`

## Validation
- `python -m unittest tests.parse.test_rawrequest tests.parse.test_url tests.parse.test_headers tests.core.test_importable_api tests.connection.test_requester tests.core.test_native_fuzzer tests.core.test_fuzzer_filter_stacks -v`
- `python -m unittest tests.connection.test_requester tests.connection.test_dns tests.core.test_scanner -v`
- `python testing.py`
- `python -m flake8 lib/parse/rawrequest.py lib/parse/url.py lib/core/api.py lib/controller/controller.py lib/connection/requester.py lib/connection/native.py lib/core/fuzzer.py lib/utils/file.py lib/utils/mimetype.py tests/parse/test_rawrequest.py tests/parse/test_url.py tests/core/test_importable_api.py tests/connection/test_requester.py tests/core/test_native_fuzzer.py tests/core/test_fuzzer_filter_stacks.py testing.py`
- `cargo test --manifest-path native/Cargo.toml`
- Python 3.14 validation with `dirsearch_native` built through `maturin develop`; `tests.connection.test_requester` passed with native tests enabled
- Docker build and local smoke validation for `threaded`, `async`, and `native-rust` via `docker compose -f - build` with `build.network: host`
- Docker smokes covered `--version`, `--help`, a basic scan, raw GET with query, raw POST/body for Python stacks, and native-rust rejection of raw POST/body