### PR TITLE
Guard wildcard similarity for large bodies

### DIFF
--- a/lib/core/scanner.py
+++ b/lib/core/scanner.py
@@ -44,6 +44,7 @@ from lib.utils.random import rand_stealth_word
 
 AUTO_CALIBRATION_EXTRA_SAMPLES = 2
 AMBIGUOUS_SIMILARITY_THRESHOLD = 0.9
+AMBIGUOUS_SIMILARITY_MAX_CONTENT_LENGTH = 262144
 
 
 class BaseScanner:
@@ -148,6 +149,12 @@ class BaseScanner:
             return False
 
         if self.content_parser.static_patterns and len(self.content_parser.static_patterns) >= 20:
+            return False
+
+        if (
+            len(self.response.content) > AMBIGUOUS_SIMILARITY_MAX_CONTENT_LENGTH
+            or len(response.content) > AMBIGUOUS_SIMILARITY_MAX_CONTENT_LENGTH
+        ):
             return False
 
         similarity = content_similarity(self.response.content, response.content)

--- a/tests/core/test_scanner.py
+++ b/tests/core/test_scanner.py
@@ -17,6 +17,7 @@
 #  Author: Mauro Soria
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from lib.connection.response import NativeResponse
 from lib.core.data import options
@@ -89,3 +90,56 @@ class TestScanner(TestCase):
         )
 
         self.assertTrue(scanner.check("admin", response))
+
+    def test_probable_wildcard_skips_expensive_similarity_for_large_bodies(self):
+        class DummyParser:
+            static_patterns = ()
+            is_ambiguous = True
+
+        large_body = b"a" * 270000
+        scanner = BaseScanner(None)
+        scanner.response = NativeResponse(
+            "https://example.com/random",
+            200,
+            [("content-type", "text/html")],
+            large_body,
+        )
+        scanner.content_parser = DummyParser()
+        response = NativeResponse(
+            "https://example.com/admin",
+            200,
+            [("content-type", "text/html")],
+            large_body,
+        )
+
+        with patch(
+            "lib.core.scanner.content_similarity",
+            side_effect=AssertionError("expensive similarity should be skipped"),
+        ):
+            self.assertFalse(scanner.is_probable_wildcard("admin", response))
+
+    def test_probable_wildcard_keeps_similarity_for_medium_bodies(self):
+        class DummyParser:
+            static_patterns = ()
+            is_ambiguous = True
+
+        medium_body = b"a" * 70000
+        scanner = BaseScanner(None)
+        scanner.response = NativeResponse(
+            "https://example.com/random",
+            200,
+            [("content-type", "text/html")],
+            medium_body,
+        )
+        scanner.content_parser = DummyParser()
+        response = NativeResponse(
+            "https://example.com/admin",
+            200,
+            [("content-type", "text/html")],
+            medium_body,
+        )
+
+        with patch("lib.core.scanner.content_similarity", return_value=1) as similarity:
+            self.assertTrue(scanner.is_probable_wildcard("admin", response))
+
+        similarity.assert_called_once()


### PR DESCRIPTION
## Summary
- Add a conservative content-size guard before the ambiguous wildcard similarity fallback.
- Skip the expensive body similarity calculation when either response body is larger than 256 KiB.
- Add regression tests proving very large bodies return before `content_similarity` is called while medium-size bodies still use the fallback.

## Why
The ambiguous wildcard fallback is useful for dynamic soft-404 pages, but full body similarity can become unnecessarily expensive on very large responses. For large bodies, this PR keeps the heuristic conservative and avoids the costly comparison without disabling the fallback for ordinary and moderately large HTML error pages.

## Validation
- `python -m unittest tests.core.test_scanner`
- `python -m unittest tests.core.test_scanner tests.core.test_wordlist_backend tests.core.test_dictionary_templates`
- `python dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q`
- `git diff --check`