### PR TITLE
Make scheme detection tests network independent

### DIFF
--- a/tests/utils/test_schemedet.py
+++ b/tests/utils/test_schemedet.py
@@ -16,14 +16,40 @@
 #  Author: Mauro Soria
 
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
-from lib.core.settings import DUMMY_DOMAIN
+from lib.core.settings import SOCKET_TIMEOUT
 from lib.utils.schemedet import detect_scheme
 
 
 class TestSchemedet(TestCase):
-    def test_detect_scheme(self):
-        self.assertEqual(detect_scheme(DUMMY_DOMAIN, 443), "https", "Incorrect scheme detected")
-        # These ports intentionally exercise the failed TLS probe fallback.
-        self.assertEqual(detect_scheme(DUMMY_DOMAIN, 80), "http", "Incorrect scheme detected")
-        self.assertEqual(detect_scheme(DUMMY_DOMAIN, 1234), "http", "Incorrect scheme detected")
+    def run_probe(self, connect_error=None):
+        raw_socket = Mock()
+        connection = Mock()
+        connection.connect.side_effect = connect_error
+        context = Mock()
+        context.wrap_socket.return_value = connection
+
+        with patch(
+            "lib.utils.schemedet.socket.socket", return_value=raw_socket
+        ) as socket_factory, patch(
+            "lib.utils.schemedet.ssl.create_default_context", return_value=context
+        ) as context_factory:
+            scheme = detect_scheme("example.test", 443)
+
+        socket_factory.assert_called_once_with()
+        raw_socket.settimeout.assert_called_once_with(SOCKET_TIMEOUT)
+        context_factory.assert_called_once_with()
+        context.wrap_socket.assert_called_once_with(
+            raw_socket, server_hostname="example.test"
+        )
+        connection.connect.assert_called_once_with(("example.test", 443))
+        connection.close.assert_called_once_with()
+
+        return scheme
+
+    def test_detects_https_when_tls_connection_succeeds(self):
+        self.assertEqual(self.run_probe(), "https")
+
+    def test_falls_back_to_http_when_tls_connection_fails(self):
+        self.assertEqual(self.run_probe(OSError("network unavailable")), "http")


### PR DESCRIPTION
## Summary

- replace external TLS probes in the scheme-detection test with mocked sockets
- cover both a successful TLS connection and the HTTP fallback after `OSError`
- assert timeout setup, TLS wrapping, destination, and connection cleanup

## Root cause

The test connected to `example.com`, so its result depended on outbound network access. Offline and sandboxed package builds could therefore fail even though `detect_scheme()` behaved correctly.

## Impact

Production behavior is unchanged. The test is now deterministic and does not perform DNS, TCP, or local socket binding.

## Validation

- `python -m unittest tests.utils.test_schemedet tests.test_optional_db_dependencies`
- `python -m flake8 tests/utils/test_schemedet.py`
- `python testing.py` (152 tests, 4 skipped)

Closes #1592
