### PR TITLE
Split CLI help and document wordlist placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Split CLI help into common (`-h` / `--help`) and complete (`-hh` / `--help-all`) views.
+- Documented the complete template wordlist placeholder reference.
+
 ## [0.5.0] - May 29, 2026
 This release includes all user-facing changes since the last published release,
 `v0.4.3`.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ python3 dirsearch.py -u https://target -e php,html,js -w /path/to/wordlist
 python3 dirsearch.py -u https://target -r --max-recursion-depth 3
 ```
 
-Use `python3 dirsearch.py -h` for the full CLI help.
+Use `python3 dirsearch.py -h` for common options or `python3 dirsearch.py -hh`
+for the complete CLI help.
 
 ## Python API
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,11 +1,15 @@
 # CLI Options
 
+Use `-h` or `--help` for common options. The complete reference below is
+available from `-hh` or `--help-all`.
+
 ```text
 Usage: dirsearch.py [-u|--url] target [-e|--extensions] extensions [options]
 
 Options:
   --version             show program's version number and exit
-  -h, --help            show this help message and exit
+  -h, --help            Show common options and exit
+  --help-all            Show all options and exit (short form: -hh)
 
   Mandatory:
     -u URL, --url=URL   Target URL(s), can use multiple flags

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,8 @@
 
 [![Dirsearch demo](https://asciinema.org/a/380112.svg)](https://asciinema.org/a/380112)
 
-These examples cover the most common arguments. Use `python3 dirsearch.py -h` for the complete option list.
+These examples cover the most common arguments. Use `python3 dirsearch.py -h`
+for common options or `python3 dirsearch.py -hh` for the complete option list.
 
 ## Simple Usage
 

--- a/docs/wordlists.md
+++ b/docs/wordlists.md
@@ -3,7 +3,7 @@
 ## Summary
 
 - A wordlist is a text file where each line is a path.
-- Unlike other tools, dirsearch only replaces the `%EXT%` keyword with extensions from the `-e` flag.
+- In ordinary wordlists, dirsearch replaces the `%EXT%` keyword with extensions from the `-e` flag.
 - For wordlists without `%EXT%`, such as [SecLists](https://github.com/danielmiessler/SecLists), use `-f` / `--force-extensions` to append extensions and `/` to every wordlist entry.
 - To apply selected extensions to entries that already have extensions, use `--overwrite-extensions`.
 - Some extensions are excluded from overwrite behavior, such as `.log`, `.json`, `.xml`, and media extensions like `.jpg` and `.png`.
@@ -83,17 +83,26 @@ python3 dirsearch.py -u https://target --wordlist-categories all
 
 ## Templates
 
-Template wordlists live in `db/templates/` and support placeholders such as:
+Template wordlists live in `db/templates/` and support these placeholders:
 
-- `%SUBJECT%`
-- `%CRUD_OP%`
-- `%AUTH_OP%`
-- `%ADMIN_OP%`
-- `%ENV%`
-- `%DATE%`
-- `%API_VERSION%`
-- `%CATEGORY:name%`
-- `%EXT%`
+- `%EXT%`: extensions supplied with `-e` / `--extensions`.
+- `%SUBJECT%`: common resources such as users, accounts, posts, products, orders, and invoices.
+- `%CRUD_OP%`: create, read, update, delete, list, get, add, edit, remove, and search.
+- `%AUTH_OP%`: login, logout, signin, signout, signup, register, reset, forgot, password, oauth, and sso.
+- `%ADMIN_OP%`: admin, dashboard, panel, manage, settings, users, roles, and permissions.
+- `%ENV%`: dev, development, test, stage, staging, prod, production, and local.
+- `%SEP%`: separators `-`, `_`, `.`, and `/`.
+- `%DB%` and its compatibility alias `%DB_ENGINE%`: mysql, postgres, postgresql, sqlite, mariadb, mongodb, and redis.
+- `%ARCHIVE%` and its compatibility alias `%ARCHIVE_EXT%`: zip, tar, tar.gz, tgz, gz, 7z, rar, and bak.
+- `%API_VERSION%`: v1, v2, v3, v4, latest, and beta.
+- `%YYYY%`, `%YY%`, `%MM%`, and `%DD%`: components of the current date when the wordlist is generated.
+- `%DATE%`: the current date in `YYYY-MM-DD` form.
+- `%DATE_COMPACT%`: the current date in `YYYYMMDD` form.
+- `%CATEGORY:name%`: entries from `db/categories/name.txt` or a mapped bundled category.
+
+Repeated placeholders reuse the same value within a line. Distinct placeholders
+expand as a Cartesian product, unknown placeholders remain unchanged, and
+placeholders with no values emit no entries.
 
 Preview resolved files and generated entry counts without scanning:
 

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -16,6 +16,7 @@
 #
 #  Author: Mauro Soria
 
+from copy import copy
 from optparse import OptionParser, OptionGroup, Values
 
 
@@ -27,10 +28,159 @@ from lib.core.settings import (
 from lib.utils.common import get_config_file
 
 
-def parse_arguments() -> Values:
+COMMON_HELP_OPTIONS = frozenset(
+    {
+        "--version",
+        "--help",
+        "--help-all",
+        "--url",
+        "--urls-file",
+        "--stdin",
+        "--cidr",
+        "--raw",
+        "--session",
+        "--config",
+        "--wordlists",
+        "--wordlist-categories",
+        "--extensions",
+        "--force-extensions",
+        "--exclude-extensions",
+        "--prefixes",
+        "--suffixes",
+        "--threads",
+        "--async",
+        "--no-async",
+        "--recursive",
+        "--max-recursion-depth",
+        "--recursion-status",
+        "--include-status",
+        "--exclude-status",
+        "--exclude-sizes",
+        "--exclude-text",
+        "--exclude-regex",
+        "--exclude-redirect",
+        "--max-time",
+        "--target-max-time",
+        "--http-method",
+        "--data",
+        "--header",
+        "--follow-redirects",
+        "--random-agent",
+        "--user-agent",
+        "--cookie",
+        "--auth",
+        "--auth-type",
+        "--timeout",
+        "--delay",
+        "--proxy",
+        "--tor",
+        "--scheme",
+        "--max-rate",
+        "--retries",
+        "--crawl",
+        "--full-url",
+        "--no-color",
+        "--quiet-mode",
+        "--verbose",
+        "--output-formats",
+        "--output-file",
+        "--log",
+    }
+)
+
+
+class DirsearchOptionParser(OptionParser):
+    def _process_short_opts(self, rargs, values) -> None:
+        # optparse treats -hh as two -h flags unless it is handled explicitly.
+        if rargs[0] == "-hh":
+            rargs[0] = "--help-all"
+            self._process_long_opt(rargs, values)
+            return
+
+        super()._process_short_opts(rargs, values)
+
+
+def _iter_options(parser: OptionParser):
+    yield from parser.option_list
+    for group in parser.option_groups:
+        yield from group.option_list
+
+
+def _is_common_help_option(option) -> bool:
+    return bool(
+        COMMON_HELP_OPTIONS.intersection(option._short_opts + option._long_opts)
+    )
+
+
+def _build_common_help_parser(parser: OptionParser) -> OptionParser:
+    available_options = {
+        option_string
+        for option in _iter_options(parser)
+        for option_string in option._short_opts + option._long_opts
+    }
+    missing_options = COMMON_HELP_OPTIONS - available_options
+    if missing_options:
+        raise RuntimeError(
+            f"Unknown common help options: {', '.join(sorted(missing_options))}"
+        )
+
+    common_parser = OptionParser(
+        usage=parser.usage,
+        description=parser.description,
+        epilog=(
+            "Use '-hh' or '--help-all' to show every option. "
+            f"{parser.epilog}"
+        ),
+        add_help_option=False,
+    )
+
+    for option in parser.option_list:
+        if _is_common_help_option(option):
+            common_parser.add_option(copy(option))
+
+    for group in parser.option_groups:
+        common_group = OptionGroup(common_parser, group.title, group.description)
+        for option in group.option_list:
+            if _is_common_help_option(option):
+                common_group.add_option(copy(option))
+        if common_group.option_list:
+            common_parser.add_option_group(common_group)
+
+    return common_parser
+
+
+def _show_common_help(option, option_string, value, parser: OptionParser) -> None:
+    _build_common_help_parser(parser).print_help()
+    parser.exit()
+
+
+def _show_all_help(option, option_string, value, parser: OptionParser) -> None:
+    parser.print_help()
+    parser.exit()
+
+
+def parse_arguments(arguments: list[str] | None = None) -> Values:
     usage = "Usage: %prog [-u|--url] target [-e|--extensions] extensions [options]"
     epilog = "See 'config.ini' for the example configuration file"
-    parser = OptionParser(usage=usage, epilog=epilog, version=f"dirsearch v{VERSION}")
+    parser = DirsearchOptionParser(
+        usage=usage,
+        epilog=epilog,
+        version=f"dirsearch v{VERSION}",
+        add_help_option=False,
+    )
+    parser.add_option(
+        "-h",
+        "--help",
+        action="callback",
+        callback=_show_common_help,
+        help="Show common options and exit",
+    )
+    parser.add_option(
+        "--help-all",
+        action="callback",
+        callback=_show_all_help,
+        help="Show all options and exit (short form: -hh)",
+    )
 
     # Mandatory arguments
     mandatory = OptionGroup(parser, "Mandatory")
@@ -774,6 +924,6 @@ def parse_arguments() -> Values:
     parser.add_option_group(advanced)
     parser.add_option_group(view)
     parser.add_option_group(output)
-    options, _ = parser.parse_args()
+    options, _ = parser.parse_args(arguments)
 
     return options

--- a/testing.py
+++ b/testing.py
@@ -50,6 +50,7 @@ from tests.core.test_native_fuzzer import TestNativeFuzzer  # noqa: F401
 from tests.core.test_request_backend import TestRequestBackend  # noqa: F401
 from tests.core.test_scanner import TestScanner  # noqa: F401
 from tests.core.test_wordlist_backend import TestWordlistBackend  # noqa: F401
+from tests.parse.test_cmdline import TestCommandLineHelp  # noqa: F401
 from tests.parse.test_config import TestConfigParser  # noqa: F401
 from tests.parse.test_headers import TestHeadersParser  # noqa: F401
 from tests.parse.test_rawrequest import TestRawRequestParser  # noqa: F401

--- a/tests/core/test_dictionary_templates.py
+++ b/tests/core/test_dictionary_templates.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os
 import tempfile
+from pathlib import Path
 from unittest import TestCase
 
 from lib.core.data import options
 from lib.core.dictionary import Dictionary
 from lib.core.exceptions import WordlistLimitError
+from lib.core.wordlist_template import DEFAULT_PLACEHOLDERS
 
 
 class TestDictionaryTemplates(TestCase):
@@ -83,3 +85,22 @@ class TestDictionaryTemplates(TestCase):
 
         with self.assertRaises(WordlistLimitError):
             self._dictionary("%CRUD_OP%_articles.php")
+
+    def test_wordlist_documentation_lists_all_supported_placeholders(self):
+        documentation = (
+            Path(__file__).parents[2] / "docs" / "wordlists.md"
+        ).read_text(encoding="utf-8")
+        placeholders = set(DEFAULT_PLACEHOLDERS) | {
+            "EXT",
+            "YYYY",
+            "YY",
+            "MM",
+            "DD",
+            "DATE",
+            "DATE_COMPACT",
+        }
+
+        for placeholder in sorted(placeholders):
+            with self.subTest(placeholder=placeholder):
+                self.assertIn(f"%{placeholder}%", documentation)
+        self.assertIn("%CATEGORY:name%", documentation)

--- a/tests/parse/test_cmdline.py
+++ b/tests/parse/test_cmdline.py
@@ -1,0 +1,52 @@
+import io
+from contextlib import redirect_stdout
+from unittest import TestCase
+
+from lib.parse.cmdline import parse_arguments
+
+
+class TestCommandLineHelp(TestCase):
+    def _help_output(self, *arguments: str) -> str:
+        output = io.StringIO()
+        with redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            parse_arguments(list(arguments))
+
+        self.assertEqual(raised.exception.code, 0)
+        return output.getvalue()
+
+    def test_common_help_aliases_match(self):
+        self.assertEqual(self._help_output("-h"), self._help_output("--help"))
+
+    def test_common_help_uses_explicit_option_selection(self):
+        output = self._help_output("-h")
+
+        self.assertIn("--wordlists", output)
+        self.assertIn("--threads", output)
+        self.assertIn("--output-file", output)
+        self.assertIn("Use '-hh' or '--help-all' to show every option", output)
+        self.assertNotIn("--wordlist-backend", output)
+        self.assertNotIn("--match-header-regex", output)
+        self.assertNotIn("--mysql-url", output)
+
+    def test_full_help_aliases_match(self):
+        short_output = self._help_output("-hh")
+        long_output = self._help_output("--help-all")
+
+        self.assertEqual(short_output, long_output)
+        self.assertIn("--wordlist-backend", short_output)
+        self.assertIn("--match-header-regex", short_output)
+        self.assertIn("--mysql-url", short_output)
+
+    def test_help_change_does_not_affect_normal_parsing(self):
+        parsed = parse_arguments(
+            ["-u", "https://example.com", "-w", "words.txt", "-t", "20"]
+        )
+
+        self.assertEqual(parsed.urls, ["https://example.com"])
+        self.assertEqual(parsed.wordlists, "words.txt")
+        self.assertEqual(parsed.thread_count, 20)
+
+    def test_help_alias_can_still_be_an_option_value(self):
+        parsed = parse_arguments(["-H", "-hh"])
+
+        self.assertEqual(parsed.headers, ["-hh"])


### PR DESCRIPTION
## Summary

- keep `-h` / `--help` focused on an explicit list of common options
- add `-hh` / `--help-all` for the complete option reference
- document every supported template wordlist placeholder and compatibility alias
- add CLI compatibility tests and a documentation-sync regression test

Closes #1595
Closes #1598

## Compatibility

Existing scan options and parsing behavior are unchanged. The exact `-hh` token is handled before `optparse` expands short-option clusters, while values such as `-H -hh` remain valid. `--help` still exits successfully, and the complete former help remains available through the new full-help aliases.

## Validation

- `python -m unittest tests.parse.test_cmdline tests.core.test_dictionary_templates`
- `python testing.py` — 158 tests passed, 4 skipped
- `flake8 .`
- `codespell -S CONTRIBUTORS.md,./db/categories/*,./build`
- `python -m pip install .`
- installed CLI smoke tests for `--version`, `-h`, `-hh`, and `--help-all`
