### PR TITLE
Reuse and interrupt the native HTTP engine

### DIFF
--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -20,6 +20,25 @@ class NativeHTTPBackend:
             raise RequestException(get_native_backend_install_error()) from e
 
         self._native = dirsearch_native
+        self._engine = None
+        self._engine_config = None
+
+    def _get_engine(self):
+        config = {
+            "concurrency": options["thread_count"],
+            "timeout_secs": options["timeout"],
+            "headers": list(options["headers"].items()),
+            "proxies": self._proxy_urls(),
+            "follow_redirects": options["follow_redirects"],
+        }
+        if self._engine is None or config != self._engine_config:
+            self._engine = self._native.NativeHttpEngine(**config)
+            self._engine_config = config
+        return self._engine
+
+    def cancel(self) -> None:
+        if self._engine is not None:
+            self._engine.cancel()
 
     def scan(
         self,
@@ -30,15 +49,10 @@ class NativeHTTPBackend:
         raw_paths = list(paths)
         request_paths = [append_query_string(path, query) for path in raw_paths]
         quoted_paths = [safequote(path) for path in request_paths]
-        results = self._native.scan_http(
+        results = self._get_engine().scan(
             base_url,
             quoted_paths,
-            concurrency=options["thread_count"],
-            timeout_secs=options["timeout"],
-            headers=list(options["headers"].items()),
-            proxies=self._proxy_urls(),
             max_retries=options["max_retries"],
-            follow_redirects=options["follow_redirects"],
             max_body_size=MAX_RESPONSE_SIZE,
             **self._filter_options(),
         )

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -543,6 +543,11 @@ class NativeFuzzer(Fuzzer):
     def is_finished(self) -> bool:
         return self._finished
 
+    def quit(self) -> None:
+        super().quit()
+        if self._native_backend is not None:
+            self._native_backend.cancel()
+
 
 class AsyncFuzzer(BaseFuzzer):
     def __init__(

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,4 +14,4 @@ pyo3 = { version = "0.24", features = ["extension-module", "abi3-py313"] }
 rayon = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
 regex = "1.11"
-tokio = { version = "1.43", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "time"] }

--- a/native/README.md
+++ b/native/README.md
@@ -3,12 +3,15 @@
 This crate is an experimental Phase 5 native backend. It is opt-in for source
 installs and is included in `native-rust` release artifacts.
 
-It exposes two PyO3 functions:
+It exposes two PyO3 functions and a class:
 
 - `generate_wordlist(...)` for deterministic ordered wordlist generation.
-- `scan_http(...)` for batch HTTP GET requests using `reqwest` and `tokio`.
+- `NativeHttpEngine` for batch HTTP GET requests using `reqwest` and `tokio`.
+- `scan_http(...)` as the compatibility entrypoint backed by a cached engine.
 
-`scan_http(...)` also evaluates the cheap legacy status/size filters and the
+`NativeHttpEngine` keeps its Tokio runtime and HTTP clients alive across
+multiple batches and supports cooperative cancellation. Its `scan(...)` method
+also evaluates the cheap legacy status/size filters and the
 advanced match/filter options in native code. Filtered responses are returned as
 lightweight events with metadata and an empty body so Python can keep progress
 and not-found callbacks authoritative. Native regex matching uses Rust's

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -7,8 +7,12 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+use tokio::task::JoinSet;
+
+const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[pyclass]
 struct NativeHttpResult {
@@ -32,10 +36,34 @@ struct NativeHttpResult {
     body: Vec<u8>,
 }
 
+#[pyclass]
+struct NativeHttpEngine {
+    runtime: tokio::runtime::Runtime,
+    clients: Vec<reqwest::Client>,
+    raw_headers: HeaderPairs,
+    concurrency: usize,
+    timeout_secs: f64,
+    follow_redirects: bool,
+    use_raw_http: bool,
+    cancelled: Arc<AtomicBool>,
+}
+
 type NumericRange = (usize, usize);
 type TimeFilter = (String, f64);
 type HeaderPairs = Vec<(String, String)>;
 type RawHttpResponse = (u16, HeaderPairs, Vec<u8>, usize);
+
+#[derive(Clone, Eq, PartialEq)]
+struct NativeHttpEngineConfig {
+    concurrency: usize,
+    timeout_bits: u64,
+    headers: HeaderPairs,
+    proxies: Vec<String>,
+    follow_redirects: bool,
+}
+
+type CachedNativeHttpEngine = Option<(NativeHttpEngineConfig, Arc<NativeHttpEngine>)>;
+static DEFAULT_HTTP_ENGINE: OnceLock<Mutex<CachedNativeHttpEngine>> = OnceLock::new();
 
 #[derive(Clone)]
 struct NativeFilterConfig {
@@ -455,6 +483,278 @@ fn build_http_client(
     builder.build()
 }
 
+#[pymethods]
+impl NativeHttpEngine {
+    #[new]
+    #[pyo3(signature = (
+        concurrency=25,
+        timeout_secs=7.5,
+        headers=Vec::new(),
+        proxies=Vec::new(),
+        follow_redirects=false,
+    ))]
+    fn new(
+        concurrency: usize,
+        timeout_secs: f64,
+        headers: HeaderPairs,
+        proxies: Vec<String>,
+        follow_redirects: bool,
+    ) -> PyResult<Self> {
+        let mut header_map = HeaderMap::new();
+        for (name, value) in &headers {
+            let name = HeaderName::from_bytes(name.as_bytes())
+                .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+            let value = HeaderValue::from_str(value)
+                .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+            header_map.insert(name, value);
+        }
+
+        let use_raw_http = proxies.is_empty();
+        let clients = if proxies.is_empty() {
+            vec![build_http_client(
+                &header_map,
+                concurrency,
+                timeout_secs,
+                follow_redirects,
+                None,
+            )
+            .map_err(|error| PyRuntimeError::new_err(error.to_string()))?]
+        } else {
+            proxies
+                .iter()
+                .map(|proxy_url| {
+                    build_http_client(
+                        &header_map,
+                        concurrency,
+                        timeout_secs,
+                        follow_redirects,
+                        Some(proxy_url),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| PyRuntimeError::new_err(error.to_string()))?
+        };
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(runtime_worker_count())
+            .build()
+            .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+
+        Ok(Self {
+            runtime,
+            clients,
+            raw_headers: headers,
+            concurrency: concurrency.max(1),
+            timeout_secs,
+            follow_redirects,
+            use_raw_http,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        base_url,
+        paths,
+        max_retries=0,
+        max_body_size=83886080,
+        include_status_codes=Vec::new(),
+        exclude_status_codes=Vec::new(),
+        minimum_response_size=0,
+        maximum_response_size=0,
+        matcher_mode="or".to_string(),
+        filter_mode="or".to_string(),
+        match_status_codes=Vec::new(),
+        filter_status_codes=Vec::new(),
+        match_sizes=Vec::new(),
+        filter_sizes=Vec::new(),
+        match_words=Vec::new(),
+        filter_words=Vec::new(),
+        match_lines=Vec::new(),
+        filter_lines=Vec::new(),
+        match_regex=None,
+        filter_regex=None,
+        match_headers=Vec::new(),
+        filter_headers=Vec::new(),
+        match_header_regex=None,
+        filter_header_regex=None,
+        match_time=Vec::new(),
+        filter_time=Vec::new(),
+    ))]
+    fn scan(
+        &self,
+        py: Python<'_>,
+        base_url: String,
+        paths: Vec<String>,
+        max_retries: usize,
+        max_body_size: usize,
+        include_status_codes: Vec<u16>,
+        exclude_status_codes: Vec<u16>,
+        minimum_response_size: usize,
+        maximum_response_size: usize,
+        matcher_mode: String,
+        filter_mode: String,
+        match_status_codes: Vec<u16>,
+        filter_status_codes: Vec<u16>,
+        match_sizes: Vec<NumericRange>,
+        filter_sizes: Vec<NumericRange>,
+        match_words: Vec<NumericRange>,
+        filter_words: Vec<NumericRange>,
+        match_lines: Vec<NumericRange>,
+        filter_lines: Vec<NumericRange>,
+        match_regex: Option<String>,
+        filter_regex: Option<String>,
+        match_headers: Vec<String>,
+        filter_headers: Vec<String>,
+        match_header_regex: Option<String>,
+        filter_header_regex: Option<String>,
+        match_time: Vec<TimeFilter>,
+        filter_time: Vec<TimeFilter>,
+    ) -> PyResult<Vec<NativeHttpResult>> {
+        let filter_config = Arc::new(
+            NativeFilterConfig::new(
+                include_status_codes,
+                exclude_status_codes,
+                minimum_response_size,
+                maximum_response_size,
+                matcher_mode,
+                filter_mode,
+                match_status_codes,
+                filter_status_codes,
+                match_sizes,
+                filter_sizes,
+                match_words,
+                filter_words,
+                match_lines,
+                filter_lines,
+                match_regex,
+                filter_regex,
+                match_headers,
+                filter_headers,
+                match_header_regex,
+                filter_header_regex,
+                match_time,
+                filter_time,
+            )
+            .map_err(PyRuntimeError::new_err)?,
+        );
+
+        self.cancelled.store(false, Ordering::Release);
+        let cancelled = self.cancelled.clone();
+        let clients = self.clients.clone();
+        let raw_headers = self.raw_headers.clone();
+        let concurrency = self.concurrency;
+        let timeout_secs = self.timeout_secs;
+        let follow_redirects = self.follow_redirects;
+        let use_raw_http = self.use_raw_http;
+        let runtime = &self.runtime;
+
+        py.allow_threads(move || {
+            runtime.block_on(async move {
+                let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
+                let result_count = paths.len();
+                let mut tasks = JoinSet::new();
+
+                for (request_index, path) in paths.into_iter().enumerate() {
+                    let client = clients[request_index % clients.len()].clone();
+                    let base_url = base_url.clone();
+                    let raw_headers = raw_headers.clone();
+                    let semaphore = semaphore.clone();
+                    let filter_config = filter_config.clone();
+                    tasks.spawn(async move {
+                        let _permit = match semaphore.acquire_owned().await {
+                            Ok(permit) => permit,
+                            Err(error) => {
+                                return (
+                                    request_index,
+                                    native_error_result(path, 0.0, error.to_string()),
+                                );
+                            }
+                        };
+                        let url = format!("{base_url}{path}");
+                        let start = Instant::now();
+
+                        let result = if use_raw_http
+                            && !follow_redirects
+                            && should_use_raw_http(&base_url, &path)
+                        {
+                            let raw_base_url = base_url.clone();
+                            let raw_path = path.clone();
+                            let raw_filter_config = filter_config.clone();
+                            let raw_result = tokio::task::spawn_blocking(move || {
+                                raw_http_get(
+                                    &raw_base_url,
+                                    raw_path,
+                                    &raw_headers,
+                                    timeout_secs,
+                                    max_body_size,
+                                    start,
+                                    raw_filter_config.as_ref(),
+                                )
+                            })
+                            .await;
+
+                            match raw_result {
+                                Ok(result) => result,
+                                Err(error) => native_error_result(
+                                    path,
+                                    start.elapsed().as_secs_f64() * 1000.0,
+                                    error.to_string(),
+                                ),
+                            }
+                        } else {
+                            request_with_client(
+                                &client,
+                                url,
+                                path,
+                                max_retries,
+                                max_body_size,
+                                start,
+                                filter_config.as_ref(),
+                            )
+                            .await
+                        };
+                        (request_index, result)
+                    });
+                }
+
+                let mut results = Vec::with_capacity(result_count);
+                while !tasks.is_empty() {
+                    tokio::select! {
+                        joined = tasks.join_next() => {
+                            match joined {
+                                Some(Ok(result)) => results.push(result),
+                                Some(Err(error)) => {
+                                    return Err(PyRuntimeError::new_err(error.to_string()));
+                                }
+                                None => break,
+                            }
+                        }
+                        _ = tokio::time::sleep(SIGNAL_POLL_INTERVAL) => {}
+                    }
+
+                    if cancelled.load(Ordering::Acquire) {
+                        tasks.abort_all();
+                        return Ok(Vec::new());
+                    }
+                    Python::with_gil(|py| py.check_signals())?;
+                    if cancelled.load(Ordering::Acquire) {
+                        tasks.abort_all();
+                        return Ok(Vec::new());
+                    }
+                }
+
+                results.sort_by_key(|(request_index, _)| *request_index);
+                Ok(results.into_iter().map(|(_, result)| result).collect())
+            })
+        })
+    }
+}
+
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 #[pyo3(signature = (
@@ -496,7 +796,7 @@ fn scan_http(
     paths: Vec<String>,
     concurrency: usize,
     timeout_secs: f64,
-    headers: Vec<(String, String)>,
+    headers: HeaderPairs,
     proxies: Vec<String>,
     max_retries: usize,
     follow_redirects: bool,
@@ -524,190 +824,128 @@ fn scan_http(
     match_time: Vec<TimeFilter>,
     filter_time: Vec<TimeFilter>,
 ) -> PyResult<Vec<NativeHttpResult>> {
-    let filter_config = Arc::new(
-        NativeFilterConfig::new(
-            include_status_codes,
-            exclude_status_codes,
-            minimum_response_size,
-            maximum_response_size,
-            matcher_mode,
-            filter_mode,
-            match_status_codes,
-            filter_status_codes,
-            match_sizes,
-            filter_sizes,
-            match_words,
-            filter_words,
-            match_lines,
-            filter_lines,
-            match_regex,
-            filter_regex,
-            match_headers,
-            filter_headers,
-            match_header_regex,
-            filter_header_regex,
-            match_time,
-            filter_time,
-        )
-        .map_err(PyRuntimeError::new_err)?,
-    );
-
-    py.allow_threads(move || {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .worker_threads(runtime_worker_count())
-            .build()
+    let config = NativeHttpEngineConfig {
+        concurrency,
+        timeout_bits: timeout_secs.to_bits(),
+        headers: headers.clone(),
+        proxies: proxies.clone(),
+        follow_redirects,
+    };
+    let engine = {
+        let cache = DEFAULT_HTTP_ENGINE.get_or_init(|| Mutex::new(None));
+        let mut cached = cache
+            .lock()
             .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
-
-        runtime.block_on(async move {
-            let raw_headers = headers.clone();
-            let mut header_map = HeaderMap::new();
-            for (name, value) in headers {
-                let name = HeaderName::from_bytes(name.as_bytes())
-                    .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
-                let value = HeaderValue::from_str(&value)
-                    .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
-                header_map.insert(name, value);
-            }
-
-            let use_raw_http = proxies.is_empty();
-            let clients = if proxies.is_empty() {
-                vec![build_http_client(
-                    &header_map,
+        if cached
+            .as_ref()
+            .is_none_or(|(cached_config, _)| *cached_config != config)
+        {
+            *cached = Some((
+                config,
+                Arc::new(NativeHttpEngine::new(
                     concurrency,
                     timeout_secs,
+                    headers,
+                    proxies,
                     follow_redirects,
-                    None,
-                )
-                .map_err(|error| PyRuntimeError::new_err(error.to_string()))?]
-            } else {
-                proxies
-                    .iter()
-                    .map(|proxy_url| {
-                        build_http_client(
-                            &header_map,
-                            concurrency,
-                            timeout_secs,
-                            follow_redirects,
-                            Some(proxy_url),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|error| PyRuntimeError::new_err(error.to_string()))?
-            };
+                )?),
+            ));
+        }
+        cached.as_ref().unwrap().1.clone()
+    };
 
-            let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
-            let mut tasks = Vec::with_capacity(paths.len());
+    engine.scan(
+        py,
+        base_url,
+        paths,
+        max_retries,
+        max_body_size,
+        include_status_codes,
+        exclude_status_codes,
+        minimum_response_size,
+        maximum_response_size,
+        matcher_mode,
+        filter_mode,
+        match_status_codes,
+        filter_status_codes,
+        match_sizes,
+        filter_sizes,
+        match_words,
+        filter_words,
+        match_lines,
+        filter_lines,
+        match_regex,
+        filter_regex,
+        match_headers,
+        filter_headers,
+        match_header_regex,
+        filter_header_regex,
+        match_time,
+        filter_time,
+    )
+}
 
-            for (request_index, path) in paths.into_iter().enumerate() {
-                let client = clients[request_index % clients.len()].clone();
-                let base_url = base_url.clone();
-                let raw_headers = raw_headers.clone();
-                let semaphore = semaphore.clone();
-                let filter_config = filter_config.clone();
-                tasks.push(tokio::spawn(async move {
-                    let _permit = match semaphore.acquire_owned().await {
-                        Ok(permit) => permit,
-                        Err(error) => {
-                            return native_error_result(path, 0.0, error.to_string());
-                        }
-                    };
-                    let url = format!("{base_url}{path}");
-                    let start = Instant::now();
-
-                    if use_raw_http && !follow_redirects && should_use_raw_http(&base_url, &path) {
-                        let raw_base_url = base_url.clone();
-                        let raw_path = path.clone();
-                        let raw_filter_config = filter_config.clone();
-                        let raw_result = tokio::task::spawn_blocking(move || {
-                            raw_http_get(
-                                &raw_base_url,
-                                raw_path,
-                                &raw_headers,
-                                timeout_secs,
-                                max_body_size,
-                                start,
-                                raw_filter_config.as_ref(),
-                            )
-                        })
-                        .await;
-
-                        return match raw_result {
-                            Ok(result) => result,
-                            Err(error) => native_error_result(
-                                path,
-                                start.elapsed().as_secs_f64() * 1000.0,
-                                error.to_string(),
-                            ),
-                        };
-                    }
-
-                    let mut response = None;
-                    let mut last_error = None;
-                    for _ in 0..=max_retries {
-                        match client.get(&url).send().await {
-                            Ok(value) => {
-                                response = Some(value);
-                                last_error = None;
-                                break;
-                            }
-                            Err(error) => last_error = Some(error.to_string()),
-                        }
-                    }
-                    let response = match response {
-                        Some(response) => response,
-                        None => {
-                            return native_error_result(
-                                path,
-                                start.elapsed().as_secs_f64() * 1000.0,
-                                last_error.unwrap_or_else(|| "request failed".to_string()),
-                            );
-                        }
-                    };
-                    let status = response.status().as_u16();
-                    let headers = response
-                        .headers()
-                        .iter()
-                        .map(|(name, value)| {
-                            (
-                                name.as_str().to_string(),
-                                value.to_str().unwrap_or_default().to_string(),
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    let (body, body_length) =
-                        match read_response_body(response, max_body_size).await {
-                            Ok(result) => result,
-                            Err(error) => {
-                                return native_error_result(
-                                    path,
-                                    start.elapsed().as_secs_f64() * 1000.0,
-                                    error.to_string(),
-                                );
-                            }
-                        };
-                    native_http_result_with_length(
-                        path,
-                        status,
-                        headers,
-                        body,
-                        body_length,
-                        start.elapsed().as_secs_f64() * 1000.0,
-                        filter_config.as_ref(),
-                    )
-                }));
+async fn request_with_client(
+    client: &reqwest::Client,
+    url: String,
+    path: String,
+    max_retries: usize,
+    max_body_size: usize,
+    start: Instant,
+    filter_config: &NativeFilterConfig,
+) -> NativeHttpResult {
+    let mut response = None;
+    let mut last_error = None;
+    for _ in 0..=max_retries {
+        match client.get(&url).send().await {
+            Ok(value) => {
+                response = Some(value);
+                last_error = None;
+                break;
             }
-
-            let mut results = Vec::with_capacity(tasks.len());
-            for task in tasks {
-                let result = task
-                    .await
-                    .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
-                results.push(result);
-            }
-            Ok(results)
+            Err(error) => last_error = Some(error.to_string()),
+        }
+    }
+    let response = match response {
+        Some(response) => response,
+        None => {
+            return native_error_result(
+                path,
+                start.elapsed().as_secs_f64() * 1000.0,
+                last_error.unwrap_or_else(|| "request failed".to_string()),
+            );
+        }
+    };
+    let status = response.status().as_u16();
+    let headers = response
+        .headers()
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                value.to_str().unwrap_or_default().to_string(),
+            )
         })
-    })
+        .collect::<Vec<_>>();
+    let (body, body_length) = match read_response_body(response, max_body_size).await {
+        Ok(result) => result,
+        Err(error) => {
+            return native_error_result(
+                path,
+                start.elapsed().as_secs_f64() * 1000.0,
+                error.to_string(),
+            );
+        }
+    };
+    native_http_result_with_length(
+        path,
+        status,
+        headers,
+        body,
+        body_length,
+        start.elapsed().as_secs_f64() * 1000.0,
+        filter_config,
+    )
 }
 
 #[cfg(test)]
@@ -1389,6 +1627,7 @@ mod tests {
 fn dirsearch_native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(generate_wordlist, module)?)?;
     module.add_function(wrap_pyfunction!(scan_http, module)?)?;
+    module.add_class::<NativeHttpEngine>()?;
     module.add_class::<NativeHttpResult>()?;
     Ok(())
 }

--- a/testing.py
+++ b/testing.py
@@ -22,6 +22,7 @@ import unittest
 
 from tests.connection.test_dns import TestDNS  # noqa: F401
 from tests.connection.test_native_backend import TestNativeHTTPBackend  # noqa: F401
+from tests.connection.test_native_engine import TestNativeHttpEngine  # noqa: F401
 from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
 from tests.connection.test_requester import (  # noqa: F401
     TestAsyncRequesterElapsed,

--- a/tests/connection/test_native_backend.py
+++ b/tests/connection/test_native_backend.py
@@ -17,13 +17,28 @@ class FakeNativeResult:
     body = []
 
 
-class FakeNativeModule:
-    def __init__(self):
+class FakeNativeEngine:
+    def __init__(self, **config):
+        self.config = config
         self.calls = []
+        self.cancelled = False
 
-    def scan_http(self, *args, **kwargs):
+    def scan(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         return [FakeNativeResult()]
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class FakeNativeModule:
+    def __init__(self):
+        self.engines = []
+
+    def NativeHttpEngine(self, **config):
+        engine = FakeNativeEngine(**config)
+        self.engines.append(engine)
+        return engine
 
 
 class TestNativeHTTPBackend(TestCase):
@@ -83,11 +98,17 @@ class TestNativeHTTPBackend(TestCase):
         self.assertEqual(response.body, b"")
         self.assertEqual(response.length, 64)
 
-        args, kwargs = fake_native.calls[0]
+        self.assertEqual(len(fake_native.engines), 1)
+        engine = fake_native.engines[0]
+        self.assertEqual(engine.config["concurrency"], 7)
+        self.assertEqual(engine.config["timeout_secs"], 3.5)
+        self.assertEqual(
+            engine.config["proxies"],
+            ["http://user:password@127.0.0.1:8080"],
+        )
+
+        args, kwargs = engine.calls[0]
         self.assertEqual(args[:2], ("https://example.com/", ["missing%20page"]))
-        self.assertEqual(kwargs["concurrency"], 7)
-        self.assertEqual(kwargs["timeout_secs"], 3.5)
-        self.assertEqual(kwargs["proxies"], ["http://user:password@127.0.0.1:8080"])
         self.assertEqual(kwargs["include_status_codes"], [200, 204])
         self.assertEqual(kwargs["exclude_status_codes"], [500])
         self.assertEqual(kwargs["minimum_response_size"], 10)
@@ -103,3 +124,16 @@ class TestNativeHTTPBackend(TestCase):
         self.assertEqual(kwargs["match_header_regex"], "etag: .+")
         self.assertEqual(kwargs["filter_header_regex"], "x-cache: fallback-[0-9]+")
         self.assertEqual(kwargs["match_time"], [(">", 100.0)])
+
+    def test_reuses_engine_across_chunks_and_forwards_cancellation(self):
+        fake_native = FakeNativeModule()
+
+        with patch.dict("sys.modules", {"dirsearch_native": fake_native}):
+            backend = NativeHTTPBackend()
+            list(backend.scan("https://example.com/", ["first"]))
+            list(backend.scan("https://example.com/", ["second"]))
+            backend.cancel()
+
+        self.assertEqual(len(fake_native.engines), 1)
+        self.assertEqual(len(fake_native.engines[0].calls), 2)
+        self.assertTrue(fake_native.engines[0].cancelled)

--- a/tests/connection/test_native_engine.py
+++ b/tests/connection/test_native_engine.py
@@ -1,0 +1,157 @@
+import os
+import signal
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest import TestCase, skipUnless
+
+try:
+    import dirsearch_native
+except ImportError:
+    dirsearch_native = None
+
+
+class NativeScanInterrupted(Exception):
+    pass
+
+
+class StalledHTTPServer:
+    def __init__(self):
+        self.listener = socket.socket()
+        self.listener.bind(("127.0.0.1", 0))
+        self.listener.listen()
+        self.release = threading.Event()
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self):
+        host, port = self.listener.getsockname()
+        return f"http://{host}:{port}/"
+
+    def _serve(self):
+        try:
+            connection, _ = self.listener.accept()
+            with connection:
+                self.release.wait(timeout=5)
+        except OSError:
+            pass
+
+    def close(self):
+        self.release.set()
+        self.listener.close()
+        self.thread.join(timeout=1)
+
+
+class KeepAliveHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        body = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *args):
+        return None
+
+
+class CountingHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self):
+        super().__init__(("127.0.0.1", 0), KeepAliveHandler)
+        self.connection_count = 0
+        self.thread = threading.Thread(target=self.serve_forever, daemon=True)
+        self.thread.start()
+
+    def get_request(self):
+        request = super().get_request()
+        self.connection_count += 1
+        return request
+
+    @property
+    def url(self):
+        host, port = self.server_address
+        return f"http://{host}:{port}/"
+
+    def close(self):
+        self.shutdown()
+        self.server_close()
+        self.thread.join(timeout=1)
+
+
+@skipUnless(
+    dirsearch_native is not None
+    and hasattr(dirsearch_native, "NativeHttpEngine"),
+    "native extension is not installed",
+)
+class TestNativeHttpEngine(TestCase):
+    def test_reuses_http_connection_across_scans(self):
+        server = CountingHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine()
+
+        try:
+            first = engine.scan(server.url, ["first"])
+            second = engine.scan(server.url, ["second"])
+        finally:
+            server.close()
+
+        self.assertEqual([first[0].status, second[0].status], [200, 200])
+        self.assertEqual(server.connection_count, 1)
+
+    def test_compatibility_function_reuses_http_connection(self):
+        server = CountingHTTPServer()
+
+        try:
+            first = dirsearch_native.scan_http(server.url, ["first"])
+            second = dirsearch_native.scan_http(server.url, ["second"])
+        finally:
+            server.close()
+
+        self.assertEqual([first[0].status, second[0].status], [200, 200])
+        self.assertEqual(server.connection_count, 1)
+
+    def test_explicit_cancellation_interrupts_active_scan(self):
+        server = StalledHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=5)
+        cancel_timer = threading.Timer(0.1, engine.cancel)
+
+        try:
+            cancel_timer.start()
+            started = time.monotonic()
+            results = engine.scan(server.url, ["slow"])
+            elapsed = time.monotonic() - started
+        finally:
+            cancel_timer.join(timeout=1)
+            server.close()
+
+        self.assertEqual(results, [])
+        self.assertLess(elapsed, 2)
+
+    def test_python_signal_interrupts_active_scan(self):
+        server = StalledHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=5)
+        previous_handler = signal.getsignal(signal.SIGINT)
+        signal_timer = threading.Timer(
+            0.1, lambda: os.kill(os.getpid(), signal.SIGINT)
+        )
+
+        def interrupt_scan(_signum, _frame):
+            raise NativeScanInterrupted("stop native scan")
+
+        try:
+            signal.signal(signal.SIGINT, interrupt_scan)
+            signal_timer.start()
+            started = time.monotonic()
+            with self.assertRaisesRegex(NativeScanInterrupted, "stop native scan"):
+                engine.scan(server.url, ["slow"])
+            elapsed = time.monotonic() - started
+        finally:
+            signal_timer.join(timeout=1)
+            signal.signal(signal.SIGINT, previous_handler)
+            server.close()
+
+        self.assertLess(elapsed, 2)

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -35,10 +35,14 @@ class FakeNativeBackend:
     def __init__(self, items):
         self.items = items
         self.calls = []
+        self.cancelled = False
 
     def scan(self, base_url, paths, query=""):
         self.calls.append((base_url, list(paths), query))
         yield from self.items
+
+    def cancel(self):
+        self.cancelled = True
 
 
 def make_dictionary(paths):
@@ -182,3 +186,11 @@ class TestNativeFuzzer(TestCase):
         self.assertEqual([next(resumed), next(resumed)], ["admin", "login"])
         with self.assertRaises(StopIteration):
             next(resumed)
+
+    def test_quit_cancels_active_native_engine(self):
+        backend = FakeNativeBackend([])
+        fuzzer = self.make_fuzzer(backend, DummyDictionary([]), [], [], [])
+
+        fuzzer.quit()
+
+        self.assertTrue(backend.cancelled)


### PR DESCRIPTION
## Summary

- keep one Tokio runtime and configured reqwest client pool alive across native chunks
- poll Python signals during active Rust batches and forward native next/quit as cooperative cancellation
- preserve the documented `scan_http(...)` compatibility API with a cached engine
- retain result ordering and rebuild the engine only when redirect, proxy, header, timeout, or concurrency settings change

## Impact

Native chunks no longer recreate their runtime and clients, so keep-alive connections cross chunk boundaries. Ctrl+C can enter the Python pause handler while requests are stalled instead of waiting for the entire chunk timeout. Explicit native quit/next cancels the active batch.

This is stacked on #1605 because interrupting a reserved native chunk requires its unfinished paths to remain recoverable in saved sessions.

Refs #1588.

## Regression coverage

- real HTTP/1.1 connection reuse across separate engine scans and the compatibility function
- explicit cancellation latency against a stalled five-second request
- SIGINT propagation latency against a stalled five-second request
- Python wrapper engine reuse and cancellation forwarding
- redirect, authenticated proxy, encoded-path, query, result-order, async/native session, and filtered-result parity

## Validation

- `cargo fmt --manifest-path native/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path native/Cargo.toml` — 11 passed
- `cargo clippy --locked --manifest-path native/Cargo.toml --all-targets -- -D warnings`
- built and installed the native wheel with Python 3.14
- `python -m unittest tests.connection.test_native_engine tests.connection.test_requester.TestNativeRequesterPathPreservation tests.connection.test_native_backend tests.core.test_native_fuzzer` — 15 passed
- `python testing.py` with the native extension — 160 passed
- `flake8 .`