### PR TITLE
Guard against runaway deep-recursive scans on uniform responses

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -58,6 +58,7 @@ from lib.core.settings import (
     DEFAULT_SESSION_FILE,
     EXTENSION_RECOGNITION_REGEX,
     MAX_CONSECUTIVE_REQUEST_ERRORS,
+    MAX_RECURSIVE_UNIFORM_RESPONSES,
     NEW_LINE,
     SIGINT_FORCE_QUIT_THRESHOLD,
     SIGINT_WINDOW_SECONDS,
@@ -168,6 +169,10 @@ class Controller:
         self._handling_pause = False
         self._force_quit_handler = _create_force_quit_handler()
         self.loop = None  # Will be set if async mode is used
+        # Counters for the runaway recursion guard, keyed by
+        # (branch, status code, content length)
+        self._uniform_response_counts: dict[tuple[str, int, int], int] = {}
+        self._uniform_recursion_warned: set[str] = set()
 
         if options["session_file"]:
             self._import(options["session_file"])
@@ -506,6 +511,9 @@ class Controller:
             break
 
     def set_target(self, url: str) -> None:
+        self._uniform_response_counts.clear()
+        self._uniform_recursion_warned.clear()
+
         if options["request_backend"] == "native":
             if error := get_native_target_error(url):
                 raise InvalidURLException(error)
@@ -577,14 +585,17 @@ class Controller:
                 options["force_recursive"],
             )
         ):
-            if response.redirect:
-                new_path = clean_path(parse_path(response.redirect))
-                added_to_queue = self.recur_for_redirect(response.path, new_path)
-            elif len(response.history):
-                old_path = clean_path(parse_path(response.history[0]))
-                added_to_queue = self.recur_for_redirect(old_path, response.path)
-            else:
-                added_to_queue = self.recur(response.path)
+            added_to_queue: list[str] = []
+
+            if not self.is_runaway_recursion(self.fuzzer.base_path, response):
+                if response.redirect:
+                    new_path = clean_path(parse_path(response.redirect))
+                    added_to_queue = self.recur_for_redirect(response.path, new_path)
+                elif len(response.history):
+                    old_path = clean_path(parse_path(response.history[0]))
+                    added_to_queue = self.recur_for_redirect(old_path, response.path)
+                else:
+                    added_to_queue = self.recur(response.path)
 
             if added_to_queue:
                 interface.new_directories(added_to_queue)
@@ -732,6 +743,33 @@ class Controller:
                         raise skipexc
         finally:
             pass
+
+    def is_runaway_recursion(self, branch: str, response: BaseResponse) -> bool:
+        """Detect runaway recursion caused by servers replying with uniform
+        fallback pages (same status code and content length for every path).
+
+        Counts recursion-triggering responses per scanned branch and, once a
+        branch exceeds MAX_RECURSIVE_UNIFORM_RESPONSES identical responses,
+        stops recursing deeper into it. Returns True when recursion should be
+        skipped.
+        """
+
+        key = (branch, response.status, response.length)
+        count = self._uniform_response_counts.get(key, 0) + 1
+        self._uniform_response_counts[key] = count
+
+        if count < MAX_RECURSIVE_UNIFORM_RESPONSES:
+            return False
+
+        if branch not in self._uniform_recursion_warned:
+            self._uniform_recursion_warned.add(branch)
+            interface.warning(
+                f'{NEW_LINE}Stopped recursing deeper into "{branch}": received '
+                f"{count} responses with identical status ({response.status}) "
+                f"and size ({response.length}), likely wildcard responses"
+            )
+
+        return True
 
     def add_directory(self, path: str) -> None:
         """Add directory to the recursion queue"""

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -90,6 +90,10 @@ class BaseFuzzer:
     def set_base_path(self, path: str) -> None:
         self._base_path = path
 
+    @property
+    def base_path(self) -> str:
+        return self._base_path
+
     def get_scanners_for(self, path: str) -> Generator[BaseScanner, None, None]:
         # Clean the path, so can check for extensions/suffixes
         path = clean_path(path)

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -184,6 +184,12 @@ TEST_PATH_LENGTH = 6
 
 MAX_CONSECUTIVE_REQUEST_ERRORS = 75
 
+# Maximum number of identical (status code, content length) responses that may
+# trigger recursion within a single scanned branch before recursion is stopped
+# for that branch. Guards against runaway deep-recursive scans on web apps
+# serving the same fallback page for every path
+MAX_RECURSIVE_UNIFORM_RESPONSES = 10
+
 # Signal handling settings for PyInstaller Linux builds
 # Time window (seconds) for detecting rapid consecutive Ctrl+C presses
 SIGINT_WINDOW_SECONDS = 0.8

--- a/tests/controller/test_runaway_recursion_guard.py
+++ b/tests/controller/test_runaway_recursion_guard.py
@@ -1,0 +1,105 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.settings import MAX_RECURSIVE_UNIFORM_RESPONSES
+
+
+def make_response(status=200, length=1024, path="admin"):
+    return SimpleNamespace(
+        status=status,
+        length=length,
+        path=path,
+        redirect="",
+        history=[],
+    )
+
+
+class TestRunawayRecursionGuard(unittest.TestCase):
+    def setUp(self):
+        self.controller = object.__new__(Controller)
+        self.controller._uniform_response_counts = {}
+        self.controller._uniform_recursion_warned = set()
+
+    def test_allows_recursion_below_threshold(self):
+        response = make_response()
+
+        for _ in range(MAX_RECURSIVE_UNIFORM_RESPONSES - 1):
+            self.assertFalse(
+                self.controller.is_runaway_recursion("/admin/", response)
+            )
+
+    def test_blocks_recursion_at_threshold_and_beyond(self):
+        response = make_response()
+
+        for _ in range(MAX_RECURSIVE_UNIFORM_RESPONSES - 1):
+            self.controller.is_runaway_recursion("/admin/", response)
+
+        for _ in range(5):
+            self.assertTrue(
+                self.controller.is_runaway_recursion("/admin/", response)
+            )
+
+    def test_warning_logged_once_per_branch(self):
+        response = make_response()
+
+        with patch("lib.controller.controller.interface") as mock_interface:
+            for _ in range(MAX_RECURSIVE_UNIFORM_RESPONSES * 2):
+                self.controller.is_runaway_recursion("/admin/", response)
+
+        self.assertEqual(mock_interface.warning.call_count, 1)
+
+    def test_counter_scoped_per_branch(self):
+        response = make_response()
+
+        for _ in range(MAX_RECURSIVE_UNIFORM_RESPONSES - 1):
+            self.controller.is_runaway_recursion("/admin/", response)
+
+        # Same fingerprint on a different branch starts from a fresh count
+        self.assertFalse(self.controller.is_runaway_recursion("/blog/", response))
+
+    def test_distinct_fingerprints_tracked_separately(self):
+        first = make_response(status=200, length=1024)
+        second = make_response(status=200, length=2048)
+
+        for _ in range(MAX_RECURSIVE_UNIFORM_RESPONSES - 1):
+            self.assertFalse(self.controller.is_runaway_recursion("/", first))
+            self.assertFalse(self.controller.is_runaway_recursion("/", second))
+
+    def test_match_callback_skips_recursion_when_guard_trips(self):
+        controller = object.__new__(Controller)
+        controller._uniform_response_counts = {}
+        controller._uniform_recursion_warned = set()
+        controller.directories = []
+        controller.passed_urls = set()
+        controller.url = "https://example.com/"
+        controller.base_path = ""
+        controller.fuzzer = SimpleNamespace(base_path="/")
+
+        with patch.dict(
+            options,
+            {
+                "recursion_status_codes": {200},
+                "recursive": True,
+                "deep_recursive": False,
+                "force_recursive": False,
+                "skip_on_status": set(),
+                "full_url": False,
+                "replay_proxy": None,
+                "crawl": False,
+                "exclude_subdirs": [],
+                "recursion_depth": 0,
+            },
+        ), patch("lib.controller.controller.interface") as mock_interface:
+            for i in range(MAX_RECURSIVE_UNIFORM_RESPONSES + 3):
+                controller.match_callback(make_response(path=f"word{i}/"))
+
+        added = len(controller.directories)
+        self.assertEqual(added, MAX_RECURSIVE_UNIFORM_RESPONSES - 1)
+        self.assertEqual(mock_interface.warning.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
On apps serving an identical fallback page for every path (common with React/Next.js/Angular), `-r --deep-recursive -i 200` never stops: every same-size 200 response is treated as a found directory and deep-recursed, so the scan queue grows endlessly with no new results.

This adds a bounded recursion guard: while scanning a branch, dirsearch counts responses that trigger recursion by `(status code, content length)` under that branch. After `MAX_RECURSIVE_UNIFORM_RESPONSES` (10, configurable via settings) identical responses, it stops recursing deeper into that branch and logs a warning once:

```
Stopped recursing deeper into "/admin/": received 10 responses with identical status (200) and size (1024), likely wildcard responses
```

Behavior is otherwise identical — filters, redirects-based recursion, replay-proxy, and crawl are unaffected, and branches with diverse responses are never throttled.

Commands run: `python -m pytest tests/` (197 passed, 4 skipped), flake8 on touched files, plus new `tests/controller/test_runaway_recursion_guard.py` covering the guard offline with synthetic responses.

Fixes #1492
