### PR TITLE
Extract runtime fingerprint helpers

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -32,6 +32,7 @@ from lib.core.dictionary import Dictionary
 from lib.core.exceptions import RequestException
 from lib.core.filters import matches_numeric_ranges, matches_time_filters
 from lib.core.logger import logger
+from lib.core.runtime_fingerprint import response_fingerprint
 from lib.core.scanner import AsyncScanner, BaseScanner, Scanner
 from lib.core.settings import (
     DEFAULT_TEST_PREFIXES,
@@ -40,7 +41,6 @@ from lib.core.settings import (
 )
 from lib.parse.url import clean_path
 from lib.utils.common import lstrip_once
-from lib.utils.diff import normalize_dynamic_content
 
 
 AUTO_CALIBRATION_DUPLICATE_THRESHOLD = 8
@@ -283,21 +283,7 @@ class BaseFuzzer:
 
     @staticmethod
     def response_fingerprint(resp: BaseResponse) -> tuple:
-        path = clean_path(resp.full_path).strip("/")
-        body = normalize_dynamic_content(resp.text)
-        redirect = clean_path(resp.redirect)
-
-        if path:
-            body = body.replace(path, "__PATH__")
-            redirect = redirect.replace(path, "__PATH__")
-
-        return (
-            resp.status,
-            resp.type,
-            redirect,
-            len(body) // 64,
-            hash(body[:4096]),
-        )
+        return response_fingerprint(resp)
 
     def process_response(self, path: str, response: BaseResponse) -> None:
         scanners = self.get_scanners_for(path)

--- a/lib/core/runtime_fingerprint.py
+++ b/lib/core/runtime_fingerprint.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from collections.abc import Iterable
+
+from lib.connection.response import BaseResponse
+from lib.parse.url import clean_path
+from lib.utils.common import replace_path
+from lib.utils.diff import normalize_dynamic_content
+
+
+RUNTIME_MATCH_STREAK_THRESHOLD = 8
+
+
+def response_fingerprint(response: BaseResponse) -> tuple:
+    body = normalize_dynamic_content(response.text)
+    path = clean_path(response.full_path).strip("/")
+    redirect = clean_path(response.redirect)
+    if path:
+        body = _replace_reflected_path(body, path)
+        redirect = _replace_reflected_path(redirect, path)
+    return (
+        response.status,
+        response.type,
+        redirect,
+        len(body) // 64,
+        hashlib.sha256(body[:4096].encode()).hexdigest(),
+    )
+
+
+def _replace_reflected_path(value: str, path: str) -> str:
+    value = replace_path(value, path, "__PATH__")
+    return value.replace(path, "__PATH__")
+
+
+def repeated_match_recalibration(
+    responses: Iterable[BaseResponse],
+    *,
+    threshold: int = RUNTIME_MATCH_STREAK_THRESHOLD,
+) -> tuple[set[tuple], str | None]:
+    fingerprints = [response_fingerprint(response) for response in responses]
+    if len(fingerprints) < threshold:
+        return set(), None
+
+    most_common, count = Counter(fingerprints).most_common(1)[0]
+    if count < threshold:
+        return set(), None
+
+    return {most_common}, "repeated_match_fingerprint"

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -151,10 +151,18 @@ def replace_path(string, path, replace_with):
         return re.sub(regex, replace_with, string)
 
     path = "/" + path
+    path_with_encoded_segments = "/" + quote(path.lstrip("/"), safe="")
+    path_with_escaped_slashes = path.replace("/", r"\/")
     string = sub(string, quote(path), replace_with)
+    string = sub(string, quote(path, safe=""), replace_with)
+    string = sub(string, path_with_encoded_segments, replace_with)
     string = sub(string, quote(quote(path)), replace_with)
+    string = sub(string, quote(quote(path, safe=""), safe=""), replace_with)
+    string = sub(string, quote(path_with_encoded_segments, safe=""), replace_with)
     string = sub(string, unquote(path), replace_with)
     string = sub(string, unquote(unquote(path)), replace_with)
     string = sub(string, escape(path), replace_with)
+    string = sub(string, path_with_escaped_slashes, replace_with)
+    string = sub(string, dumps(path).replace("/", r"\/"), replace_with)
     string = sub(string, dumps(path), replace_with)
     return sub(string, path, replace_with)

--- a/testing.py
+++ b/testing.py
@@ -48,6 +48,7 @@ from tests.core.test_fuzzer_filter_stacks import (  # noqa: F401
 from tests.core.test_importable_api import TestImportableAPI  # noqa: F401
 from tests.core.test_native_fuzzer import TestNativeFuzzer  # noqa: F401
 from tests.core.test_request_backend import TestRequestBackend  # noqa: F401
+from tests.core.test_runtime_fingerprint import TestRuntimeFingerprint  # noqa: F401
 from tests.core.test_scanner import TestScanner  # noqa: F401
 from tests.core.test_wordlist_backend import TestWordlistBackend  # noqa: F401
 from tests.parse.test_config import TestConfigParser  # noqa: F401

--- a/tests/core/test_runtime_fingerprint.py
+++ b/tests/core/test_runtime_fingerprint.py
@@ -1,0 +1,100 @@
+import os
+import subprocess
+import sys
+from unittest import TestCase
+
+from lib.connection.response import NativeResponse
+from lib.core.runtime_fingerprint import (
+    RUNTIME_MATCH_STREAK_THRESHOLD,
+    repeated_match_recalibration,
+    response_fingerprint,
+)
+
+
+def runtime_response(path, body, *, status=200, headers=None):
+    response_headers = {"content-type": "text/html"}
+    response_headers.update(headers or {})
+    return NativeResponse(
+        f"https://example.com/{path}",
+        status,
+        list(response_headers.items()),
+        body,
+    )
+
+
+class TestRuntimeFingerprint(TestCase):
+    def test_response_fingerprint_ignores_reflected_path_and_dynamic_tokens(self):
+        first = runtime_response(
+            "foo/block-1",
+            b"Not found /foo/block-1. Request id 550e8400-e29b-41d4-a716-446655440000.",
+        )
+        second = runtime_response(
+            "foo/block-2",
+            b"Not found /foo%2Fblock-2. Request id 550e8400-e29b-41d4-a716-446655440001.",
+        )
+
+        self.assertEqual(response_fingerprint(first), response_fingerprint(second))
+
+    def test_response_fingerprint_preserves_bare_path_normalization(self):
+        first = runtime_response(
+            "missing-1",
+            b"missing missing-1 soft 404 body with repeated template content",
+        )
+        second = runtime_response(
+            "missing-2",
+            b"missing missing-2 soft 404 body with repeated template content",
+        )
+
+        self.assertEqual(response_fingerprint(first), response_fingerprint(second))
+
+    def test_response_fingerprint_uses_stable_digest_between_processes(self):
+        script = """
+from lib.connection.response import NativeResponse
+from lib.core.runtime_fingerprint import response_fingerprint
+response = NativeResponse(
+    "https://example.com/block-1",
+    200,
+    [("content-type", "text/html")],
+    b"Not found /block-1. Request id 550e8400-e29b-41d4-a716-446655440000.",
+)
+print(response_fingerprint(response)[-1])
+"""
+        digests = []
+        for seed in ("1", "2"):
+            env = dict(os.environ, PYTHONHASHSEED=seed)
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                check=True,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+            digests.append(result.stdout.strip())
+
+        self.assertEqual(digests[0], digests[1])
+        self.assertEqual(len(digests[0]), 64)
+
+    def test_repeated_match_recalibration_waits_for_threshold(self):
+        responses = [
+            runtime_response(
+                f"block-{index}",
+                f"Not found /block-{index}".encode(),
+            )
+            for index in range(RUNTIME_MATCH_STREAK_THRESHOLD - 1)
+        ]
+
+        self.assertEqual(repeated_match_recalibration(responses), (set(), None))
+
+    def test_repeated_match_recalibration_returns_common_fingerprint(self):
+        responses = [
+            runtime_response(
+                f"block-{index}",
+                f"Not found /block-{index}".encode(),
+            )
+            for index in range(RUNTIME_MATCH_STREAK_THRESHOLD)
+        ]
+
+        fingerprints, reason = repeated_match_recalibration(responses)
+
+        self.assertEqual(reason, "repeated_match_fingerprint")
+        self.assertEqual(fingerprints, {response_fingerprint(responses[0])})

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -31,6 +31,9 @@ class TestCommonUtils(TestCase):
         self.assertEqual(replace_path("/abc or /abc?k=v", "abc", "REPLACED"), "REPLACED or REPLACED?k=v", "Path was not replaced")
         self.assertEqual(replace_path("http://a.co/abc", "abc", "REPLACED"), "http://a.coREPLACED", "Path was not replaced")
         self.assertEqual(replace_path("http://a.co/abcdef", "abc", "REPLACED"), "http://a.co/abcdef", "Path was replaced even though it should have not")
+        self.assertEqual(replace_path("/foo%2Fbar", "foo/bar", "REPLACED"), "REPLACED", "Path with encoded slash was not replaced")
+        self.assertEqual(replace_path("%2Ffoo%2Fbar", "foo/bar", "REPLACED"), "REPLACED", "Fully encoded path was not replaced")
+        self.assertEqual(replace_path(r"\/foo\/bar", "foo/bar", "REPLACED"), "REPLACED", "JSON escaped path was not replaced")
 
     def test_strip_and_uniquify(self):
         self.assertEqual(strip_and_uniquify(["foo", "bar", " bar ", "foo"]), ["foo", "bar"], "The results are not stripped or contain duplicates or in wrong order")


### PR DESCRIPTION
## Summary
- Add `lib/core/runtime_fingerprint.py` as a leaf module for response runtime fingerprints and repeated-match recalibration.
- Route `BaseFuzzer.response_fingerprint()` through the new helper.
- Reuse the existing `replace_path()` reflection normalizer for runtime fingerprints, and extend it to cover encoded slash and JSON-escaped slash path variants.
- Preserve the previous bare-path normalization behavior used by auto-calibration.
- Switch the runtime fingerprint digest from process-randomized `hash()` to a stable SHA-256 digest.
- Add focused tests for reflected path normalization, stable digests across hash seeds, threshold behavior, and repeated fingerprint recalibration.

## Why
Upcoming preflight/runtime filtering work needs fingerprint helpers without importing the full preflight core from the fuzzer hot path. This PR keeps the extraction small and does not enable runtime filters or recalibration in fuzzer behavior yet.

The fuzzer already had path reflection normalization inline. This PR keeps that behavior, moves it into a small reusable helper, and makes it use the project’s existing path replacement utility so encoded reflected paths are handled consistently.

## Validation
- `python -m unittest tests.core.test_runtime_fingerprint tests.utils.test_common tests.core.test_advanced_filters tests.core.test_fuzzer_filter_stacks`
- `python -m unittest tests.core.test_runtime_fingerprint tests.core.test_fuzzer_filter_stacks`
- `python -m unittest tests.core.test_runtime_fingerprint tests.core.test_fuzzer_filter_stacks tests.core.test_native_fuzzer tests.core.test_request_backend`
- `python testing.py` passed 141 tests with 2 skips.
- `python dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q`
- `git diff --check`