### PR TITLE
Resolve macOS OpenSSL before bundling

### DIFF
--- a/pyinstaller/dirsearch.spec
+++ b/pyinstaller/dirsearch.spec
@@ -81,6 +81,19 @@ report_templates = os.path.join(PROJECT_ROOT, 'lib', 'report')
 if os.path.exists(report_templates):
     datas.append((report_templates, 'lib/report'))
 
+excluded_imports = [
+    'tkinter',
+    'unittest',
+    'pydoc',
+    'doctest',
+    'test',
+    'tests',
+]
+if sys.platform == "darwin":
+    # Prevent PyInstaller from resolving Python's OpenSSL dependency through
+    # mysql-connector's incompatible vendored OpenSSL during Analysis.
+    excluded_imports.append("_mysql_connector")
+
 a = Analysis(
     [os.path.join(PROJECT_ROOT, 'dirsearch.py')],
     pathex=[PROJECT_ROOT],
@@ -90,14 +103,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[
-        'tkinter',
-        'unittest',
-        'pydoc',
-        'doctest',
-        'test',
-        'tests',
-    ],
+    excludes=excluded_imports,
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
     cipher=block_cipher,

--- a/tests/test_native_install_packaging.py
+++ b/tests/test_native_install_packaging.py
@@ -55,6 +55,10 @@ class TestNativeInstallPackaging(TestCase):
         )
 
         self.assertIn('if sys.platform == "darwin":', pyinstaller_spec)
+        self.assertIn(
+            'excluded_imports.append("_mysql_connector")',
+            pyinstaller_spec,
+        )
         self.assertIn('startswith("mysql/vendor/")', pyinstaller_spec)
         self.assertIn('startswith("_mysql_connector")', pyinstaller_spec)
 


### PR DESCRIPTION
## Summary

- exclude `_mysql_connector` during PyInstaller analysis on macOS
- keep the post-analysis vendor-library filter as a defensive check
- assert the pre-analysis exclusion in packaging tests

## Root cause

Filtering MySQL's vendored OpenSSL only after `Analysis` was too late. PyInstaller had already resolved Python 3.14's `_ssl` dependency through that incompatible copy; removing it afterward left `_ssl` with no `libssl.3.dylib`. Excluding the MySQL C extension before analysis lets PyInstaller resolve Python's OpenSSL correctly while Connector/Python keeps its pure-Python fallback.

## Validation

- macOS Intel: async, threaded, and native-rust builds passed in run 31762665287
- macOS Apple Silicon: async, threaded, and native-rust builds passed in run 31762666921
