### PR TITLE
Add preflight runtime filter strategy

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -32,7 +32,7 @@ from lib.core.dictionary import Dictionary
 from lib.core.exceptions import RequestException
 from lib.core.filters import matches_numeric_ranges, matches_time_filters
 from lib.core.logger import logger
-from lib.core.runtime_fingerprint import response_fingerprint
+from lib.core.runtime_fingerprint import build_runtime_filter, response_fingerprint
 from lib.core.scanner import AsyncScanner, BaseScanner, Scanner
 from lib.core.settings import (
     DEFAULT_TEST_PREFIXES,
@@ -80,6 +80,7 @@ class BaseFuzzer:
         self.error_callbacks = error_callbacks
         self._similar_fingerprints: dict[tuple, int] = {}
         self._auto_calibrated_fingerprints: set[tuple] = set()
+        self.runtime_filter = build_runtime_filter(options.get("preflight", False))
 
         self.scanners: dict[str, dict[str, Scanner]] = {
             "default": {},
@@ -285,10 +286,33 @@ class BaseFuzzer:
     def response_fingerprint(resp: BaseResponse) -> tuple:
         return response_fingerprint(resp)
 
+    @property
+    def recalibration_events(self) -> list[str]:
+        return self.runtime_filter.recalibration_events
+
+    def is_runtime_filtered(self, response: BaseResponse) -> bool:
+        return self.runtime_filter.is_filtered(response)
+
+    def add_runtime_fingerprints(self, fingerprints: set[tuple]) -> None:
+        self.runtime_filter.add_fingerprints(fingerprints)
+
+    def reset_match_streak(self) -> None:
+        self.runtime_filter.reset()
+
+    def record_match_for_recalibration(self, response: BaseResponse) -> None:
+        self.runtime_filter.record_match(response)
+
     def process_response(self, path: str, response: BaseResponse) -> None:
         scanners = self.get_scanners_for(path)
 
+        if self.is_runtime_filtered(response):
+            self.reset_match_streak()
+            for callback in self.not_found_callbacks:
+                callback(response)
+            return
+
         if self.is_excluded(response):
+            self.reset_match_streak()
             for callback in self.not_found_callbacks:
                 callback(response)
             return
@@ -296,6 +320,7 @@ class BaseFuzzer:
         for tester in scanners:
             # Check if the response is unique, not wildcard
             if not tester.check(path, response):
+                self.reset_match_streak()
                 for callback in self.not_found_callbacks:
                     callback(response)
                 return
@@ -307,6 +332,8 @@ class BaseFuzzer:
 
         for callback in self.match_callbacks:
             callback(response)
+
+        self.record_match_for_recalibration(response)
 
 
 class Fuzzer(BaseFuzzer):
@@ -421,6 +448,7 @@ class Fuzzer(BaseFuzzer):
         try:
             response = self._requester.request(path)
         except RequestException as e:
+            self.reset_match_streak()
             for callback in self.error_callbacks:
                 callback(e)
             return
@@ -499,10 +527,12 @@ class NativeFuzzer(Fuzzer):
                     if self._quit_event.is_set():
                         break
                     if error is not None:
+                        self.reset_match_streak()
                         for callback in self.error_callbacks:
                             callback(error)
                         continue
                     if response.filtered:
+                        self.reset_match_streak()
                         for callback in self.not_found_callbacks:
                             callback(response)
                         continue
@@ -609,6 +639,7 @@ class AsyncFuzzer(BaseFuzzer):
         try:
             response = await self._requester.request(path)
         except RequestException as e:
+            self.reset_match_streak()
             for callback in self.error_callbacks:
                 callback(e)
             return

--- a/lib/core/runtime_fingerprint.py
+++ b/lib/core/runtime_fingerprint.py
@@ -13,6 +13,60 @@ from lib.utils.diff import normalize_dynamic_content
 RUNTIME_MATCH_STREAK_THRESHOLD = 8
 
 
+class DisabledRuntimeFilter:
+    def __init__(self) -> None:
+        self.recalibration_events: list[str] = []
+
+    def add_fingerprints(self, fingerprints: set[tuple]) -> None:
+        del fingerprints
+
+    def is_filtered(self, response: BaseResponse) -> bool:
+        del response
+        return False
+
+    def record_match(self, response: BaseResponse) -> None:
+        del response
+
+    def reset(self) -> None:
+        return None
+
+
+class PreflightRuntimeFilter:
+    def __init__(self) -> None:
+        self.fingerprints: set[tuple] = set()
+        self.match_streak: list[BaseResponse] = []
+        self.recalibration_events: list[str] = []
+
+    def add_fingerprints(self, fingerprints: set[tuple]) -> None:
+        self.fingerprints.update(fingerprints)
+
+    def is_filtered(self, response: BaseResponse) -> bool:
+        return response_fingerprint(response) in self.fingerprints
+
+    def record_match(self, response: BaseResponse) -> None:
+        self.match_streak.append(response)
+        fingerprints, reason = repeated_match_recalibration(self.match_streak)
+        if not fingerprints:
+            return
+
+        self.add_fingerprints(fingerprints)
+        self.recalibration_events.append(reason or "repeated_match_fingerprint")
+        self.reset()
+
+    def reset(self) -> None:
+        self.match_streak.clear()
+
+
+RuntimeFilter = DisabledRuntimeFilter | PreflightRuntimeFilter
+
+
+def build_runtime_filter(enabled: bool) -> RuntimeFilter:
+    if enabled:
+        return PreflightRuntimeFilter()
+
+    return DisabledRuntimeFilter()
+
+
 def response_fingerprint(response: BaseResponse) -> tuple:
     body = normalize_dynamic_content(response.text)
     path = clean_path(response.full_path).strip("/")

--- a/tests/core/test_fuzzer_filter_stacks.py
+++ b/tests/core/test_fuzzer_filter_stacks.py
@@ -3,6 +3,7 @@ from unittest import IsolatedAsyncioTestCase, TestCase
 
 from lib.connection.response import NativeResponse
 from lib.core.data import blacklists, options
+from lib.core.exceptions import RequestException
 from lib.core.fuzzer import AsyncFuzzer, Fuzzer, NativeFuzzer
 
 
@@ -39,6 +40,11 @@ class DummySyncRequester:
             return stack_response(path, b"keep admin panel")
 
         return stack_response(path, b"not found")
+
+
+class ErrorRequester:
+    def request(self, path):
+        raise RequestException(f"boom: {path}")
 
 
 class DummyAsyncRequester:
@@ -144,6 +150,94 @@ class TestSyncFuzzerFilterStack(FilterStackOptionsMixin, TestCase):
         self.assertEqual([response.full_path for response in matches], ["keep"])
         self.assertEqual([response.full_path for response in misses], ["drop"])
         self.assertEqual(errors, [])
+
+    def test_runtime_filter_is_disabled_by_default(self):
+        dictionary = DummyDictionary([])
+        matches = []
+        misses = []
+        errors = []
+        fuzzer = Fuzzer(
+            DummySyncRequester(),
+            dictionary,
+            match_callbacks=(matches.append,),
+            not_found_callbacks=(misses.append,),
+            error_callbacks=(errors.append,),
+        )
+
+        for index in range(9):
+            fuzzer.process_response(
+                f"block-{index}",
+                stack_response(
+                    f"block-{index}",
+                    f"burst block /block-{index}".encode(),
+                ),
+            )
+
+        self.assertEqual(len(matches), 9)
+        self.assertEqual(misses, [])
+        self.assertEqual(errors, [])
+        self.assertEqual(fuzzer.recalibration_events, [])
+
+    def test_runtime_filter_recalibrates_when_preflight_is_enabled(self):
+        options["preflight"] = True
+        dictionary = DummyDictionary([])
+        matches = []
+        misses = []
+        errors = []
+        fuzzer = Fuzzer(
+            DummySyncRequester(),
+            dictionary,
+            match_callbacks=(matches.append,),
+            not_found_callbacks=(misses.append,),
+            error_callbacks=(errors.append,),
+        )
+
+        for index in range(8):
+            fuzzer.process_response(
+                f"block-{index}",
+                stack_response(
+                    f"block-{index}",
+                    f"burst block /block-{index}".encode(),
+                ),
+            )
+        final_response = stack_response("block-final", b"burst block /block-final")
+        fuzzer.process_response("block-final", final_response)
+
+        self.assertEqual(len(matches), 8)
+        self.assertEqual(misses, [final_response])
+        self.assertEqual(errors, [])
+        self.assertEqual(fuzzer.recalibration_events, ["repeated_match_fingerprint"])
+
+    def test_runtime_filter_resets_match_streak_on_error(self):
+        options["preflight"] = True
+        dictionary = DummyDictionary([])
+        matches = []
+        misses = []
+        errors = []
+        fuzzer = Fuzzer(
+            ErrorRequester(),
+            dictionary,
+            match_callbacks=(matches.append,),
+            not_found_callbacks=(misses.append,),
+            error_callbacks=(errors.append,),
+        )
+
+        for index in range(7):
+            fuzzer.process_response(
+                f"block-{index}",
+                stack_response(
+                    f"block-{index}",
+                    f"burst block /block-{index}".encode(),
+                ),
+            )
+        fuzzer.scan("boom")
+        final_response = stack_response("block-final", b"burst block /block-final")
+        fuzzer.process_response("block-final", final_response)
+
+        self.assertEqual(len(matches), 8)
+        self.assertEqual(misses, [])
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(fuzzer.recalibration_events, [])
 
 
 class TestAsyncFuzzerFilterStack(FilterStackOptionsMixin, IsolatedAsyncioTestCase):

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -151,3 +151,49 @@ class TestNativeFuzzer(TestCase):
         self.assertEqual(misses, [response])
         self.assertEqual(errors, [])
         self.assertEqual(response.length, 64)
+
+    def test_native_filtered_result_resets_preflight_match_streak(self):
+        options["preflight"] = True
+        repeated = [
+            (
+                f"block-{index}",
+                NativeResponse(
+                    f"https://example.com/block-{index}",
+                    200,
+                    [("content-type", "text/plain")],
+                    f"burst block /block-{index}".encode(),
+                ),
+                None,
+            )
+            for index in range(7)
+        ]
+        filtered = NativeResponse(
+            "https://example.com/missing",
+            404,
+            [("content-type", "text/plain")],
+            [],
+            length=64,
+            filtered=True,
+            filter_reason="advanced_filter",
+        )
+        final = NativeResponse(
+            "https://example.com/block-final",
+            200,
+            [("content-type", "text/plain")],
+            b"burst block /block-final",
+        )
+        backend = FakeNativeBackend(
+            repeated + [("missing", filtered, None), ("block-final", final, None)]
+        )
+        dictionary = DummyDictionary([path for path, _, _ in backend.items])
+        matches = []
+        misses = []
+        errors = []
+
+        fuzzer = self.make_fuzzer(backend, dictionary, matches, misses, errors)
+        fuzzer.start()
+
+        self.assertEqual(len(matches), 8)
+        self.assertEqual(misses, [filtered])
+        self.assertEqual(errors, [])
+        self.assertEqual(fuzzer.recalibration_events, [])

--- a/tests/core/test_runtime_fingerprint.py
+++ b/tests/core/test_runtime_fingerprint.py
@@ -6,6 +6,9 @@ from unittest import TestCase
 from lib.connection.response import NativeResponse
 from lib.core.runtime_fingerprint import (
     RUNTIME_MATCH_STREAK_THRESHOLD,
+    DisabledRuntimeFilter,
+    PreflightRuntimeFilter,
+    build_runtime_filter,
     repeated_match_recalibration,
     response_fingerprint,
 )
@@ -23,6 +26,37 @@ def runtime_response(path, body, *, status=200, headers=None):
 
 
 class TestRuntimeFingerprint(TestCase):
+    def test_build_runtime_filter_returns_disabled_filter_by_default(self):
+        runtime_filter = build_runtime_filter(False)
+        sample = runtime_response("block", b"Not found /block")
+
+        runtime_filter.record_match(sample)
+        runtime_filter.add_fingerprints({response_fingerprint(sample)})
+
+        self.assertIsInstance(runtime_filter, DisabledRuntimeFilter)
+        self.assertFalse(runtime_filter.is_filtered(sample))
+        self.assertEqual(runtime_filter.recalibration_events, [])
+
+    def test_preflight_runtime_filter_records_repeated_matches(self):
+        runtime_filter = build_runtime_filter(True)
+        responses = [
+            runtime_response(
+                f"block-{index}",
+                f"Not found /block-{index}".encode(),
+            )
+            for index in range(RUNTIME_MATCH_STREAK_THRESHOLD)
+        ]
+
+        for sample in responses:
+            runtime_filter.record_match(sample)
+
+        self.assertIsInstance(runtime_filter, PreflightRuntimeFilter)
+        self.assertTrue(runtime_filter.is_filtered(responses[0]))
+        self.assertEqual(
+            runtime_filter.recalibration_events,
+            ["repeated_match_fingerprint"],
+        )
+
     def test_response_fingerprint_ignores_reflected_path_and_dynamic_tokens(self):
         first = runtime_response(
             "foo/block-1",


### PR DESCRIPTION
## Summary
- Add a runtime filtering strategy around the response fingerprint helpers from #1573.
- Use a disabled null object by default so normal scans do not record match streaks or filter responses.
- Enable repeated-match recalibration only when `options["preflight"]` is true.
- Route runtime-filtered responses to `not_found_callbacks` and reset match streaks on excluded responses, wildcard responses, sync/async errors, and native filtered results.
- Add sync and native regression tests for default-off behavior, enabled recalibration, and streak reset behavior.

## Why
Runtime filtering is needed for the upcoming preflight flow, but it must not affect normal scans. The strategy/null-object design keeps the fuzzer hot path simple: it always calls the runtime filter object, while the disabled implementation remains a no-op unless preflight explicitly enables the active implementation.

## Stacking
- Base: `runtime-fingerprint-helpers` / #1573
- This PR should be reviewed after #1573 or retargeted to `master` after #1573 lands.

## Validation
- `python -m unittest tests.core.test_runtime_fingerprint tests.core.test_fuzzer_filter_stacks tests.core.test_native_fuzzer`
- `python testing.py` passed 147 tests with 2 skips.
- `python dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q`
- `git diff --check`