### PR TITLE
Fix native build Python selection

### DIFF
--- a/pyinstaller/build.sh
+++ b/pyinstaller/build.sh
@@ -17,6 +17,14 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 python_cmd() {
+    if [[ -n "${PYTHON_CMD:-}" ]]; then
+        echo "$PYTHON_CMD"
+        return
+    fi
+    if [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/python" ]]; then
+        echo "$VIRTUAL_ENV/bin/python"
+        return
+    fi
     command -v python3 || command -v python
 }
 
@@ -54,7 +62,7 @@ build_native() {
         rustup default stable
     fi
     "$PYTHON_CMD" -m pip install --only-binary=:all: maturin
-    "$PYTHON_CMD" scripts/build_native.py --out dist/native-wheels
+    "$PYTHON_CMD" scripts/build_native.py --python "$PYTHON_CMD" --out dist/native-wheels
 }
 
 build_stack() {

--- a/scripts/build_native.py
+++ b/scripts/build_native.py
@@ -25,11 +25,11 @@ def clean_wheel_dir(wheel_dir: Path) -> None:
 def resolve_python(value: str) -> Path:
     candidate = Path(value)
     if candidate.exists() or len(candidate.parts) > 1:
-        return candidate.resolve()
+        return candidate.absolute()
 
     resolved = shutil.which(value)
     if resolved:
-        return Path(resolved).resolve()
+        return Path(resolved).absolute()
 
     return candidate
 

--- a/tests/test_native_install_packaging.py
+++ b/tests/test_native_install_packaging.py
@@ -1,5 +1,9 @@
+import os
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase
+
+from scripts.build_native import resolve_python
 
 
 class TestNativeInstallPackaging(TestCase):
@@ -52,3 +56,22 @@ class TestNativeInstallPackaging(TestCase):
         self.assertIn("python3.14-dev", docs)
         self.assertIn("python3.14-devel", docs)
         self.assertNotIn("maturin develop", docs)
+
+    def test_pyinstaller_native_build_uses_selected_python(self):
+        build_script = Path("pyinstaller/build.sh").read_text(encoding="utf-8")
+
+        self.assertIn('${VIRTUAL_ENV:-}', build_script)
+        self.assertIn('"$PYTHON_CMD" scripts/build_native.py --python "$PYTHON_CMD"', build_script)
+
+    def test_native_builder_preserves_python_symlink(self):
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            target = temp_path / "python-real"
+            link = temp_path / "python"
+            target.touch()
+            try:
+                os.symlink(target, link)
+            except (AttributeError, NotImplementedError, OSError) as error:
+                self.skipTest(f"Python symlink unavailable: {error}")
+
+            self.assertEqual(resolve_python(str(link)), link.absolute())


### PR DESCRIPTION
## Summary

Fix the PyInstaller native Rust build so it consistently uses the selected Python interpreter when building the native wheel.

## Root Cause

`pyinstaller/build.sh` installed `maturin` with `PYTHON_CMD`, but `scripts/build_native.py` then resolved the selected interpreter with `Path.resolve()`. On common virtualenv layouts, `venv/bin/python` is a symlink to `/usr/bin/python3.14`, so resolving it dereferenced the venv interpreter into the system interpreter. The nested `python -m maturin` command then ran outside the virtualenv even though `maturin` was installed inside it.

## Changes

- Prefer an explicit `PYTHON_CMD` override when set.
- Prefer `$VIRTUAL_ENV/bin/python` when a virtualenv is active.
- Pass `--python "$PYTHON_CMD"` into `scripts/build_native.py` so the nested maturin build receives the selected interpreter.
- Preserve Python symlink paths in `scripts/build_native.py` instead of dereferencing them to the system Python.
- Add packaging regression tests for the PyInstaller native build path and Python symlink handling.

## Validation

- `python3 -m unittest tests.test_native_install_packaging`
- `bash -n pyinstaller/build.sh`
- `git diff --check`