### PR TITLE
Restore dictionary validation for crawled paths

### DIFF
--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -21,7 +21,7 @@ from typing import Any, Iterator
 
 from lib.core.decorators import locked
 from lib.core.settings import SCRIPT_PATH
-from lib.core.wordlist_backend import get_wordlist_backend
+from lib.core.wordlist_backend import get_wordlist_backend, is_valid_path
 from lib.utils.file import FileUtils
 
 
@@ -105,6 +105,9 @@ class Dictionary:
         """
 
         return get_wordlist_backend().generate(files, is_blacklist=is_blacklist)
+
+    def is_valid(self, path: str) -> bool:
+        return is_valid_path(path)
 
     def add_extra(self, path) -> None:
         if path in self._items or path in self._extra:

--- a/lib/core/wordlist_backend.py
+++ b/lib/core/wordlist_backend.py
@@ -27,6 +27,24 @@ class WordlistBackend(Protocol):
     def generate(self, files: list[str], is_blacklist: bool = False) -> list[str]:
         pass
 
+    def is_valid(self, path: str) -> bool:
+        pass
+
+
+def is_valid_path(path: str) -> bool:
+    # Skip comments and empty lines
+    if not path or path.startswith("#"):
+        return False
+
+    # Skip if the path has excluded extensions
+    cleaned_path = clean_path(path)
+    if cleaned_path.endswith(
+        tuple(f".{extension}" for extension in options["exclude_extensions"])
+    ):
+        return False
+
+    return True
+
 
 class PythonWordlistBackend:
     name = "python"
@@ -108,18 +126,7 @@ class PythonWordlistBackend:
             return list(wordlist)
 
     def is_valid(self, path: str) -> bool:
-        # Skip comments and empty lines
-        if not path or path.startswith("#"):
-            return False
-
-        # Skip if the path has excluded extensions
-        cleaned_path = clean_path(path)
-        if cleaned_path.endswith(
-            tuple(f".{extension}" for extension in options["exclude_extensions"])
-        ):
-            return False
-
-        return True
+        return is_valid_path(path)
 
     def _add_wordlist_entry(self, wordlist: OrderedSet, path: str) -> None:
         wordlist.add(path)
@@ -159,6 +166,9 @@ class NativeWordlistBackend:
             overwrite_extensions=options["overwrite_extensions"],
             max_size=options["wordlist_max_size"],
         )
+
+    def is_valid(self, path: str) -> bool:
+        return is_valid_path(path)
 
     def _requires_python_template_expansion(self, files: list[str]) -> bool:
         extension_token = EXTENSION_TAG.strip("%").upper()

--- a/tests/core/test_dictionary_templates.py
+++ b/tests/core/test_dictionary_templates.py
@@ -69,6 +69,15 @@ class TestDictionaryTemplates(TestCase):
 
         self.assertEqual(list(dictionary), ["index.php", "index.json"])
 
+    def test_is_valid_filters_invalid_crawled_paths(self):
+        options["exclude_extensions"] = ("zip",)
+        dictionary = Dictionary(files=[])
+
+        self.assertTrue(dictionary.is_valid("admin"))
+        self.assertFalse(dictionary.is_valid(""))
+        self.assertFalse(dictionary.is_valid("#comment"))
+        self.assertFalse(dictionary.is_valid("backup.zip?download=1"))
+
     def test_generation_limit(self):
         options["wordlist_max_size"] = 1
 


### PR DESCRIPTION
## Summary

- Restore `Dictionary.is_valid()` so `--crawl` can validate discovered paths before queueing them.
- Share the validation logic with wordlist backends to keep comment, empty-path, and excluded-extension filtering consistent.
- Add regression coverage for crawled path validation.

Fixes #1576.

## Validation

- `/tmp/dirsearch-issue1576-venv/bin/python -m unittest tests.core.test_dictionary_templates tests.core.test_wordlist_backend`
- `/tmp/dirsearch-issue1576-venv/bin/python -m unittest tests.connection.test_requester tests.connection.test_dns tests.core.test_scanner`
- `/tmp/dirsearch-issue1576-venv/bin/python testing.py`
- local `--crawl` smoke against an HTTP server that links `/home.html` to `/crawled.html`