### PR TITLE
Improve Python packaging for nixpkgs

### DIFF
--- a/pyinstaller/dirsearch.spec
+++ b/pyinstaller/dirsearch.spec
@@ -35,7 +35,6 @@ hidden_imports += [
     'markupsafe',
     'OpenSSL',
     'cryptography',
-    'ntlm_auth',
     'requests_ntlm',
     'bs4',
     'beautifulsoup4',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
     "Programming Language :: Python",
     "Environment :: Console",
     "Intended Audience :: Information Technology",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
     "Topic :: Security",
     "Programming Language :: Python :: 3.11",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pyopenssl==26.1.0
 requests==2.33.1
 requests-ntlm==1.3.0
 colorama==0.4.6
-ntlm-auth==1.5.0
 beautifulsoup4==4.14.3
 defusedcsv==3.0.0
 defusedxml==0.7.1

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,7 +4,6 @@ pyopenssl==26.1.0
 requests==2.33.1
 requests-ntlm==1.3.0
 colorama==0.4.6
-ntlm-auth==1.5.0
 beautifulsoup4==4.14.3
 defusedcsv==3.0.0
 defusedxml==0.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ show-source = True
 statistics = True
 
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -18,50 +18,36 @@
 #  Author: Mauro Soria
 
 import ast
-import os
-import shutil
-import tempfile
 from pathlib import Path
 
 import setuptools
 
 
 ROOT = Path(__file__).resolve().parent
-
-# Preserve the historical packaged layout until the repository is reorganized.
-# The built distribution expects a top-level "dirsearch" package that contains
-# the entry module, config.ini, db/, and the lib/ package tree.
-env_dir = tempfile.mkdtemp(prefix="dirsearch-install-")
-package_root = Path(env_dir, "dirsearch")
-shutil.copytree(
-    ROOT,
-    package_root,
-    ignore=shutil.ignore_patterns(
-        ".git",
-        ".github",
-        ".cache",
-        ".venv",
-        "build",
-        "dist",
-        "target",
-        "__pycache__",
-        "*.pyc",
-        "*.pyo",
-        "*.pyd",
-        "tests",
-        "sessions",
-    ),
-)
-
-os.chdir(env_dir)
+PACKAGE_DATA_EXCLUDED_NAMES = {"__pycache__", "target"}
+PACKAGE_DATA_EXCLUDED_SUFFIXES = {".pyc", ".pyo", ".pyd"}
 
 
 def package_files(directory: Path) -> list[str]:
     files: list[str] = []
     for path in sorted(directory.rglob("*")):
+        relative = path.relative_to(directory)
+        if set(relative.parts) & PACKAGE_DATA_EXCLUDED_NAMES:
+            continue
+        if path.suffix in PACKAGE_DATA_EXCLUDED_SUFFIXES:
+            continue
         if path.is_file():
-            files.append(str(path.relative_to(package_root)))
+            files.append(str(path.relative_to(ROOT)))
     return files
+
+
+def package_names() -> list[str]:
+    packages = ["dirsearch"]
+    packages.extend(
+        f"dirsearch.{package}"
+        for package in setuptools.find_packages(include=("lib", "lib.*"))
+    )
+    return packages
 
 
 def read_version(path: Path) -> str:
@@ -94,7 +80,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Environment :: Console",
         "Intended Audience :: Information Technology",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: OS Independent",
         "Topic :: Security",
         "Programming Language :: Python :: 3.11",
@@ -114,12 +99,16 @@ setuptools.setup(
             "dirsearch-build-native=dirsearch.lib.core.native_builder:main",
         ]
     },
-    packages=setuptools.find_packages(exclude=("dirsearch.tests", "dirsearch.tests.*")),
+    packages=package_names(),
+    package_dir={
+        "dirsearch": ".",
+        "dirsearch.lib": "lib",
+    },
     package_data={
         "dirsearch": [
             "config.ini",
-            *package_files(package_root / "db"),
-            *package_files(package_root / "native"),
+            *package_files(ROOT / "db"),
+            *package_files(ROOT / "native"),
         ],
         "dirsearch.lib.report": ["templates/*.html"],
     },

--- a/tests/test_native_install_packaging.py
+++ b/tests/test_native_install_packaging.py
@@ -16,8 +16,34 @@ class TestNativeInstallPackaging(TestCase):
     def test_package_data_includes_native_sources(self):
         setup_py = Path("setup.py").read_text(encoding="utf-8")
 
-        self.assertIn('*package_files(package_root / "native")', setup_py)
+        self.assertIn('*package_files(ROOT / "native")', setup_py)
         self.assertIn('"target"', setup_py)
+
+    def test_setup_uses_standard_package_dir_mapping(self):
+        setup_py = Path("setup.py").read_text(encoding="utf-8")
+
+        self.assertIn('"dirsearch": "."', setup_py)
+        self.assertIn('"dirsearch.lib": "lib"', setup_py)
+        self.assertNotIn("tempfile.mkdtemp", setup_py)
+        self.assertNotIn("shutil.copytree", setup_py)
+        self.assertNotIn("os.chdir", setup_py)
+
+    def test_ntlm_auth_is_not_a_direct_dependency(self):
+        requirement_files = (
+            Path("requirements.txt"),
+            Path("requirements/runtime.txt"),
+        )
+
+        for path in requirement_files:
+            with self.subTest(path=str(path)):
+                self.assertNotIn(
+                    "ntlm-auth",
+                    path.read_text(encoding="utf-8"),
+                )
+        self.assertNotIn(
+            "ntlm_auth",
+            Path("pyinstaller/dirsearch.spec").read_text(encoding="utf-8"),
+        )
 
     def test_install_docs_use_native_builder_flow(self):
         docs = Path("docs/installation.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Remove the temporary-copy based `setup.py` packaging flow and use explicit `package_dir` mappings for the existing source layout.
- Keep packaged data collection for `db/` and `native/` while excluding generated build artifacts such as `target` and bytecode.
- Drop the obsolete direct `ntlm-auth` requirement and PyInstaller hidden import; current NTLM support is provided through `requests-ntlm` and `httpx-ntlm`, which depend on `pyspnego`.
- Clean up setuptools metadata that breaks modern wheel builds by removing the legacy license classifier and replacing `description-file` with `description_file`.

Addresses #1471

## Tests
- `python -m unittest tests.test_native_install_packaging`
- `python -m py_compile setup.py`
- `git diff --check`
- `python -m pip install .` in a clean virtual environment with current `pip`, `setuptools`, and `wheel`
- `python tests/check_packaged_install.py` from the installed environment
- `dirsearch --version` from the installed environment
- `python testing.py`

Nix is not installed in this environment, so I validated the upstream packaging behavior that the `nixpkgs` derivation depends on rather than running `nix-build`.