### PR TITLE
Unify fuzzer response fingerprint bookkeeping

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -48,6 +48,32 @@ AUTO_CALIBRATION_FORCED_THRESHOLD = 3
 AUTO_CALIBRATION_MIN_CONTENT_LENGTH = 32
 
 
+class FingerprintCache:
+    """Single bookkeeping cache for repeated-response fingerprints.
+
+    Tracks how many times each fingerprint was recorded and which
+    fingerprints have been calibrated as noise. Fingerprints may be exact
+    response hashes or fuzzy response tuples; each caller keeps its own key
+    space, so the two never collide.
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict = {}
+        self._calibrated: set = set()
+
+    def count(self, fingerprint) -> int:
+        return self._counts.get(fingerprint, 0)
+
+    def record(self, fingerprint) -> None:
+        self._counts[fingerprint] = self.count(fingerprint) + 1
+
+    def calibrate(self, fingerprint) -> None:
+        self._calibrated.add(fingerprint)
+
+    def is_calibrated(self, fingerprint) -> bool:
+        return fingerprint in self._calibrated
+
+
 def response_headers_text(resp: BaseResponse) -> str:
     return "\n".join(f"{name}: {value}" for name, value in resp.headers.items())
 
@@ -74,12 +100,10 @@ class BaseFuzzer:
         self._requester = requester
         self._dictionary = dictionary
         self._base_path: str = ""
-        self._hashes: dict = {}
         self.match_callbacks = match_callbacks
         self.not_found_callbacks = not_found_callbacks
         self.error_callbacks = error_callbacks
-        self._similar_fingerprints: dict[tuple, int] = {}
-        self._auto_calibrated_fingerprints: set[tuple] = set()
+        self._fingerprints = FingerprintCache()
 
         self.scanners: dict[str, dict[str, Scanner]] = {
             "default": {},
@@ -161,7 +185,7 @@ class BaseFuzzer:
 
         if (
             options["filter_threshold"]
-            and self._hashes.get(hash(resp), 0) >= options["filter_threshold"]
+            and self._fingerprints.count(hash(resp)) >= options["filter_threshold"]
         ):
             return True
 
@@ -223,26 +247,24 @@ class BaseFuzzer:
 
     def is_auto_calibrated(self, resp: BaseResponse) -> bool:
         fingerprint = self.response_fingerprint(resp)
-        if fingerprint in self._auto_calibrated_fingerprints:
+        if self._fingerprints.is_calibrated(fingerprint):
             logger.debug(f'"{resp.url}" filtered by auto-calibration fingerprint')
             return True
 
         if not self.should_record_auto_calibration(resp):
             return False
 
-        self._similar_fingerprints[fingerprint] = (
-            self._similar_fingerprints.get(fingerprint, 0) + 1
-        )
+        self._fingerprints.record(fingerprint)
         threshold = (
             AUTO_CALIBRATION_FORCED_THRESHOLD
             if options["auto_calibration"]
             else AUTO_CALIBRATION_DUPLICATE_THRESHOLD
         )
 
-        if self._similar_fingerprints[fingerprint] < threshold:
+        if self._fingerprints.count(fingerprint) < threshold:
             return False
 
-        self._auto_calibrated_fingerprints.add(fingerprint)
+        self._fingerprints.calibrate(fingerprint)
         logger.debug(
             f'"{resp.url}" filtered by repeated response auto-calibration '
             f'(threshold={threshold})'
@@ -317,9 +339,7 @@ class BaseFuzzer:
                 return
 
         if options["filter_threshold"]:
-            hash_ = hash(response)
-            self._hashes.setdefault(hash_, 0)
-            self._hashes[hash_] += 1
+            self._fingerprints.record(hash(response))
 
         for callback in self.match_callbacks:
             callback(response)

--- a/tests/core/test_advanced_filters.py
+++ b/tests/core/test_advanced_filters.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from uuid import uuid4
 
 from lib.connection.response import NativeResponse
 from lib.core.data import blacklists, options
@@ -218,3 +219,43 @@ class TestAdvancedFilters(TestCase):
         self.assertFalse(self.fuzzer.is_excluded(repeated[0]))
         self.assertFalse(self.fuzzer.is_excluded(repeated[1]))
         self.assertTrue(self.fuzzer.is_excluded(repeated[2]))
+
+    def test_filter_threshold_skips_repeated_static_pages(self):
+        options["filter_threshold"] = 2
+        matches = []
+        misses = []
+        fuzzer = BaseFuzzer(
+            None,
+            DummyDictionary(),
+            match_callbacks=(matches.append,),
+            not_found_callbacks=(misses.append,),
+            error_callbacks=(),
+        )
+
+        for _ in range(3):
+            fuzzer.process_response("admin", response(body=b"admin panel"))
+
+        self.assertEqual(len(matches), 2)
+        self.assertEqual(len(misses), 1)
+        self.assertFalse(fuzzer.is_excluded(response(body=b"unique static page")))
+
+    def test_calibrated_fingerprint_filters_dynamic_page_false_positives(self):
+        options["auto_calibration"] = True
+
+        def dynamic_page(index):
+            return response(
+                path=f"missing-{index}",
+                body=(
+                    f"error {uuid4()} while serving session {uuid4()} "
+                    "soft 404 template body shared across dynamic pages"
+                ).encode(),
+            )
+
+        pages = [dynamic_page(index) for index in range(5)]
+        self.assertFalse(self.fuzzer.is_excluded(pages[0]))
+        self.assertFalse(self.fuzzer.is_excluded(pages[1]))
+        self.assertTrue(self.fuzzer.is_excluded(pages[2]))
+
+        for page in pages[3:]:
+            self.assertNotEqual(hash(page), hash(pages[0]))
+            self.assertTrue(self.fuzzer.is_excluded(page))


### PR DESCRIPTION
`Fuzzer` tracked dynamic-page fingerprints in two separate structures (`_hashes` and `_auto_calibrated_fingerprints`) with overlapping bookkeeping — flagged in #1600. This unifies them behind a single fingerprint cache while preserving observable behavior exactly: calibrated fingerprints still prevent false-positive recursion on dynamic pages, static-page hash skipping still works, and filter ordering is unchanged.

`lib/core/fuzzer.py` holds the unified cache; `tests/core/test_advanced_filters.py` gains coverage pinning both legacy behaviors through the new path. Full suite: 193 passed, 4 skipped (pre-existing skips).

Fixes #1600
