### PR TITLE
Normalize response size filter units

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -100,7 +100,7 @@ Options:
                         ranges (e.g. 301,500-599)
     --exclude-sizes=SIZES
                         Exclude responses by sizes, separated by commas (e.g.
-                        0B,4KB)
+                        0,0B,4KB)
     --exclude-text=TEXTS
                         Exclude responses by text, can use multiple flags
     --exclude-regex=REGEX
@@ -115,9 +115,9 @@ Options:
                         Skip target whenever hit one of these status codes,
                         separated by commas, support ranges
     --min-response-size=LENGTH
-                        Minimum response length
+                        Minimum response length (e.g. 1024,1KB)
     --max-response-size=LENGTH
-                        Maximum response length
+                        Maximum response length (e.g. 1024,1KB)
     --max-time=SECONDS  Maximum runtime for the scan
     --target-max-time=SECONDS
                         Maximum runtime for a target

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,6 +87,10 @@ dirsearch also performs automatic wildcard and soft-404 calibration. You normall
 python3 dirsearch.py -e php,html,js -u https://target --exclude-sizes 1B,243KB
 ```
 
+Response size filters accept raw bytes without a suffix or readable units such as
+`B`, `KB`, `MB`, and `GB`. The same format works for `--exclude-sizes`,
+`--min-response-size`, and `--max-response-size`.
+
 ```sh
 python3 dirsearch.py -e php,html,js -u https://target --exclude-text "403 Forbidden"
 ```

--- a/lib/core/filters.py
+++ b/lib/core/filters.py
@@ -20,6 +20,18 @@ import re
 
 NumericRange = tuple[int, int]
 TimeFilter = tuple[str, float]
+SIZE_UNITS = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024 ** 2,
+    "GB": 1024 ** 3,
+    "TB": 1024 ** 4,
+    "PB": 1024 ** 5,
+    "EB": 1024 ** 6,
+    "ZB": 1024 ** 7,
+    "YB": 1024 ** 8,
+}
+SIZE_RE = re.compile(r"^(\d+)\s*([KMGTPEZY]?B)?$", re.IGNORECASE)
 
 
 def parse_numeric_ranges(value: str | None) -> tuple[NumericRange, ...]:
@@ -75,6 +87,41 @@ def parse_time_filters(value: str | None) -> tuple[TimeFilter, ...]:
             raise ValueError(f"Invalid time filter: {operator}{token}") from error
 
     return tuple(filters)
+
+
+def parse_size(value: str | int | None) -> int:
+    if value is None or value == "":
+        return 0
+
+    if isinstance(value, int):
+        if value < 0:
+            raise ValueError(f"Invalid response size: {value}")
+        return value
+
+    token = value.strip()
+    if not token:
+        return 0
+
+    match = SIZE_RE.fullmatch(token)
+    if not match:
+        raise ValueError(f"Invalid response size: {value}")
+
+    number, unit = match.groups()
+    multiplier = SIZE_UNITS[(unit or "B").upper()]
+    return int(number) * multiplier
+
+
+def parse_size_list(value: str | None) -> set[int]:
+    if not value:
+        return set()
+
+    sizes = set()
+    for token in value.split(","):
+        token = token.strip()
+        if token:
+            sizes.add(parse_size(token))
+
+    return sizes
 
 
 def validate_regex(pattern: str | None, label: str) -> None:

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -39,7 +39,7 @@ from lib.core.settings import (
     WILDCARD_TEST_POINT_MARKER,
 )
 from lib.parse.url import clean_path
-from lib.utils.common import get_readable_size, lstrip_once
+from lib.utils.common import lstrip_once
 from lib.utils.diff import normalize_dynamic_content
 
 
@@ -113,7 +113,7 @@ class BaseFuzzer:
         ):
             return True
 
-        if get_readable_size(resp.length).rstrip() in options["exclude_sizes"]:
+        if resp.length in options["exclude_sizes"]:
             return True
 
         if resp.length < options["minimum_response_size"]:

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -43,6 +43,8 @@ from lib.core.native_runtime import (
 )
 from lib.core.filters import (
     parse_numeric_ranges,
+    parse_size,
+    parse_size_list,
     parse_time_filters,
     validate_regex,
 )
@@ -275,7 +277,15 @@ def parse_options() -> dict[str, Any]:
             ]
         )
     ]
-    opt.exclude_sizes = {size.strip().upper() for size in opt.exclude_sizes.split(",")}
+    opt.exclude_sizes = _parse_size_list(opt.exclude_sizes, "--exclude-sizes")
+    opt.minimum_response_size = _parse_size(
+        opt.minimum_response_size,
+        "--min-response-size",
+    )
+    opt.maximum_response_size = _parse_size(
+        opt.maximum_response_size,
+        "--max-response-size",
+    )
 
     if opt.extensions == "*":
         opt.extensions = COMMON_EXTENSIONS
@@ -403,6 +413,22 @@ def _parse_advanced_ranges(value: str | None, option_name: str) -> tuple[tuple[i
 def _parse_advanced_times(value: str | None, option_name: str) -> tuple[tuple[str, float], ...]:
     try:
         return parse_time_filters(value)
+    except ValueError as error:
+        print(f"{option_name}: {error}")
+        sys.exit(1)
+
+
+def _parse_size(value: str | int | None, option_name: str) -> int:
+    try:
+        return parse_size(value)
+    except ValueError as error:
+        print(f"{option_name}: {error}")
+        sys.exit(1)
+
+
+def _parse_size_list(value: str | None, option_name: str) -> set[int]:
+    try:
+        return parse_size_list(value)
     except ValueError as error:
         print(f"{option_name}: {error}")
         sys.exit(1)

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -306,7 +306,7 @@ def parse_arguments() -> Values:
         action="store",
         dest="exclude_sizes",
         metavar="SIZES",
-        help="Exclude responses by sizes, separated by commas (e.g. 0B,4KB)",
+        help="Exclude responses by sizes, separated by commas (e.g. 0,0B,4KB)",
     )
     general.add_option(
         "--exclude-text",
@@ -346,18 +346,16 @@ def parse_arguments() -> Values:
     general.add_option(
         "--min-response-size",
         action="store",
-        type="int",
         dest="minimum_response_size",
-        help="Minimum response length",
+        help="Minimum response length (e.g. 1024,1KB)",
         metavar="LENGTH",
         default=0,
     )
     general.add_option(
         "--max-response-size",
         action="store",
-        type="int",
         dest="maximum_response_size",
-        help="Maximum response length",
+        help="Maximum response length (e.g. 1024,1KB)",
         metavar="LENGTH",
         default=0,
     )

--- a/tests/core/test_advanced_filters.py
+++ b/tests/core/test_advanced_filters.py
@@ -2,7 +2,12 @@ from unittest import TestCase
 
 from lib.connection.response import NativeResponse
 from lib.core.data import blacklists, options
-from lib.core.filters import parse_numeric_ranges, parse_time_filters
+from lib.core.filters import (
+    parse_numeric_ranges,
+    parse_size,
+    parse_size_list,
+    parse_time_filters,
+)
 from lib.core.fuzzer import BaseFuzzer
 
 
@@ -79,6 +84,34 @@ class TestAdvancedFilters(TestCase):
 
         self.assertTrue(self.fuzzer.is_excluded(response(body=b"not found")))
         self.assertFalse(self.fuzzer.is_excluded(response(body=b"admin panel")))
+
+    def test_parse_response_sizes(self):
+        self.assertEqual(parse_size("1024"), 1024)
+        self.assertEqual(parse_size("1024B"), 1024)
+        self.assertEqual(parse_size("1KB"), 1024)
+        self.assertEqual(parse_size("2MB"), 2 * 1024 * 1024)
+        self.assertEqual(parse_size(" 3 gb "), 3 * 1024 ** 3)
+        self.assertEqual(parse_size_list("1024,1KB,2MB"), {1024, 2 * 1024 * 1024})
+
+    def test_parse_response_size_rejects_invalid_units(self):
+        with self.assertRaises(ValueError):
+            parse_size("12XB")
+
+    def test_exclude_sizes_match_raw_bytes_and_units(self):
+        options["exclude_sizes"] = parse_size_list("1024,2KB")
+
+        self.assertTrue(self.fuzzer.is_excluded(response(body=b"x" * 1024)))
+        self.assertTrue(self.fuzzer.is_excluded(response(body=b"x" * 2048)))
+        self.assertFalse(self.fuzzer.is_excluded(response(body=b"x" * 1536)))
+
+    def test_min_and_max_response_sizes_use_parsed_bytes(self):
+        options["minimum_response_size"] = parse_size("1KB")
+        options["maximum_response_size"] = parse_size("2KB")
+
+        self.assertTrue(self.fuzzer.is_excluded(response(body=b"x" * 1023)))
+        self.assertFalse(self.fuzzer.is_excluded(response(body=b"x" * 1024)))
+        self.assertFalse(self.fuzzer.is_excluded(response(body=b"x" * 2048)))
+        self.assertTrue(self.fuzzer.is_excluded(response(body=b"x" * 2049)))
 
     def test_size_words_lines_and_time_filters(self):
         options["match_sizes"] = parse_numeric_ranges("10-20")

--- a/tests/core/test_options.py
+++ b/tests/core/test_options.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.core.options import parse_options
+
+
+class TestOptions(TestCase):
+    def test_response_size_options_accept_raw_bytes_and_units(self):
+        args = [
+            "dirsearch.py",
+            "--wordlist-status",
+            "-e",
+            "php",
+            "--exclude-sizes",
+            "512,1KB,2MB",
+            "--min-response-size",
+            "1KB",
+            "--max-response-size",
+            "2MB",
+        ]
+
+        with patch("sys.argv", args):
+            parsed = parse_options()
+
+        self.assertEqual(parsed["exclude_sizes"], {512, 1024, 2 * 1024 * 1024})
+        self.assertEqual(parsed["minimum_response_size"], 1024)
+        self.assertEqual(parsed["maximum_response_size"], 2 * 1024 * 1024)
+
+    def test_response_size_options_accept_bytes_suffix(self):
+        args = [
+            "dirsearch.py",
+            "--wordlist-status",
+            "-e",
+            "php",
+            "--exclude-sizes",
+            "1024B",
+            "--min-response-size",
+            "512B",
+            "--max-response-size",
+            "2048B",
+        ]
+
+        with patch("sys.argv", args):
+            parsed = parse_options()
+
+        self.assertEqual(parsed["exclude_sizes"], {1024})
+        self.assertEqual(parsed["minimum_response_size"], 512)
+        self.assertEqual(parsed["maximum_response_size"], 2048)


### PR DESCRIPTION
## Summary
- Accept raw byte values and readable size units for `--exclude-sizes`, `--min-response-size`, and `--max-response-size`.
- Normalize response size filters to bytes before scanning so all three options use the same internal representation.
- Update help/docs and add coverage for byte values, `B`, `KB`, `MB`, invalid units, and fuzzer min/max behavior.

Fixes #1489

## Tests
- `python -m unittest tests.core.test_advanced_filters tests.core.test_options tests.core.test_fuzzer_filter_stacks tests.core.test_native_fuzzer tests.core.test_async_fuzzer tests.connection.test_native_backend`
- `python dirsearch.py --wordlist-status -e php --exclude-sizes 512,1KB --min-response-size 1KB --max-response-size 2MB`
- `python dirsearch.py --wordlist-status -e php --min-response-size 12XB`
- `python testing.py`