### PR TITLE
Add native backend parity guardrails and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,29 @@ jobs:
         flake8 .
     - name: Codespell
       run: codespell -S CONTRIBUTORS.md,./db/categories/*
+
+  native:
+    name: Native backend
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install maturin -r requirements.txt
+    - name: Check Rust formatting
+      run: cargo fmt --manifest-path native/Cargo.toml --all -- --check
+    - name: Test Rust crate
+      run: cargo test --locked --manifest-path native/Cargo.toml
+    - name: Build and install native extension
+      run: python scripts/build_native.py --keep-target
+    - name: Test native Python integration
+      run: |
+        python -c "import dirsearch_native"
+        python -m unittest tests.connection.test_requester.TestNativeRequesterPathPreservation
+        python testing.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         flake8 .
     - name: Codespell
-      run: codespell -S CONTRIBUTORS.md,./db/categories/*
+      run: codespell -S CONTRIBUTORS.md,./db/categories/*,./build
 
   native:
     name: Native backend

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -48,7 +48,10 @@ from lib.core.exceptions import (
     WordlistLimitError,
 )
 from lib.core.logger import enable_logging, logger
-from lib.core.request_backend import get_native_request_backend_error
+from lib.core.request_backend import (
+    get_native_request_backend_error,
+    get_native_target_error,
+)
 from lib.core.settings import (
     BANNER,
     DEFAULT_HEADERS,
@@ -498,6 +501,10 @@ class Controller:
             break
 
     def set_target(self, url: str) -> None:
+        if options["request_backend"] == "native":
+            if error := get_native_target_error(url):
+                raise InvalidURLException(error)
+
         # If no scheme specified, unset it first
         if "://" not in url:
             url = f'{options["scheme"] or UNKNOWN}://{url}'

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -277,6 +277,8 @@ class BaseFuzzer:
                 options["match_words"],
                 options["match_lines"],
                 options["match_regex"],
+                options["match_headers"],
+                options["match_header_regex"],
                 options["match_time"],
             )
         )

--- a/lib/core/request_backend.py
+++ b/lib/core/request_backend.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
 from optparse import Values
+from urllib.parse import urlparse
 
 
 REQUEST_BACKENDS = ("python", "native")
+
+
+def get_native_target_error(url: str) -> str | None:
+    parsed = urlparse(url if "://" in url else f"//{url}")
+    if parsed.username is not None:
+        return (
+            "--request-backend native does not support credentials embedded "
+            "in target URLs yet"
+        )
+
+    return None
 
 
 def get_native_request_backend_error(opt: Values) -> str | None:
@@ -17,8 +29,6 @@ def get_native_request_backend_error(opt: Values) -> str | None:
         return "--request-backend native does not support proxies yet"
     if opt.proxy_auth:
         return "--request-backend native does not support proxy authentication yet"
-    if opt.replay_proxy:
-        return "--request-backend native does not support --replay-proxy yet"
     if opt.auth or opt.auth_type:
         return "--request-backend native does not support authentication yet"
     if opt.cert_file or opt.key_file:
@@ -27,11 +37,17 @@ def get_native_request_backend_error(opt: Values) -> str | None:
         return "--request-backend native does not support --random-agent yet"
     if opt.network_interface:
         return "--request-backend native does not support --interface yet"
+    if opt.ip:
+        return "--request-backend native does not support --ip yet"
     if opt.max_rate:
         return "--request-backend native does not support --max-rate yet"
     if opt.delay:
         return "--request-backend native does not support --delay yet"
     if opt.follow_redirects:
         return "--request-backend native does not support --follow-redirects yet"
+
+    for url in getattr(opt, "urls", ()):
+        if error := get_native_target_error(url):
+            return error
 
     return None

--- a/tests/core/test_advanced_filters.py
+++ b/tests/core/test_advanced_filters.py
@@ -188,6 +188,26 @@ class TestAdvancedFilters(TestCase):
             )
         )
 
+    def test_header_text_matcher_disables_auto_calibration(self):
+        options["auto_calibration"] = True
+        options["match_headers"] = ["x-result: found"]
+        candidate = response(
+            body=b"repeated response body that is long enough for calibration",
+            headers=[("X-Result", "found")],
+        )
+
+        self.assertFalse(self.fuzzer.should_record_auto_calibration(candidate))
+
+    def test_header_regex_matcher_disables_auto_calibration(self):
+        options["auto_calibration"] = True
+        options["match_header_regex"] = r"X-Result: found-[0-9]+"
+        candidate = response(
+            body=b"repeated response body that is long enough for calibration",
+            headers=[("X-Result", "found-42")],
+        )
+
+        self.assertFalse(self.fuzzer.should_record_auto_calibration(candidate))
+
     def test_forced_auto_calibration_filters_repeated_reflected_responses(self):
         options["auto_calibration"] = True
         repeated = [

--- a/tests/core/test_request_backend.py
+++ b/tests/core/test_request_backend.py
@@ -21,9 +21,11 @@ def native_options(**overrides):
         "key_file": None,
         "random_agents": False,
         "network_interface": None,
+        "ip": None,
         "max_rate": 0,
         "delay": 0,
         "follow_redirects": False,
+        "urls": ["https://example.com"],
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -49,6 +51,37 @@ class TestRequestBackend(TestCase):
         self.assertEqual(
             get_native_request_backend_error(native_options(proxies=["127.0.0.1:8080"])),
             "--request-backend native does not support proxies yet",
+        )
+
+    def test_native_rejects_ip_override(self):
+        self.assertEqual(
+            get_native_request_backend_error(native_options(ip="127.0.0.1")),
+            "--request-backend native does not support --ip yet",
+        )
+
+    def test_native_accepts_replay_proxy(self):
+        self.assertIsNone(
+            get_native_request_backend_error(
+                native_options(replay_proxy="http://127.0.0.1:8080")
+            )
+        )
+
+    def test_native_rejects_embedded_target_credentials(self):
+        self.assertEqual(
+            get_native_request_backend_error(
+                native_options(urls=["https://user:pass@example.com"])
+            ),
+            "--request-backend native does not support credentials embedded "
+            "in target URLs yet",
+        )
+
+    def test_native_rejects_embedded_target_credentials_without_scheme(self):
+        self.assertEqual(
+            get_native_request_backend_error(
+                native_options(urls=["user:pass@example.com"])
+            ),
+            "--request-backend native does not support credentials embedded "
+            "in target URLs yet",
         )
 
     def test_native_rejects_delay(self):


### PR DESCRIPTION
## Summary

- reject `--ip` and URL-embedded credentials in native mode instead of silently ignoring them
- allow `--replay-proxy` with native scans because matching responses are replayed through the Python requester
- prevent response auto-calibration from overriding explicit header matchers
- build and install the Rust extension in CI, run Rust tests, and exercise the real native Python integration path
- exclude the generated packaging tree from codespell so successful test jobs do not fail on copied wordlists

## Validation

GitHub Actions runs:
- Python 3.11 and 3.14 on Linux and Windows
- Rust formatting and crate tests
- native wheel build and import on Python 3.14
- native request path integration tests
- full Python test suite with the native extension installed
