### PR TITLE
Fix macOS release builds

### DIFF
--- a/.github/workflows/portable-builds.yml
+++ b/.github/workflows/portable-builds.yml
@@ -68,6 +68,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends build-essential
 
       - name: Build portable folder
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ matrix.stack.name }}" = "native-rust" ]; then
             rustup default stable

--- a/pyinstaller/dirsearch.spec
+++ b/pyinstaller/dirsearch.spec
@@ -104,6 +104,20 @@ a = Analysis(
     noarchive=False,
 )
 
+# mysql-connector's C extension vendors OpenSSL on macOS. In a one-file
+# bundle, those dylibs can shadow the OpenSSL used by Python's ssl module.
+# Omit the extension and its vendor libraries so Connector/Python falls back
+# to its pure-Python implementation.
+if sys.platform == "darwin":
+    a.binaries = [
+        entry
+        for entry in a.binaries
+        if not (
+            entry[0].replace("\\", "/").startswith("mysql/vendor/")
+            or os.path.basename(entry[0]).startswith("_mysql_connector")
+        )
+    ]
+
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
 exe = EXE(

--- a/tests/test_native_install_packaging.py
+++ b/tests/test_native_install_packaging.py
@@ -49,6 +49,22 @@ class TestNativeInstallPackaging(TestCase):
             Path("pyinstaller/dirsearch.spec").read_text(encoding="utf-8"),
         )
 
+    def test_macos_pyinstaller_omits_mysql_vendor_openssl(self):
+        pyinstaller_spec = Path("pyinstaller/dirsearch.spec").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('if sys.platform == "darwin":', pyinstaller_spec)
+        self.assertIn('startswith("mysql/vendor/")', pyinstaller_spec)
+        self.assertIn('startswith("_mysql_connector")', pyinstaller_spec)
+
+    def test_portable_workflow_uses_github_token(self):
+        workflow = Path(".github/workflows/portable-builds.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("GITHUB_TOKEN: ${{ github.token }}", workflow)
+
     def test_install_docs_use_native_builder_flow(self):
         docs = Path("docs/installation.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- exclude mysql-connector's vendored OpenSSL libraries and C extension from macOS PyInstaller bundles
- keep MySQL report support through Connector/Python's pure-Python fallback
- authenticate python-build-standalone API requests in the portable-build matrix
- add packaging regression assertions

## Root cause

The macOS one-file bundles loaded `mysql/vendor/libssl.3.dylib` before Python 3.14's SSL dependency, causing `_ssl` to fail with a missing `SSL_SESSION_get_time_ex` symbol. One portable job also exhausted GitHub's unauthenticated API rate limit even though the build script already supports `GITHUB_TOKEN`.

## Validation

- `python3 -m unittest tests.test_native_install_packaging` (9 tests passed)
- Release run 31756543512 reproduced the macOS loader failure and API rate-limit failure; the release matrix will be rerun after merge.
