### PR TITLE
Preserve in-flight paths in saved sessions

### DIFF
--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -55,6 +55,7 @@ class Dictionary:
         # Items in self._extra will be cleared when self.reset() is called
         self._extra_index = 0
         self._extra = []
+        self._claimed = []
 
     @property
     def index(self) -> int:
@@ -71,14 +72,40 @@ class Dictionary:
         else:
             raise StopIteration
 
+    @locked
+    def claim_next(self) -> str:
+        """Return the next path and keep it recoverable until released."""
+        if len(self._extra) > self._extra_index:
+            path = self._extra[self._extra_index]
+            self._claimed.append(path)
+            self._extra_index += 1
+            return path
+        elif len(self._items) > self._index:
+            path = self._items[self._index]
+            self._claimed.append(path)
+            self._index += 1
+            return path
+        else:
+            raise StopIteration
+
+    @locked
+    def release_claim(self, path: str) -> None:
+        self._claimed.remove(path)
+
     def __contains__(self, item: str) -> bool:
         return item in self._items
 
-    def __getstate__(self) -> tuple[list[str], int]:
-        return self._items, self._index, self._extra, self._extra_index
+    def __getstate__(self) -> tuple[list[str], int, list[str], int]:
+        extra = (
+            self._extra[:self._extra_index]
+            + self._claimed
+            + self._extra[self._extra_index:]
+        )
+        return list(self._items), self._index, extra, self._extra_index
 
-    def __setstate__(self, state: tuple[list[str], int]) -> None:
+    def __setstate__(self, state: tuple[list[str], int, list[str], int]) -> None:
         self._items, self._index, self._extra, self._extra_index = state
+        self._claimed = []
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._items)
@@ -118,3 +145,4 @@ class Dictionary:
     def reset(self) -> None:
         self._index = self._extra_index = 0
         self._extra.clear()
+        self._claimed.clear()

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -514,15 +514,19 @@ class NativeFuzzer(Fuzzer):
                 ):
                     if self._quit_event.is_set():
                         break
-                    if error is not None:
-                        for callback in self.error_callbacks:
-                            callback(error)
-                        continue
-                    if response.filtered:
-                        for callback in self.not_found_callbacks:
-                            callback(response)
-                        continue
-                    self.process_response(path, response)
+                    try:
+                        if error is not None:
+                            for callback in self.error_callbacks:
+                                callback(error)
+                            continue
+                        if response.filtered:
+                            for callback in self.not_found_callbacks:
+                                callback(response)
+                            continue
+                        self.process_response(path, response)
+                    finally:
+                        dictionary_path = lstrip_once(path, self._base_path)
+                        self._dictionary.release_claim(dictionary_path)
         finally:
             self._finished = True
 
@@ -531,7 +535,7 @@ class NativeFuzzer(Fuzzer):
         paths = []
         for _ in range(chunk_size):
             try:
-                paths.append(self._base_path + next(self._dictionary))
+                paths.append(self._base_path + self._dictionary.claim_next())
             except StopIteration:
                 break
         return paths
@@ -636,11 +640,14 @@ class AsyncFuzzer(BaseFuzzer):
             await self._play_event.wait()
 
             try:
-                path = next(self._dictionary)
+                path = self._dictionary.claim_next()
             except StopIteration:
                 return
 
-            async with self.sem:
-                await self.scan(self._base_path + path)
+            try:
+                async with self.sem:
+                    await self.scan(self._base_path + path)
+            finally:
+                self._dictionary.release_claim(path)
 
             await asyncio.sleep(options["delay"])

--- a/tests/core/test_async_fuzzer.py
+++ b/tests/core/test_async_fuzzer.py
@@ -1,7 +1,9 @@
+import asyncio
 from unittest import IsolatedAsyncioTestCase
 
 from lib.connection.response import NativeResponse
 from lib.core.data import blacklists, options
+from lib.core.dictionary import Dictionary
 from lib.core.fuzzer import AsyncFuzzer
 
 
@@ -18,6 +20,12 @@ class DummyDictionary:
 
     def __len__(self):
         return len(self.paths)
+
+    def claim_next(self):
+        return next(self)
+
+    def release_claim(self, path):
+        return None
 
 
 class DummyAsyncRequester:
@@ -36,6 +44,25 @@ class DummyAsyncRequester:
             [("Content-Type", "text/plain")],
             b"not found",
         )
+
+
+class BlockingAsyncRequester:
+    def __init__(self):
+        self.started = asyncio.Event()
+
+    async def request(self, path):
+        self.started.set()
+        await asyncio.Event().wait()
+
+
+def make_dictionary(paths):
+    dictionary = object.__new__(Dictionary)
+    dictionary._items = list(paths)
+    dictionary._index = 0
+    dictionary._extra = []
+    dictionary._extra_index = 0
+    dictionary._claimed = []
+    return dictionary
 
 
 class TestAsyncFuzzer(IsolatedAsyncioTestCase):
@@ -88,3 +115,32 @@ class TestAsyncFuzzer(IsolatedAsyncioTestCase):
         self.assertEqual([response.full_path for response in matches], ["home.html"])
         self.assertEqual(misses, [])
         self.assertEqual(errors, [])
+
+    async def test_saved_state_retries_cancelled_in_flight_path(self):
+        dictionary = make_dictionary(["admin", "login"])
+        requester = BlockingAsyncRequester()
+        fuzzer = AsyncFuzzer(
+            requester,
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+
+        async def skip_scanners():
+            return None
+
+        fuzzer.setup_scanners = skip_scanners
+        run_task = asyncio.create_task(fuzzer.start())
+        await requester.started.wait()
+
+        saved_state = dictionary.__getstate__()
+        run_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await run_task
+
+        resumed = object.__new__(Dictionary)
+        resumed.__setstate__(saved_state)
+        self.assertEqual([next(resumed), next(resumed)], ["admin", "login"])
+        with self.assertRaises(StopIteration):
+            next(resumed)

--- a/tests/core/test_fuzzer_filter_stacks.py
+++ b/tests/core/test_fuzzer_filter_stacks.py
@@ -20,6 +20,12 @@ class DummyDictionary:
     def __len__(self):
         return len(self.paths)
 
+    def claim_next(self):
+        return next(self)
+
+    def release_claim(self, path):
+        return None
+
 
 def stack_response(path, body, *, filtered=False, filter_reason=None):
     return NativeResponse(

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from lib.connection.response import NativeResponse
 from lib.core.data import blacklists, options
+from lib.core.dictionary import Dictionary
 from lib.core.exceptions import RequestException
 from lib.core.fuzzer import NativeFuzzer
 
@@ -19,6 +20,12 @@ class DummyDictionary:
     def __len__(self):
         return len(self.paths)
 
+    def claim_next(self):
+        return next(self)
+
+    def release_claim(self, path):
+        return None
+
 
 class DummyRequester:
     _url = "https://example.com/"
@@ -32,6 +39,16 @@ class FakeNativeBackend:
     def scan(self, base_url, paths, query=""):
         self.calls.append((base_url, list(paths), query))
         yield from self.items
+
+
+def make_dictionary(paths):
+    dictionary = object.__new__(Dictionary)
+    dictionary._items = list(paths)
+    dictionary._index = 0
+    dictionary._extra = []
+    dictionary._extra_index = 0
+    dictionary._claimed = []
+    return dictionary
 
 
 class TestNativeFuzzer(TestCase):
@@ -151,3 +168,17 @@ class TestNativeFuzzer(TestCase):
         self.assertEqual(misses, [response])
         self.assertEqual(errors, [])
         self.assertEqual(response.length, 64)
+
+    def test_saved_state_retries_unreturned_chunk_paths(self):
+        dictionary = make_dictionary(["admin", "login"])
+        backend = FakeNativeBackend([])
+        fuzzer = self.make_fuzzer(backend, dictionary, [], [], [])
+
+        fuzzer.start()
+        saved_state = dictionary.__getstate__()
+
+        resumed = object.__new__(Dictionary)
+        resumed.__setstate__(saved_state)
+        self.assertEqual([next(resumed), next(resumed)], ["admin", "login"])
+        with self.assertRaises(StopIteration):
+            next(resumed)


### PR DESCRIPTION
## Summary

- track paths claimed by async and native fuzzers until their result is processed
- include unfinished claims in serialized dictionary state so session resume retries them
- add regressions for async cancellation and interrupted native chunks

## Root cause

The dictionary index advances when a worker claims a path. Async pause immediately opens the menu, so saving and quitting can serialize that advanced index before in-flight tasks complete; controller cleanup then cancels those tasks. The same claimed-path accounting is required for interruptible native chunks because a whole chunk is reserved before Rust returns results.

Threaded mode already drains active requests before session export. This change gives async and native saved sessions the same at-least-once coverage guarantee without replaying paths whose callbacks completed.

## Validation

- `python -m unittest tests.core.test_async_fuzzer tests.core.test_native_fuzzer tests.core.test_fuzzer_filter_stacks tests.controller.test_session_store tests.controller.test_async_controller`
- `python testing.py` — 154 passed, 4 skipped