### PR TITLE
Improve native Rust install UX

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -31,7 +31,7 @@ Requirements:
 
 - Python 3.14 for release-equivalent builds.
 - PyInstaller 6.20.0.
-- Rust and maturin when building `native-rust`.
+- Rust when building `native-rust`; build scripts install maturin as needed.
 
 Native Rust builds use `scripts/build_native.py` to build one wheel, install that exact wheel path, and verify `import dirsearch_native`. This avoids shell-specific wildcard behavior on Windows and keeps Docker, PyInstaller, and portable builds on the same path. The native wheel is packaged with `requires-python >=3.14` and PyO3 `cp313-abi3`, the highest stable ABI feature available in PyO3 0.24 for Python 3.14 release builds.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,16 +31,16 @@ python3 dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q
 
 ## Choose an Install Path
 
-- Use release artifacts when you do not want to compile anything. Single-file PyInstaller binaries and portable archives with bundled dependencies are available for Windows x64, Linux x64, Linux ARM64, macOS Intel, and macOS Apple Silicon.
-- Use `pip install git+https://github.com/maurosoria/dirsearch.git` when you want the Python stack from the current GitHub source. This does not compile the Rust native backend.
-- Use the native source build steps when you want `--request-backend native` and `--wordlist-backend native` from a source checkout.
-- Use the `native-rust` release artifact when you want the Rust backend without installing a Rust toolchain.
+- Use release artifacts when you do not want to compile anything. Single-file PyInstaller binaries and portable archives are available for Windows x64, Linux x64, Linux ARM64, macOS Intel, and macOS Apple Silicon.
+- Use the Python-only pip install when you want the current GitHub source and the default Python request backend. This works on Python 3.11-3.14 and does not compile the Rust native engine.
+- Use the native Rust pip install when you want `--request-backend native` or `--wordlist-backend native`. This requires Python 3.14, Rust/Cargo, Python development headers, and a C compiler.
+- Use the source checkout build only when developing or producing release artifacts. Normal native installs do not require manually cloning the repository.
 
-## Platform Setup
+## Python-Only Install from GitHub
+
+Requirement: Python 3.11 or higher.
 
 ### Ubuntu and Debian, amd64 or arm64
-
-Install prerequisites for the Python stack:
 
 ```sh
 sudo apt-get update
@@ -52,19 +52,7 @@ python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
 dirsearch --version
 ```
 
-Add these packages before building the native Rust backend:
-
-```sh
-sudo apt-get install -y build-essential curl python3-dev
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-. "$HOME/.cargo/env"
-```
-
-Use Linux `x64` release assets on amd64 and Linux `arm64` release assets on ARM64/aarch64.
-
 ### Red Hat and Fedora, amd64 or arm64
-
-Install prerequisites for the Python stack:
 
 ```sh
 sudo dnf install -y git ca-certificates python3 python3-pip
@@ -75,106 +63,104 @@ python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
 dirsearch --version
 ```
 
-Add these packages before building the native Rust backend:
+## Native Rust Install from GitHub
+
+Requirement: Python 3.14 or higher. The native engine is not built by the normal `pip install git+...` command; build it explicitly with `dirsearch-build-native` after installing dirsearch into the same virtual environment.
+
+### Ubuntu and Debian, amd64 or arm64
 
 ```sh
-sudo dnf install -y gcc gcc-c++ make curl python3-devel
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-. "$HOME/.cargo/env"
+sudo apt-get update
+sudo apt-get install -y \
+  git ca-certificates build-essential \
+  python3.14 python3.14-venv python3.14-dev \
+  cargo rustc
+
+python3.14 -m venv ~/.venvs/dirsearch-native
+. ~/.venvs/dirsearch-native/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch-build-native
+
+printf 'admin
+login
+' > /tmp/dirsearch-wordlist.txt
+dirsearch -u https://example.com -w /tmp/dirsearch-wordlist.txt \
+  --request-backend native --wordlist-backend native -q
 ```
 
-If your distribution splits Python by minor version, install the matching `python3.x-devel` package for the interpreter used by the virtual environment. Use Linux `x64` release assets on amd64 and Linux `arm64` release assets on ARM64/aarch64.
+If your Ubuntu or Debian release does not package Python 3.14 yet, install Python 3.14 from your platform's supported Python distribution or use a prebuilt `native-rust` release artifact instead.
+
+### Red Hat and Fedora, amd64 or arm64
+
+```sh
+sudo dnf install -y \
+  git ca-certificates gcc gcc-c++ make \
+  python3.14 python3.14-devel \
+  cargo rust
+
+python3.14 -m venv ~/.venvs/dirsearch-native
+. ~/.venvs/dirsearch-native/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch-build-native
+
+printf 'admin
+login
+' > /tmp/dirsearch-wordlist.txt
+dirsearch -u https://example.com -w /tmp/dirsearch-wordlist.txt \
+  --request-backend native --wordlist-backend native -q
+```
+
+If your Red Hat-compatible distribution does not package Python 3.14 yet, install Python 3.14 from your platform's supported Python distribution or use a prebuilt `native-rust` release artifact instead.
 
 ### macOS 26, Apple Silicon or Intel, with Homebrew
 
-Install prerequisites for the Python stack:
-
 ```sh
-brew install python git
-python3 -m venv ~/.venvs/dirsearch
-. ~/.venvs/dirsearch/bin/activate
+brew install python git rust
+python3.14 -m venv ~/.venvs/dirsearch-native
+. ~/.venvs/dirsearch-native/bin/activate
 python -m pip install --upgrade pip
 python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
-dirsearch --version
+dirsearch-build-native
 ```
-
-Add these tools before building the native Rust backend:
-
-```sh
-xcode-select --install
-brew install rust
-```
-
-Use macOS `silicon` release assets on Apple Silicon and macOS `intel` release assets on Intel.
-
-### macOS 26, Apple Silicon or Intel, without Homebrew
-
-Install Apple's command line tools, Python 3.11 or newer from python.org, and Rust from rustup:
-
-```sh
-xcode-select --install
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-. "$HOME/.cargo/env"
-python3 -m venv ~/.venvs/dirsearch
-. ~/.venvs/dirsearch/bin/activate
-python -m pip install --upgrade pip
-python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
-dirsearch --version
-```
-
-Use the same virtual environment for the native Rust build steps below.
 
 ### Windows 10 and 11, x64
 
 For no-compile installs, download the Windows x64 PyInstaller `.exe` or portable `.zip` from the Releases page. The portable archive bundles dependencies and can be preferable when antivirus software flags PyInstaller bootloaders.
 
-For the Python stack, install Python 3.11 or newer for x64 and Git for Windows, then run PowerShell:
+Before building the native Rust backend, install Python 3.14 for x64, Git for Windows, Microsoft C++ Build Tools with the Desktop development with C++ workload and a Windows SDK, then install Rust through rustup. If `winget` is unavailable, download and run `rustup-init.exe` from rustup.rs.
 
 ```powershell
-py -3 -m venv .venv
+winget install --id Python.Python.3.14 -e
+winget install --id Rustlang.Rustup -e
+py -3.14 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
 python -m pip install "git+https://github.com/maurosoria/dirsearch.git"
+dirsearch-build-native
 dirsearch --version
 ```
 
-Before building the native Rust backend, install Microsoft C++ Build Tools with the Desktop development with C++ workload and a Windows SDK, then install Rust through rustup. If `winget` is unavailable, download and run `rustup-init.exe` from rustup.rs.
+Open a new PowerShell session if `rustup`, `cargo`, or `dirsearch-build-native` is not found immediately after installation.
 
-```powershell
-winget install --id Rustlang.Rustup -e
-rustup default stable
-python -m pip install maturin
-```
+## Native Rust from a Source Checkout
 
-Open a new PowerShell session if `rustup` is not found immediately after installation.
-
-## Native Rust from Source
-
-The GitHub pip command installs the Python stack only. To build the Rust native request and wordlist backends from source, use Python 3.14, install Rust and `maturin`, then build the native wheel from a clone:
+Use this path when developing dirsearch or building release artifacts from a clone. Normal users can install from GitHub with pip and run `dirsearch-build-native` instead.
 
 ```sh
 git clone https://github.com/maurosoria/dirsearch.git --depth 1
 cd dirsearch
-python3.14 -m pip install .
-python3.14 -m pip install maturin
-python3.14 scripts/build_native.py --out dist/native-wheels
-dirsearch -u https://example.com -w tests/static/wordlist.txt --request-backend native --wordlist-backend native -q
-```
-
-On Windows PowerShell, use backslashes for local paths:
-
-```powershell
-git clone https://github.com/maurosoria/dirsearch.git --depth 1
-cd dirsearch
-py -3.14 -m venv .venv
-.\.venv\Scripts\Activate.ps1
+python3.14 -m venv .venv-native
+. .venv-native/bin/activate
+python -m pip install --upgrade pip
 python -m pip install .
-python -m pip install maturin
-python scripts\build_native.py --out dist\native-wheels
-dirsearch -u https://example.com -w tests\static\wordlist.txt --request-backend native --wordlist-backend native -q
+python scripts/build_native.py --out dist/native-wheels
+python dirsearch.py -u https://example.com -w tests/static/wordlist.txt \
+  --request-backend native --wordlist-backend native -q
 ```
 
-Without the native wheel, source installs keep the Python request backend and automatic Python wordlist fallback defaults.
+Without the native engine, source installs keep the Python request backend and automatic Python wordlist fallback defaults.
 
 Optional MySQL and PostgreSQL report dependencies are separate from the scanner runtime. Install them only when needed:
 

--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -6,6 +6,7 @@ from typing import Any
 from lib.connection.response import NativeResponse
 from lib.core.data import options
 from lib.core.exceptions import RequestException
+from lib.core.native_runtime import get_native_backend_install_error
 from lib.core.settings import MAX_RESPONSE_SIZE
 from lib.utils.common import safequote
 
@@ -15,10 +16,7 @@ class NativeHTTPBackend:
         try:
             import dirsearch_native
         except ImportError as e:
-            raise RequestException(
-                "Native request backend is not available. "
-                "Build it with: python3 -m maturin develop --manifest-path native/Cargo.toml"
-            ) from e
+            raise RequestException(get_native_backend_install_error()) from e
 
         self._native = dirsearch_native
 

--- a/lib/core/native_builder.py
+++ b/lib/core/native_builder.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from lib.core.native_runtime import (
+    MIN_NATIVE_PYTHON,
+    format_python_version,
+    get_native_python_version_error,
+)
+
+
+NATIVE_SOURCE_FILES = (
+    "pyproject.toml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "src/lib.rs",
+)
+
+
+def package_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def native_source_dir(root: Path | None = None) -> Path:
+    return (root or package_root()) / "native"
+
+
+def read_os_release(path: Path = Path("/etc/os-release")) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        values[key] = value.strip().strip('"')
+
+    return values
+
+
+def install_hint(os_release: dict[str, str] | None = None) -> str:
+    release = os_release if os_release is not None else read_os_release()
+    distro_ids = {
+        release.get("ID", "").lower(),
+        *release.get("ID_LIKE", "").lower().split(),
+    }
+
+    if distro_ids & {"ubuntu", "debian"}:
+        return (
+            "Ubuntu/Debian prerequisites: sudo apt-get install -y "
+            "build-essential python3.14-dev cargo rustc"
+        )
+    if distro_ids & {"fedora", "rhel", "centos"}:
+        return (
+            "Fedora/Red Hat prerequisites: sudo dnf install -y "
+            "gcc gcc-c++ make python3.14-devel cargo rust"
+        )
+
+    return (
+        "Install Python 3.14 development headers, Rust/Cargo, and a C compiler "
+        "with your system package manager."
+    )
+
+
+def python_headers_available() -> bool:
+    include_dir = sysconfig.get_config_var("INCLUDEPY")
+    if not include_dir:
+        return False
+
+    return Path(include_dir, "Python.h").exists()
+
+
+def pip_available() -> bool:
+    return (
+        subprocess.run(
+            [sys.executable, "-m", "pip", "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def native_sources_available(source_dir: Path) -> bool:
+    return all((source_dir / file_name).is_file() for file_name in NATIVE_SOURCE_FILES)
+
+
+def get_prerequisite_errors(
+    source_dir: Path | None = None,
+    version_info: Sequence[int] | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+    has_pip: bool | None = None,
+    has_python_headers: bool | None = None,
+) -> list[str]:
+    errors: list[str] = []
+
+    if version_error := get_native_python_version_error(version_info):
+        errors.append(version_error)
+
+    source = source_dir or native_source_dir()
+    if not native_sources_available(source):
+        errors.append(
+            "Native Rust sources are missing from this installation. "
+            "Reinstall dirsearch from the latest package or GitHub source."
+        )
+
+    if has_pip is None:
+        has_pip = pip_available()
+    if not has_pip:
+        errors.append(f"pip is not available for Python {format_python_version()}.")
+
+    for command in ("cargo", "rustc"):
+        if which(command) is None:
+            errors.append(f"Required command not found: {command}")
+
+    if not any(which(command) for command in ("cc", "gcc", "clang")):
+        errors.append("Required C compiler not found: cc, gcc, or clang")
+
+    if has_python_headers is None:
+        has_python_headers = python_headers_available()
+    if not has_python_headers:
+        major, minor = MIN_NATIVE_PYTHON
+        errors.append(
+            f"Python development headers not found for Python {major}.{minor}."
+        )
+
+    return errors
+
+
+def copy_native_sources(source_dir: Path, build_root: Path) -> Path:
+    destination = build_root / "native"
+    shutil.copytree(
+        source_dir,
+        destination,
+        ignore=shutil.ignore_patterns("target", "__pycache__", "*.pyc"),
+    )
+    return destination
+
+
+def run(command: list[str]) -> None:
+    print("+ " + shlex.join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def build_native_engine(source_dir: Path, force_reinstall: bool = True) -> None:
+    with tempfile.TemporaryDirectory(prefix="dirsearch-native-build-") as temp_dir:
+        build_source = copy_native_sources(source_dir, Path(temp_dir))
+        command = [sys.executable, "-m", "pip", "install"]
+        if force_reinstall:
+            command.append("--force-reinstall")
+        command.append(str(build_source))
+
+        run(command)
+
+    run([sys.executable, "-c", "import dirsearch_native"])
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build and install the dirsearch native Rust engine"
+    )
+    parser.add_argument(
+        "--no-force-reinstall",
+        action="store_true",
+        help="Do not pass --force-reinstall to pip",
+    )
+    args = parser.parse_args(argv)
+
+    source_dir = native_source_dir()
+    errors = get_prerequisite_errors(source_dir=source_dir)
+    if errors:
+        print("Cannot build dirsearch native Rust engine:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print(install_hint(), file=sys.stderr)
+        return 1
+
+    try:
+        build_native_engine(
+            source_dir,
+            force_reinstall=not args.no_force_reinstall,
+        )
+    except subprocess.CalledProcessError as error:
+        return error.returncode
+    except OSError as error:
+        print(f"Native Rust engine build failed: {error}", file=sys.stderr)
+        return 1
+
+    print("Native Rust engine installed: dirsearch_native", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/core/native_runtime.py
+++ b/lib/core/native_runtime.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Sequence
+
+
+MIN_NATIVE_PYTHON = (3, 14)
+
+
+def format_python_version(version_info: Sequence[int] | None = None) -> str:
+    version = version_info or sys.version_info
+    return ".".join(str(part) for part in version[:3])
+
+
+def get_native_python_version_error(
+    version_info: Sequence[int] | None = None,
+) -> str | None:
+    version = version_info or sys.version_info
+    if tuple(version[:2]) >= MIN_NATIVE_PYTHON:
+        return None
+
+    return (
+        "Native Rust backend requires Python 3.14 or newer "
+        f"(current: Python {format_python_version(version)}). "
+        "Create a Python 3.14 environment, install dirsearch there, "
+        "then run: dirsearch-build-native"
+    )
+
+
+def is_native_backend_available() -> bool:
+    return importlib.util.find_spec("dirsearch_native") is not None
+
+
+def get_native_backend_install_error(
+    version_info: Sequence[int] | None = None,
+) -> str:
+    version_error = get_native_python_version_error(version_info)
+    if version_error:
+        return version_error
+
+    return (
+        "Native Rust backend is not installed in this Python environment. "
+        "Install dirsearch, then compile the native engine with: "
+        "dirsearch-build-native. "
+        "The build requires Python 3.14 development headers, Rust/Cargo, "
+        "and a C compiler."
+    )
+
+
+def get_native_runtime_error(
+    request_backend: str = "python",
+    wordlist_backend: str = "auto",
+    version_info: Sequence[int] | None = None,
+) -> str | None:
+    if request_backend != "native" and wordlist_backend != "native":
+        return None
+
+    version_error = get_native_python_version_error(version_info)
+    if version_error:
+        return version_error
+
+    if not is_native_backend_available():
+        return get_native_backend_install_error(version_info)
+
+    return None

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -37,6 +37,10 @@ from lib.core.request_backend import (
     REQUEST_BACKENDS,
     get_native_request_backend_error,
 )
+from lib.core.native_runtime import (
+    get_native_python_version_error,
+    get_native_runtime_error,
+)
 from lib.core.filters import (
     parse_numeric_ranges,
     parse_time_filters,
@@ -177,6 +181,12 @@ def parse_options() -> dict[str, Any]:
 
     if opt.request_backend not in REQUEST_BACKENDS:
         print("--request-backend must be one of: " + ", ".join(REQUEST_BACKENDS))
+        sys.exit(1)
+
+    if (
+        opt.request_backend == "native" or opt.wordlist_backend == "native"
+    ) and (error := get_native_python_version_error()):
+        print(error)
         sys.exit(1)
 
     if opt.tor:
@@ -345,6 +355,12 @@ def parse_options() -> dict[str, Any]:
         if error := get_native_request_backend_error(opt):
             print(error)
             sys.exit(1)
+
+    if error := get_native_runtime_error(
+        opt.request_backend, opt.wordlist_backend
+    ):
+        print(error)
+        sys.exit(1)
 
     return vars(opt)
 

--- a/lib/core/wordlist_backend.py
+++ b/lib/core/wordlist_backend.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from lib.core.data import options
 from lib.core.exceptions import WordlistBackendUnavailableError, WordlistLimitError
+from lib.core.native_runtime import get_native_backend_install_error
 from lib.core.settings import (
     EXCLUDE_OVERWRITE_EXTENSIONS,
     EXTENSION_RECOGNITION_REGEX,
@@ -136,10 +137,7 @@ class NativeWordlistBackend:
         try:
             import dirsearch_native
         except ImportError as e:
-            raise WordlistBackendUnavailableError(
-                "Native wordlist backend is not available. "
-                "Build it with: python3 -m maturin develop --manifest-path native/Cargo.toml"
-            ) from e
+            raise WordlistBackendUnavailableError(get_native_backend_install_error()) from e
 
         self._native = dirsearch_native
 

--- a/native/README.md
+++ b/native/README.md
@@ -14,16 +14,22 @@ lightweight events with metadata and an empty body so Python can keep progress
 and not-found callbacks authoritative. Native regex matching uses Rust's
 `regex` crate; patterns unsupported by that engine fail before the scan starts.
 
-Build locally with a Rust toolchain and maturin:
+Build the native engine from an installed dirsearch package with Python 3.14,
+Rust/Cargo, Python development headers, and a C compiler:
 
 ```sh
-python3.14 -m pip install maturin
+dirsearch-build-native
+```
+
+For development from a source checkout, use the repository helper:
+
+```sh
 python3.14 scripts/build_native.py --out dist/native-wheels
 ```
 
-The helper installs the exact built wheel and verifies `import dirsearch_native`.
+Both helpers install the exact built wheel and verify `import dirsearch_native`.
 Release-equivalent native wheels target Python 3.14 and PyO3's `cp313-abi3`
-stable ABI.
+stable ABI. `maturin` is pulled by pip/build scripts from `native/pyproject.toml`.
 
 The benchmark summary for this backend is in
 [`docs/native-backend-benchmarks.md`](../docs/native-backend-benchmarks.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dynamic = ["version", "dependencies"]
 
 [project.scripts]
 dirsearch = "dirsearch.dirsearch:main"
+dirsearch-build-native = "dirsearch.lib.core.native_builder:main"
 
 [project.optional-dependencies]
 mysql = ["mysql-connector-python==9.6.0"]

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ shutil.copytree(
         ".venv",
         "build",
         "dist",
+        "target",
         "__pycache__",
         "*.pyc",
         "*.pyo",
@@ -107,12 +108,18 @@ setuptools.setup(
         "postgresql": ["psycopg[binary]==3.3.3"],
         "db": read_requirements(ROOT / "requirements/db.txt"),
     },
-    entry_points={"console_scripts": ["dirsearch=dirsearch.dirsearch:main"]},
+    entry_points={
+        "console_scripts": [
+            "dirsearch=dirsearch.dirsearch:main",
+            "dirsearch-build-native=dirsearch.lib.core.native_builder:main",
+        ]
+    },
     packages=setuptools.find_packages(exclude=("dirsearch.tests", "dirsearch.tests.*")),
     package_data={
         "dirsearch": [
             "config.ini",
             *package_files(package_root / "db"),
+            *package_files(package_root / "native"),
         ],
         "dirsearch.lib.report": ["templates/*.html"],
     },

--- a/tests/core/test_native_builder.py
+++ b/tests/core/test_native_builder.py
@@ -1,0 +1,73 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from lib.core.native_builder import (
+    NATIVE_SOURCE_FILES,
+    get_prerequisite_errors,
+    install_hint,
+    native_sources_available,
+)
+
+
+def create_native_source_tree(root: Path) -> Path:
+    source = root / "native"
+    for file_name in NATIVE_SOURCE_FILES:
+        path = source / file_name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+    return source
+
+
+class TestNativeBuilder(TestCase):
+    def test_native_sources_available_requires_all_files(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = create_native_source_tree(Path(directory))
+
+            self.assertTrue(native_sources_available(source))
+
+            (source / "Cargo.lock").unlink()
+
+            self.assertFalse(native_sources_available(source))
+
+    def test_prerequisite_errors_report_missing_commands_and_headers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = create_native_source_tree(Path(directory))
+            errors = get_prerequisite_errors(
+                source_dir=source,
+                version_info=(3, 14, 0),
+                which=lambda _: None,
+                has_pip=True,
+                has_python_headers=False,
+            )
+
+        self.assertIn("Required command not found: cargo", errors)
+        self.assertIn("Required command not found: rustc", errors)
+        self.assertIn("Required C compiler not found: cc, gcc, or clang", errors)
+        self.assertIn("Python development headers not found for Python 3.14.", errors)
+
+    def test_prerequisite_errors_report_python_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = create_native_source_tree(Path(directory))
+            errors = get_prerequisite_errors(
+                source_dir=source,
+                version_info=(3, 12, 3),
+                which=lambda _: "/usr/bin/tool",
+                has_pip=True,
+                has_python_headers=True,
+            )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("requires Python 3.14 or newer", errors[0])
+
+    def test_install_hint_for_debian_like_systems(self):
+        hint = install_hint({"ID": "debian", "ID_LIKE": ""})
+
+        self.assertIn("apt-get install", hint)
+        self.assertIn("python3.14-dev", hint)
+
+    def test_install_hint_for_fedora_like_systems(self):
+        hint = install_hint({"ID": "fedora", "ID_LIKE": ""})
+
+        self.assertIn("dnf install", hint)
+        self.assertIn("python3.14-devel", hint)

--- a/tests/core/test_native_runtime.py
+++ b/tests/core/test_native_runtime.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.core.native_runtime import (
+    get_native_backend_install_error,
+    get_native_python_version_error,
+    get_native_runtime_error,
+)
+
+
+class TestNativeRuntime(TestCase):
+    def test_native_rejects_python_before_314(self):
+        error = get_native_python_version_error((3, 12, 3))
+
+        self.assertIn("requires Python 3.14 or newer", error)
+        self.assertIn("current: Python 3.12.3", error)
+        self.assertIn("dirsearch-build-native", error)
+
+    def test_python_backends_do_not_require_native_module(self):
+        self.assertIsNone(
+            get_native_runtime_error(
+                request_backend="python",
+                wordlist_backend="auto",
+                version_info=(3, 12, 3),
+            )
+        )
+
+    def test_native_reports_missing_engine_on_supported_python(self):
+        with patch("lib.core.native_runtime.is_native_backend_available", return_value=False):
+            error = get_native_runtime_error(
+                request_backend="native",
+                wordlist_backend="native",
+                version_info=(3, 14, 0),
+            )
+
+        self.assertIn("Native Rust backend is not installed", error)
+        self.assertIn("dirsearch-build-native", error)
+
+    def test_native_accepts_installed_engine_on_supported_python(self):
+        with patch("lib.core.native_runtime.is_native_backend_available", return_value=True):
+            self.assertIsNone(
+                get_native_runtime_error(
+                    request_backend="native",
+                    wordlist_backend="native",
+                    version_info=(3, 14, 0),
+                )
+            )
+
+    def test_install_error_uses_python_version_error_first(self):
+        error = get_native_backend_install_error((3, 13, 9))
+
+        self.assertIn("requires Python 3.14 or newer", error)
+        self.assertNotIn("not installed", error)

--- a/tests/test_native_install_packaging.py
+++ b/tests/test_native_install_packaging.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from unittest import TestCase
+
+
+class TestNativeInstallPackaging(TestCase):
+    def test_entrypoints_include_native_builder(self):
+        self.assertIn(
+            'dirsearch-build-native = "dirsearch.lib.core.native_builder:main"',
+            Path("pyproject.toml").read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "dirsearch-build-native=dirsearch.lib.core.native_builder:main",
+            Path("setup.py").read_text(encoding="utf-8"),
+        )
+
+    def test_package_data_includes_native_sources(self):
+        setup_py = Path("setup.py").read_text(encoding="utf-8")
+
+        self.assertIn('*package_files(package_root / "native")', setup_py)
+        self.assertIn('"target"', setup_py)
+
+    def test_install_docs_use_native_builder_flow(self):
+        docs = Path("docs/installation.md").read_text(encoding="utf-8")
+
+        self.assertIn("dirsearch-build-native", docs)
+        self.assertIn("python3.14-dev", docs)
+        self.assertIn("python3.14-devel", docs)
+        self.assertNotIn("maturin develop", docs)


### PR DESCRIPTION
## Summary

Improve the source-install path for the native Rust backend by adding an installed `dirsearch-build-native` helper and clearer runtime diagnostics.

## What changed

- Add `dirsearch-build-native` as a console script that validates prerequisites, copies packaged native sources to a temporary build tree, installs the native package with pip, and verifies `import dirsearch_native`.
- Package the `native/` source tree with source installs while excluding build output such as `target`.
- Add runtime preflight errors for native request and wordlist backends so unsupported Python versions or missing native modules fail with actionable install guidance.
- Update native Rust installation docs to distinguish Python-only installs, native GitHub installs, source checkout builds, and release artifacts.
- Add focused tests for native builder prerequisites, runtime checks, and install packaging metadata.

## Validation

- `/tmp/dirsearch-native-ux-venv/bin/python -m unittest discover tests`
- `/tmp/dirsearch-native-ux-venv/bin/python dirsearch.py -u https://example.com -w tests/static/wordlist.txt --request-backend native -q` exits with the expected Python 3.14 native-backend guidance on Python 3.12.