### PR TITLE
Improve exception handling

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@
 - [Xeonacid](https://github.com/Xeonacid)
 - [Valentijn Scholten](https://www.github.com/valentijnscholten)
 - [partoneplay](https://github.com/partoneplay)
+- [mshzy](https://github.com/mshzy)
 
 
 Special thanks to all the people who are named here!

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -192,9 +192,9 @@ class Controller:
                 try:
                     FileUtils.create_dir(FileUtils.parent(options["log_file"]))
                     if not FileUtils.can_write(options["log_file"]):
-                        raise Exception
+                        raise OSError(f'Cannot write log file: {options["log_file"]}')
                     enable_logging()
-                except Exception:
+                except OSError:
                     interface.error(
                         f'Couldn\'t create log file at {options["log_file"]}'
                     )
@@ -292,11 +292,11 @@ class Controller:
             try:
                 FileUtils.create_dir(FileUtils.parent(options["log_file"]))
                 if not FileUtils.can_write(options["log_file"]):
-                    raise Exception
+                    raise OSError(f'Cannot write log file: {options["log_file"]}')
 
                 enable_logging()
 
-            except Exception:
+            except OSError:
                 interface.error(
                     f'Couldn\'t create log file at {options["log_file"]}'
                 )
@@ -406,7 +406,7 @@ class Controller:
                     shutil.rmtree(options["session_file"])
                 else:
                     os.remove(options["session_file"])
-            except Exception:
+            except OSError:
                 interface.error("Failed to delete old session file, remove it to free some space")
 
     def start(self) -> None:

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -46,6 +46,7 @@ from lib.core.wordlist_backend import WORDLIST_BACKENDS
 from lib.parse.cmdline import parse_arguments
 from lib.parse.config import ConfigParser
 from lib.parse.headers import HeadersParser
+from lib.utils import safe_xml
 from lib.utils.common import iprange, read_stdin, strip_and_uniquify
 from lib.utils.file import File, FileUtils
 from lib.parse.nmap import parse_nmap
@@ -138,7 +139,13 @@ def parse_options() -> dict[str, Any]:
     elif opt.nmap_report:
         try:
             opt.urls = parse_nmap(opt.nmap_report)
-        except Exception as e:
+        except (
+            OSError,
+            AttributeError,
+            TypeError,
+            safe_xml.ParseError,
+            safe_xml.UnsafeXML,
+        ) as e:
             print("Error while parsing Nmap report: " + str(e))
             sys.exit(1)
     elif not opt.urls and not opt.wordlist_status:
@@ -201,14 +208,14 @@ def parse_options() -> dict[str, Any]:
         try:
             fd = _access_file(opt.headers_file)
             headers.update(dict(HeadersParser(fd.read())))
-        except Exception as e:
+        except (OSError, UnicodeError, ValueError) as e:
             print("Error in headers file: " + str(e))
             sys.exit(1)
 
     if opt.headers:
         try:
             headers.update(dict(HeadersParser("\n".join(opt.headers))))
-        except Exception:
+        except (UnicodeError, ValueError):
             print("Invalid headers")
             sys.exit(1)
 

--- a/lib/parse/rawrequest.py
+++ b/lib/parse/rawrequest.py
@@ -43,8 +43,8 @@ def parse_raw(raw_file: str) -> tuple[list[str], str, dict[str, str], str | None
         host = headers.get("host")
     except KeyError:
         raise InvalidRawRequest("Can't find the Host header in the raw request")
-    except Exception as e:
+    except (IndexError, UnicodeError, ValueError) as e:
         logger.exception(e)
-        raise InvalidRawRequest("The raw request is formatively invalid")
+        raise InvalidRawRequest("The raw request is formatively invalid") from e
 
     return [host + path], method, dict(headers), body

--- a/lib/parse/url.py
+++ b/lib/parse/url.py
@@ -38,5 +38,5 @@ def parse_path(value: str) -> str:
             raise ValueError
 
         return "/".join(url.split("/")[1:])
-    except Exception:
+    except ValueError:
         return lstrip_once(value, "/")

--- a/lib/report/csv_report.py
+++ b/lib/report/csv_report.py
@@ -34,7 +34,10 @@ class CSVReport(FileReportMixin, BaseReport):
             rows = list(csv.reader(fh, delimiter=",", quotechar='"'))
             # Not a dirsearch CSV report
             if rows[0] != self.new()[0]:
-                raise ValueError(f"{file} is not a dirsearch CSV report")
+                raise ValueError(
+                    f"CSV header mismatch in {file}: expected {self.new()[0]}, "
+                    f"got {rows[0]}"
+                )
 
             return rows
 

--- a/lib/report/csv_report.py
+++ b/lib/report/csv_report.py
@@ -34,7 +34,7 @@ class CSVReport(FileReportMixin, BaseReport):
             rows = list(csv.reader(fh, delimiter=",", quotechar='"'))
             # Not a dirsearch CSV report
             if rows[0] != self.new()[0]:
-                raise Exception
+                raise ValueError(f"{file} is not a dirsearch CSV report")
 
             return rows
 

--- a/lib/report/factory.py
+++ b/lib/report/factory.py
@@ -18,7 +18,6 @@
 
 import sqlite3
 from abc import ABC, abstractmethod
-from xml.etree import ElementTree as ET
 
 from lib.core.decorators import locked
 from lib.core.exceptions import (
@@ -26,6 +25,7 @@ from lib.core.exceptions import (
     FileExistsException,
     InvalidURLException,
 )
+from lib.utils import safe_xml
 from lib.utils.file import FileUtils
 
 
@@ -35,7 +35,8 @@ REPORT_PARSE_ERRORS = (
     KeyError,
     IndexError,
     TypeError,
-    ET.ParseError,
+    safe_xml.ParseError,
+    safe_xml.UnsafeXML,
 )
 
 SQL_CONNECTION_ERRORS = (

--- a/lib/report/factory.py
+++ b/lib/report/factory.py
@@ -16,11 +16,35 @@
 #
 #  Author: Mauro Soria
 
+import sqlite3
 from abc import ABC, abstractmethod
+from xml.etree import ElementTree as ET
 
 from lib.core.decorators import locked
-from lib.core.exceptions import CannotConnectException, FileExistsException
+from lib.core.exceptions import (
+    CannotConnectException,
+    FileExistsException,
+    InvalidURLException,
+)
 from lib.utils.file import FileUtils
+
+
+REPORT_PARSE_ERRORS = (
+    OSError,
+    ValueError,
+    KeyError,
+    IndexError,
+    TypeError,
+    ET.ParseError,
+)
+
+SQL_CONNECTION_ERRORS = (
+    OSError,
+    ValueError,
+    ImportError,
+    sqlite3.DatabaseError,
+    InvalidURLException,
+)
 
 
 class BaseReport(ABC):
@@ -44,8 +68,8 @@ class FileReportMixin:
     def validate(self, file):
         try:
             self.parse(file)
-        except Exception:
-            raise FileExistsException(f"Output file {file} already exists")
+        except REPORT_PARSE_ERRORS as error:
+            raise FileExistsException(f"Output file {file} already exists") from error
 
     def parse(self, file):
         return open(file, "r").read()
@@ -93,8 +117,8 @@ class SQLReportMixin:
     def initiate(self, database, table):
         try:
             conn = self.get_connection(database)
-        except Exception as e:
-            raise CannotConnectException(f"Cannot connect to the SQL database: {str(e)}")
+        except SQL_CONNECTION_ERRORS as e:
+            raise CannotConnectException(f"Cannot connect to the SQL database: {str(e)}") from e
 
         cursor = conn.cursor()
 

--- a/lib/report/mysql_report.py
+++ b/lib/report/mysql_report.py
@@ -39,14 +39,17 @@ class MySQLReport(SQLReportMixin, BaseReport):
         from mysql.connector.constants import SQLMode
 
         parsed = urlparse(url)
-        conn = mysql.connector.connect(
-            host=parsed.hostname,
-            port=parsed.port or 3306,
-            user=parsed.username,
-            password=parsed.password,
-            database=parsed.path.lstrip("/"),
-            connection_timeout=DB_CONNECTION_TIMEOUT,
-        )
+        try:
+            conn = mysql.connector.connect(
+                host=parsed.hostname,
+                port=parsed.port or 3306,
+                user=parsed.username,
+                password=parsed.password,
+                database=parsed.path.lstrip("/"),
+                connection_timeout=DB_CONNECTION_TIMEOUT,
+            )
+        except mysql.connector.Error as error:
+            raise OSError(str(error)) from error
         conn.sql_mode = [SQLMode.ANSI_QUOTES]
 
         return conn

--- a/lib/report/postgresql_report.py
+++ b/lib/report/postgresql_report.py
@@ -35,4 +35,7 @@ class PostgreSQLReport(SQLReportMixin, BaseReport):
 
         import psycopg
 
-        return psycopg.connect(url, connect_timeout=DB_CONNECTION_TIMEOUT)
+        try:
+            return psycopg.connect(url, connect_timeout=DB_CONNECTION_TIMEOUT)
+        except psycopg.Error as error:
+            raise OSError(str(error)) from error

--- a/lib/report/sqlite_report.py
+++ b/lib/report/sqlite_report.py
@@ -46,7 +46,9 @@ class SQLiteReport(SQLReportMixin, BaseReport):
         # Check if the file is a proper sqlite database
         try:
             conn.cursor().execute("PRAGMA integrity_check")
-        except sqlite3.DatabaseError:
-            raise Exception(f"{file} is not empty or is not a SQLite database")
+        except sqlite3.DatabaseError as error:
+            raise ValueError(
+                f"{file} is not empty or is not a valid SQLite database"
+            ) from error
         else:
             return conn

--- a/lib/utils/schemedet.py
+++ b/lib/utils/schemedet.py
@@ -33,7 +33,7 @@ def detect_scheme(host, port):
     try:
         conn.connect((host, port))
         return "https"
-    except Exception:
+    except OSError:
         return "http"
     finally:
         conn.close()

--- a/tests/test_report_exception_handling.py
+++ b/tests/test_report_exception_handling.py
@@ -1,0 +1,49 @@
+import sqlite3
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from lib.core.exceptions import FileExistsException, InvalidRawRequest
+from lib.parse.rawrequest import parse_raw
+from lib.report.csv_report import CSVReport
+from lib.report.sqlite_report import SQLiteReport
+
+
+class TestReportExceptionHandling(TestCase):
+    def test_csv_report_rejects_wrong_header(self):
+        with TemporaryDirectory() as directory:
+            report = Path(directory, "report.csv")
+            report.write_text("Not,Dirsearch\n")
+
+            with self.assertRaisesRegex(ValueError, "dirsearch CSV report"):
+                CSVReport().parse(str(report))
+
+    def test_file_report_validation_chains_parse_error(self):
+        with TemporaryDirectory() as directory:
+            report = Path(directory, "report.csv")
+            report.write_text("Not,Dirsearch\n")
+
+            with self.assertRaises(FileExistsException) as context:
+                CSVReport().initiate(str(report))
+
+        self.assertIsInstance(context.exception.__cause__, ValueError)
+
+    def test_sqlite_report_rejects_non_sqlite_file(self):
+        with TemporaryDirectory() as directory:
+            database = Path(directory, "report.sqlite")
+            database.write_text("not sqlite")
+
+            with self.assertRaisesRegex(ValueError, "valid SQLite database") as context:
+                SQLiteReport().connect(str(database))
+
+        self.assertIsInstance(context.exception.__cause__, sqlite3.DatabaseError)
+
+    def test_raw_request_malformed_input_preserves_invalid_request_type(self):
+        with TemporaryDirectory() as directory:
+            request = Path(directory, "request.txt")
+            request.write_text("\n")
+
+            with self.assertRaises(InvalidRawRequest) as context:
+                parse_raw(str(request))
+
+        self.assertIsInstance(context.exception.__cause__, IndexError)

--- a/tests/test_report_exception_handling.py
+++ b/tests/test_report_exception_handling.py
@@ -15,7 +15,7 @@ class TestReportExceptionHandling(TestCase):
             report = Path(directory, "report.csv")
             report.write_text("Not,Dirsearch\n")
 
-            with self.assertRaisesRegex(ValueError, "dirsearch CSV report"):
+            with self.assertRaisesRegex(ValueError, "CSV header mismatch.*expected.*got"):
                 CSVReport().parse(str(report))
 
     def test_file_report_validation_chains_parse_error(self):


### PR DESCRIPTION
## Summary
- replace bare/generic raised exceptions with domain-appropriate built-in exceptions
- narrow clear parser/report/option exception wrappers and preserve causes with exception chaining
- keep defensive broad catches at runtime fail-safe boundaries
- add regression coverage for report validation, SQLite validation, and raw request parse failures

## Validation
- `git diff --check`
- `/home/mauro/dirsearch/.venv/bin/python -m py_compile lib/controller/controller.py lib/core/options.py lib/parse/rawrequest.py lib/parse/url.py lib/report/csv_report.py lib/report/factory.py lib/report/mysql_report.py lib/report/postgresql_report.py lib/report/sqlite_report.py lib/utils/schemedet.py tests/test_report_exception_handling.py`
- `/home/mauro/dirsearch/.venv/bin/python -m unittest tests.test_report_exception_handling tests.test_optional_db_dependencies tests.parse.test_nmap tests.utils.test_safe_xml tests.parse.test_url tests.utils.test_schemedet`
- `/home/mauro/dirsearch/.venv/bin/python dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q`

Known existing issue: `/home/mauro/dirsearch/.venv/bin/python testing.py` still fails in the native backend path with `scan_http() got an unexpected keyword argument 'include_status_codes'`.