### PR TITLE
Fix async shutdown task cleanup

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -464,24 +464,29 @@ class Controller:
         ) if options["max_time"] or options["target_max_time"] else None
 
         try:
-            await asyncio.wait_for(
-                asyncio.wait(
-                    [self.pause_future, task],
-                    return_when=asyncio.FIRST_COMPLETED,
-                ),
-                timeout=timeout,
-            )
-        except asyncio.TimeoutError:
-            if time.time() - self.start_time > options["max_time"] > 0:
-                raise QuitInterrupt("Runtime exceeded the maximum set by the user")
+            try:
+                await asyncio.wait_for(
+                    asyncio.wait(
+                        [self.pause_future, task],
+                        return_when=asyncio.FIRST_COMPLETED,
+                    ),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                if time.time() - self.start_time > options["max_time"] > 0:
+                    raise QuitInterrupt("Runtime exceeded the maximum set by the user")
 
-            raise SkipTargetInterrupt("Runtime for target exceeded the maximum set by the user")
+                raise SkipTargetInterrupt("Runtime for target exceeded the maximum set by the user")
 
-        if self.pause_future.done():
-            task.cancel()
-            await self.pause_future  # propagate the exception, if raised
+            if self.pause_future.done():
+                task.cancel()
+                await self.pause_future  # propagate the exception, if raised
 
-        await task  # propagate the exception, if raised
+            await task  # propagate the exception, if raised
+        finally:
+            if not task.done():
+                task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     def process(self, start_time: float) -> None:
         while True:

--- a/tests/controller/test_async_controller.py
+++ b/tests/controller/test_async_controller.py
@@ -1,0 +1,41 @@
+import asyncio
+import time
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.exceptions import QuitInterrupt
+
+
+class BlockingAsyncFuzzer:
+    def __init__(self):
+        self.started = asyncio.Event()
+        self.task = None
+
+    async def start(self):
+        self.task = asyncio.current_task()
+        self.started.set()
+        await asyncio.Event().wait()
+
+
+class TestAsyncController(IsolatedAsyncioTestCase):
+    async def test_quit_drains_cancelled_fuzzer_task(self):
+        controller = object.__new__(Controller)
+        controller.loop = asyncio.get_running_loop()
+        controller.pause_future = controller.loop.create_future()
+        controller.start_time = time.time()
+        controller.fuzzer = BlockingAsyncFuzzer()
+
+        with patch.dict(options, {"max_time": 0, "target_max_time": 0}):
+            run_task = controller.loop.create_task(
+                controller.start_coroutines(time.time())
+            )
+            await controller.fuzzer.started.wait()
+            controller.pause_future.set_exception(QuitInterrupt("quit"))
+
+            with self.assertRaisesRegex(QuitInterrupt, "quit"):
+                await run_task
+
+        self.assertTrue(controller.fuzzer.task.done())
+        self.assertTrue(controller.fuzzer.task.cancelled())


### PR DESCRIPTION
## Summary

- drain the async fuzzer task before propagating quit or timeout exceptions
- add regression coverage that verifies the cancelled fuzzer task is complete before shutdown returns

## Root cause

The controller cancelled `AsyncFuzzer.start()` when the pause future completed, then immediately awaited the pause future. When that future raised `QuitInterrupt`, control left `start_coroutines()` before the cancelled fuzzer task and its internal gather were awaited. Delayed workers made the resulting pending-task warning easier to reproduce.

The cleanup now runs in `finally`, ensuring the fuzzer task is cancelled when necessary and always drained before the original exception propagates.

## Impact

The `Ctrl+C` → `q` → `q` flow exits cleanly without `Task was destroyed but it is pending!` or unretrieved `CancelledError` warnings. Timeout exits receive the same cleanup guarantee.

## Validation

- `python -m unittest tests.controller.test_async_controller tests.core.test_async_fuzzer`
- `python testing.py` — 152 passed, 4 skipped
- manually reproduced the interactive quit sequence against a local HTTP server

Closes #1596