### PR TITLE
fix: improve exception handling with domain-specific types (closes #1563)

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -192,7 +192,9 @@ class Controller:
                 try:
                     FileUtils.create_dir(FileUtils.parent(options["log_file"]))
                     if not FileUtils.can_write(options["log_file"]):
-                        raise Exception
+                        raise OSError(
+                            f"Cannot write to log file: {options['log_file']}"
+                        )
                     enable_logging()
                 except Exception:
                     interface.error(
@@ -292,7 +294,9 @@ class Controller:
             try:
                 FileUtils.create_dir(FileUtils.parent(options["log_file"]))
                 if not FileUtils.can_write(options["log_file"]):
-                    raise Exception
+                    raise OSError(
+                        f"Cannot write to log file: {options['log_file']}"
+                    )
 
                 enable_logging()
 

--- a/lib/report/csv_report.py
+++ b/lib/report/csv_report.py
@@ -34,7 +34,10 @@ class CSVReport(FileReportMixin, BaseReport):
             rows = list(csv.reader(fh, delimiter=",", quotechar='"'))
             # Not a dirsearch CSV report
             if rows[0] != self.new()[0]:
-                raise Exception
+                raise ValueError(
+                    f"CSV header mismatch: expected {self.new()[0]}, "
+                    f"got {rows[0]}"
+                )
 
             return rows
 

--- a/lib/report/sqlite_report.py
+++ b/lib/report/sqlite_report.py
@@ -46,7 +46,9 @@ class SQLiteReport(SQLReportMixin, BaseReport):
         # Check if the file is a proper sqlite database
         try:
             conn.cursor().execute("PRAGMA integrity_check")
-        except sqlite3.DatabaseError:
-            raise Exception(f"{file} is not empty or is not a SQLite database")
+        except sqlite3.DatabaseError as e:
+            raise sqlite3.DatabaseError(
+                f"{file} is not empty or is not a valid SQLite database"
+            ) from e
         else:
             return conn

--- a/tests/test_report_exception_handling.py
+++ b/tests/test_report_exception_handling.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import tempfile
+import unittest
+import sqlite3
+
+# dirsearch uses relative imports; add parent to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestCSVReportExceptions(unittest.TestCase):
+    """Verify CSV report raises domain-specific exceptions on invalid input."""
+
+    def setUp(self):
+        from lib.report.csv_report import CSVReport
+        self.report = CSVReport()
+
+    def test_header_mismatch_raises_valueerror(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as f:
+            f.write("Wrong,Header,Format\n")
+            f.write("data,200,100,text/html,,0.1\n")
+            csv_path = f.name
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                self.report.parse(csv_path)
+            self.assertIn("CSV header mismatch", str(ctx.exception))
+        finally:
+            os.unlink(csv_path)
+
+    def test_valid_csv_parses_correctly(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False
+        ) as f:
+            f.write("URL,Status,Size,Content Type,Redirection,Elapsed (s)\n")
+            f.write("https://example.com,200,1234,text/html,,0.05\n")
+            csv_path = f.name
+        try:
+            rows = self.report.parse(csv_path)
+            self.assertEqual(len(rows), 2)
+        finally:
+            os.unlink(csv_path)
+
+
+class TestSQLiteReportExceptions(unittest.TestCase):
+    """Verify SQLite report raises domain-specific exceptions on invalid input."""
+
+    def setUp(self):
+        from lib.report.sqlite_report import SQLiteReport
+        self.report = SQLiteReport()
+
+    def test_corrupt_file_raises_databaseerror(self):
+        db_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".db", delete=False
+            ) as f:
+                f.write("this is not a sqlite database file\n")
+                db_path = f.name
+            with self.assertRaises(sqlite3.DatabaseError) as ctx:
+                self.report.connect(db_path)
+            self.assertIn("not a valid SQLite database", str(ctx.exception))
+        finally:
+            if db_path:
+                try:
+                    os.unlink(db_path)
+                except OSError:
+                    pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix: improve exception handling with domain-specific types (closes #1563)

Replace bare/generic exceptions with domain-appropriate built-in types
and add descriptive error messages:

- controller.py: raise OSError with log file path on write failure
- csv_report.py: raise ValueError with expected vs actual CSV header
- sqlite_report.py: raise sqlite3.DatabaseError with exception chaining (from e)
- Preserve defensive broad `except Exception` at runtime fail-safe boundaries
- Add regression tests for CSV header validation and SQLite integrity check