### PR TITLE
fix: replace empty/generic Exception with descriptive RuntimeError/ValueError

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -192,7 +192,7 @@ class Controller:
                 try:
                     FileUtils.create_dir(FileUtils.parent(options["log_file"]))
                     if not FileUtils.can_write(options["log_file"]):
-                        raise Exception
+                        raise RuntimeError("Request failed, retrying...")
                     enable_logging()
                 except Exception:
                     interface.error(
@@ -292,7 +292,7 @@ class Controller:
             try:
                 FileUtils.create_dir(FileUtils.parent(options["log_file"]))
                 if not FileUtils.can_write(options["log_file"]):
-                    raise Exception
+                    raise RuntimeError("Request failed, retrying...")
 
                 enable_logging()
 

--- a/lib/report/csv_report.py
+++ b/lib/report/csv_report.py
@@ -34,7 +34,7 @@ class CSVReport(FileReportMixin, BaseReport):
             rows = list(csv.reader(fh, delimiter=",", quotechar='"'))
             # Not a dirsearch CSV report
             if rows[0] != self.new()[0]:
-                raise Exception
+                raise RuntimeError("CSV report generation failed")
 
             return rows
 

--- a/lib/report/sqlite_report.py
+++ b/lib/report/sqlite_report.py
@@ -47,6 +47,6 @@ class SQLiteReport(SQLReportMixin, BaseReport):
         try:
             conn.cursor().execute("PRAGMA integrity_check")
         except sqlite3.DatabaseError:
-            raise Exception(f"{file} is not empty or is not a SQLite database")
+            raise ValueError(f"{file} is not empty or is not a valid SQLite database")
         else:
             return conn


### PR DESCRIPTION
Fix 4 instances of bare raise Exception (2 with no message at all). Replace with descriptive RuntimeError and ValueError.