### PR TITLE
Enable redirect following for native scans

### DIFF
--- a/lib/core/request_backend.py
+++ b/lib/core/request_backend.py
@@ -45,9 +45,6 @@ def get_native_request_backend_error(opt: Values) -> str | None:
         return "--request-backend native does not support --max-rate yet"
     if opt.delay:
         return "--request-backend native does not support --delay yet"
-    if opt.follow_redirects:
-        return "--request-backend native does not support --follow-redirects yet"
-
     for url in getattr(opt, "urls", ()):
         if error := get_native_target_error(url):
             return error

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -615,10 +615,7 @@ fn scan_http(
                     let url = format!("{base_url}{path}");
                     let start = Instant::now();
 
-                    if use_raw_http
-                        && !follow_redirects
-                        && should_use_raw_http(&base_url, &path)
-                    {
+                    if use_raw_http && !follow_redirects && should_use_raw_http(&base_url, &path) {
                         let raw_base_url = base_url.clone();
                         let raw_path = path.clone();
                         let raw_filter_config = filter_config.clone();

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -615,7 +615,10 @@ fn scan_http(
                     let url = format!("{base_url}{path}");
                     let start = Instant::now();
 
-                    if use_raw_http && should_use_raw_http(&base_url, &path) {
+                    if use_raw_http
+                        && !follow_redirects
+                        && should_use_raw_http(&base_url, &path)
+                    {
                         let raw_base_url = base_url.clone();
                         let raw_path = path.clone();
                         let raw_filter_config = filter_config.clone();

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -65,10 +65,17 @@ class RequestTargetTCPServer(socketserver.TCPServer):
 
 class RequestTargetHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
-        self.server.targets.append(self.raw_requestline.split(b" ")[1])
+        target = self.raw_requestline.split(b" ")[1]
+        self.server.targets.append(target)
         self.server.proxy_authorizations.append(
             self.headers.get("Proxy-Authorization")
         )
+        if target == b"/redirect":
+            self.send_response(302)
+            self.send_header("location", "/final")
+            self.end_headers()
+            return
+
         body = b"ok"
         self.send_response(200)
         self.send_header("content-type", "text/plain")
@@ -490,6 +497,20 @@ class TestNativeRequesterPathPreservation(BaseRequesterTestCase):
                 [normalize_percent_hex(target) for target in server.targets],
                 [expected for _, _, expected in REQUEST_TARGET_CASES],
             )
+
+    def test_native_requester_follows_redirects(self):
+        try:
+            backend = NativeHTTPBackend()
+        except RequestException as error:
+            self.skipTest(str(error))
+
+        options["follow_redirects"] = True
+        with RequestTargetServer() as server:
+            results = list(backend.scan(server.url, ["redirect"]))
+
+            self.assertEqual([error for _, _, error in results], [None])
+            self.assertEqual(results[0][1].status, 200)
+            self.assertEqual(server.targets, [b"/redirect", b"/final"])
 
     def test_native_requester_uses_authenticated_http_proxy(self):
         try:

--- a/tests/core/test_request_backend.py
+++ b/tests/core/test_request_backend.py
@@ -109,6 +109,13 @@ class TestRequestBackend(TestCase):
             "in target URLs yet",
         )
 
+    def test_native_accepts_follow_redirects(self):
+        self.assertIsNone(
+            get_native_request_backend_error(
+                native_options(follow_redirects=True)
+            )
+        )
+
     def test_native_rejects_delay(self):
         self.assertEqual(
             get_native_request_backend_error(native_options(delay=0.1)),


### PR DESCRIPTION
## Summary

- allow `--follow-redirects` with the native request backend
- use the existing bounded reqwest redirect policy for native requests
- avoid the direct raw HTTP fallback when redirects are requested, since that fallback intentionally performs a single request
- add option validation coverage and a real local redirect integration test

## Validation

GitHub Actions native build/integration, Python matrix, Docker stacks, CodeQL, and Semgrep.
