### PR TITLE
Add HTTP proxy support to native scans

### DIFF
--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -36,6 +36,7 @@ class NativeHTTPBackend:
             concurrency=options["thread_count"],
             timeout_secs=options["timeout"],
             headers=list(options["headers"].items()),
+            proxies=self._proxy_urls(),
             max_retries=options["max_retries"],
             follow_redirects=options["follow_redirects"],
             max_body_size=MAX_RESPONSE_SIZE,
@@ -61,6 +62,25 @@ class NativeHTTPBackend:
                 ),
                 None,
             )
+
+    @staticmethod
+    def _proxy_urls() -> list[str]:
+        proxies = []
+        for proxy in options["proxies"]:
+            if "://" not in proxy:
+                proxy = f"http://{proxy}"
+            elif not proxy.startswith(("http://", "https://")):
+                raise RequestException(
+                    "--request-backend native supports HTTP and HTTPS proxies only"
+                )
+
+            if options["proxy_auth"] and "@" not in proxy:
+                proxy = proxy.replace(
+                    "://", f'://{options["proxy_auth"]}@', 1
+                )
+            proxies.append(proxy)
+
+        return proxies
 
     @staticmethod
     def _filter_options() -> dict[str, Any]:

--- a/lib/core/request_backend.py
+++ b/lib/core/request_backend.py
@@ -25,10 +25,12 @@ def get_native_request_backend_error(opt: Values) -> str | None:
         return "--request-backend native currently supports GET requests only"
     if opt.data or opt.data_file:
         return "--request-backend native does not support request bodies yet"
-    if opt.proxies or opt.proxies_file or opt.tor:
-        return "--request-backend native does not support proxies yet"
-    if opt.proxy_auth:
-        return "--request-backend native does not support proxy authentication yet"
+    if opt.tor:
+        return "--request-backend native does not support Tor or SOCKS proxies yet"
+    for proxy in opt.proxies:
+        parsed = urlparse(proxy if "://" in proxy else f"http://{proxy}")
+        if parsed.scheme not in ("http", "https"):
+            return "--request-backend native supports HTTP and HTTPS proxies only"
     if opt.auth or opt.auth_type:
         return "--request-backend native does not support authentication yet"
     if opt.cert_file or opt.key_file:

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -430,6 +430,31 @@ fn lstrip_once(input: &str, pattern: &str) -> String {
     input.strip_prefix(pattern).unwrap_or(input).to_string()
 }
 
+fn build_http_client(
+    headers: &HeaderMap,
+    concurrency: usize,
+    timeout_secs: f64,
+    follow_redirects: bool,
+    proxy_url: Option<&str>,
+) -> Result<reqwest::Client, reqwest::Error> {
+    let mut builder = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .default_headers(headers.clone())
+        .redirect(if follow_redirects {
+            reqwest::redirect::Policy::limited(10)
+        } else {
+            reqwest::redirect::Policy::none()
+        })
+        .timeout(Duration::from_secs_f64(timeout_secs))
+        .pool_max_idle_per_host(concurrency);
+
+    if let Some(proxy_url) = proxy_url {
+        builder = builder.proxy(reqwest::Proxy::all(proxy_url)?);
+    }
+
+    builder.build()
+}
+
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 #[pyo3(signature = (
@@ -438,6 +463,7 @@ fn lstrip_once(input: &str, pattern: &str) -> String {
     concurrency=25,
     timeout_secs=7.5,
     headers=Vec::new(),
+    proxies=Vec::new(),
     max_retries=0,
     follow_redirects=false,
     max_body_size=83886080,
@@ -471,6 +497,7 @@ fn scan_http(
     concurrency: usize,
     timeout_secs: f64,
     headers: Vec<(String, String)>,
+    proxies: Vec<String>,
     max_retries: usize,
     follow_redirects: bool,
     max_body_size: usize,
@@ -543,24 +570,37 @@ fn scan_http(
                 header_map.insert(name, value);
             }
 
-            let client = reqwest::Client::builder()
-                .danger_accept_invalid_certs(true)
-                .default_headers(header_map)
-                .redirect(if follow_redirects {
-                    reqwest::redirect::Policy::limited(10)
-                } else {
-                    reqwest::redirect::Policy::none()
-                })
-                .timeout(std::time::Duration::from_secs_f64(timeout_secs))
-                .pool_max_idle_per_host(concurrency)
-                .build()
-                .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+            let use_raw_http = proxies.is_empty();
+            let clients = if proxies.is_empty() {
+                vec![build_http_client(
+                    &header_map,
+                    concurrency,
+                    timeout_secs,
+                    follow_redirects,
+                    None,
+                )
+                .map_err(|error| PyRuntimeError::new_err(error.to_string()))?]
+            } else {
+                proxies
+                    .iter()
+                    .map(|proxy_url| {
+                        build_http_client(
+                            &header_map,
+                            concurrency,
+                            timeout_secs,
+                            follow_redirects,
+                            Some(proxy_url),
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|error| PyRuntimeError::new_err(error.to_string()))?
+            };
 
             let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
             let mut tasks = Vec::with_capacity(paths.len());
 
-            for path in paths {
-                let client = client.clone();
+            for (request_index, path) in paths.into_iter().enumerate() {
+                let client = clients[request_index % clients.len()].clone();
                 let base_url = base_url.clone();
                 let raw_headers = raw_headers.clone();
                 let semaphore = semaphore.clone();
@@ -575,7 +615,7 @@ fn scan_http(
                     let url = format!("{base_url}{path}");
                     let start = Instant::now();
 
-                    if should_use_raw_http(&base_url, &path) {
+                    if use_raw_http && should_use_raw_http(&base_url, &path) {
                         let raw_base_url = base_url.clone();
                         let raw_path = path.clone();
                         let raw_filter_config = filter_config.clone();
@@ -1323,6 +1363,19 @@ mod tests {
     #[test]
     fn runtime_workers_follow_available_cpu_bounds() {
         assert!((1..=256).contains(&runtime_worker_count()));
+    }
+
+    #[test]
+    fn http_proxy_client_configuration_builds() {
+        let client = build_http_client(
+            &HeaderMap::new(),
+            25,
+            1.0,
+            false,
+            Some("http://user:password@127.0.0.1:8080"),
+        );
+
+        assert!(client.is_ok());
     }
 
     #[test]

--- a/tests/connection/test_native_backend.py
+++ b/tests/connection/test_native_backend.py
@@ -34,6 +34,8 @@ class TestNativeHTTPBackend(TestCase):
                 "thread_count": 7,
                 "timeout": 3.5,
                 "headers": {"user-agent": "dirsearch-test"},
+                "proxies": ["127.0.0.1:8080"],
+                "proxy_auth": "user:password",
                 "max_retries": 2,
                 "follow_redirects": False,
                 "include_status_codes": {200, 204},
@@ -85,6 +87,7 @@ class TestNativeHTTPBackend(TestCase):
         self.assertEqual(args[:2], ("https://example.com/", ["missing%20page"]))
         self.assertEqual(kwargs["concurrency"], 7)
         self.assertEqual(kwargs["timeout_secs"], 3.5)
+        self.assertEqual(kwargs["proxies"], ["http://user:password@127.0.0.1:8080"])
         self.assertEqual(kwargs["include_status_codes"], [200, 204])
         self.assertEqual(kwargs["exclude_status_codes"], [500])
         self.assertEqual(kwargs["minimum_response_size"], 10)

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -66,6 +66,9 @@ class RequestTargetTCPServer(socketserver.TCPServer):
 class RequestTargetHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         self.server.targets.append(self.raw_requestline.split(b" ")[1])
+        self.server.proxy_authorizations.append(
+            self.headers.get("Proxy-Authorization")
+        )
         body = b"ok"
         self.send_response(200)
         self.send_header("content-type", "text/plain")
@@ -81,6 +84,7 @@ class RequestTargetServer:
     def __enter__(self):
         self.server = RequestTargetTCPServer(("127.0.0.1", 0), RequestTargetHandler)
         self.server.targets = []
+        self.server.proxy_authorizations = []
         self.thread = threading.Thread(
             target=lambda: self.server.serve_forever(poll_interval=0.05),
             daemon=True,
@@ -101,6 +105,10 @@ class RequestTargetServer:
     @property
     def targets(self):
         return self.server.targets
+
+    @property
+    def proxy_authorizations(self):
+        return self.server.proxy_authorizations
 
 
 def normalize_percent_hex(target: bytes) -> bytes:
@@ -481,6 +489,29 @@ class TestNativeRequesterPathPreservation(BaseRequesterTestCase):
             self.assertCountEqual(
                 [normalize_percent_hex(target) for target in server.targets],
                 [expected for _, _, expected in REQUEST_TARGET_CASES],
+            )
+
+    def test_native_requester_uses_authenticated_http_proxy(self):
+        try:
+            backend = NativeHTTPBackend()
+        except RequestException as error:
+            self.skipTest(str(error))
+
+        with RequestTargetServer() as proxy:
+            options["proxies"] = [proxy.url]
+            options["proxy_auth"] = "user:password"
+            results = list(
+                backend.scan("http://origin.invalid/", ["admin"])
+            )
+
+            self.assertEqual([error for _, _, error in results], [None])
+            self.assertEqual(
+                proxy.targets,
+                [b"http://origin.invalid/admin"],
+            )
+            self.assertEqual(
+                proxy.proxy_authorizations,
+                ["Basic dXNlcjpwYXNzd29yZA=="],
             )
 
     def test_native_requester_appends_base_query(self):

--- a/tests/core/test_request_backend.py
+++ b/tests/core/test_request_backend.py
@@ -47,10 +47,35 @@ class TestRequestBackend(TestCase):
             "--request-backend native currently supports GET requests only",
         )
 
-    def test_native_rejects_proxies(self):
+    def test_native_accepts_http_proxies(self):
+        self.assertIsNone(
+            get_native_request_backend_error(
+                native_options(proxies=["127.0.0.1:8080", "https://proxy.example"])
+            )
+        )
+
+    def test_native_accepts_proxy_authentication(self):
+        self.assertIsNone(
+            get_native_request_backend_error(
+                native_options(
+                    proxies=["127.0.0.1:8080"],
+                    proxy_auth="user:password",
+                )
+            )
+        )
+
+    def test_native_rejects_socks_proxies(self):
         self.assertEqual(
-            get_native_request_backend_error(native_options(proxies=["127.0.0.1:8080"])),
-            "--request-backend native does not support proxies yet",
+            get_native_request_backend_error(
+                native_options(proxies=["socks5://127.0.0.1:1080"])
+            ),
+            "--request-backend native supports HTTP and HTTPS proxies only",
+        )
+
+    def test_native_rejects_tor(self):
+        self.assertEqual(
+            get_native_request_backend_error(native_options(tor=True)),
+            "--request-backend native does not support Tor or SOCKS proxies yet",
         )
 
     def test_native_rejects_ip_override(self):


### PR DESCRIPTION
## Summary

- accept HTTP and HTTPS proxy lists and proxy files with the native request backend
- preserve existing no-scheme proxy normalization and proxy credential behavior
- create one pooled reqwest client per proxy and distribute requests across the configured list
- keep raw direct-path transport disabled when a proxy is active so requests cannot bypass it
- continue rejecting Tor and SOCKS explicitly until the Rust dependency enables SOCKS support
- add Python option/bridge tests, Rust client construction coverage, and a real local authenticated proxy integration test

## Validation

GitHub Actions:
- Rust formatting and crate tests
- native wheel build and real proxy/request integration suite
- Python 3.11/3.14 matrix on Linux and Windows
- Docker stacks, CodeQL, and Semgrep
