### PR TITLE
Handle expired async scan deadlines

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -455,13 +455,36 @@ class Controller:
                 self.old_session = False
 
     async def start_coroutines(self, start_time: float) -> None:
+        now = time.time()
+        time_limits = []
+
+        if options["max_time"] > 0:
+            time_limits.append(
+                (
+                    options["max_time"] - (now - self.start_time),
+                    QuitInterrupt("Runtime exceeded the maximum set by the user"),
+                )
+            )
+        if options["target_max_time"] > 0:
+            time_limits.append(
+                (
+                    options["target_max_time"] - (now - start_time),
+                    SkipTargetInterrupt(
+                        "Runtime for target exceeded the maximum set by the user"
+                    ),
+                )
+            )
+
+        for remaining, limit_error in time_limits:
+            if remaining <= 0:
+                raise limit_error
+
+        if time_limits:
+            timeout, timeout_error = min(time_limits, key=lambda limit: limit[0])
+        else:
+            timeout, timeout_error = None, None
+
         task = self.loop.create_task(self.fuzzer.start())
-        timeout = min(
-            t for t in [
-                options["max_time"] - (time.time() - self.start_time),
-                options["target_max_time"] - (time.time() - start_time),
-            ] if t > 0
-        ) if options["max_time"] or options["target_max_time"] else None
 
         try:
             try:
@@ -473,10 +496,9 @@ class Controller:
                     timeout=timeout,
                 )
             except asyncio.TimeoutError:
-                if time.time() - self.start_time > options["max_time"] > 0:
-                    raise QuitInterrupt("Runtime exceeded the maximum set by the user")
-
-                raise SkipTargetInterrupt("Runtime for target exceeded the maximum set by the user")
+                if timeout_error is None:
+                    raise
+                raise timeout_error
 
             if self.pause_future.done():
                 task.cancel()

--- a/testing.py
+++ b/testing.py
@@ -37,6 +37,7 @@ from tests.connection.test_requester import (  # noqa: F401
 )
 from tests.connection.test_response import TestResponse  # noqa: F401
 from tests.connection.test_response import TestAsyncResponse  # noqa: F401
+from tests.controller.test_async_controller import TestAsyncController  # noqa: F401
 from tests.controller.test_session_store import TestSessionStore  # noqa: F401
 from tests.core.test_advanced_filters import TestAdvancedFilters  # noqa: F401
 from tests.core.test_async_fuzzer import TestAsyncFuzzer  # noqa: F401

--- a/tests/controller/test_async_controller.py
+++ b/tests/controller/test_async_controller.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from lib.controller.controller import Controller
 from lib.core.data import options
-from lib.core.exceptions import QuitInterrupt
+from lib.core.exceptions import QuitInterrupt, SkipTargetInterrupt
 
 
 class BlockingAsyncFuzzer:
@@ -19,13 +19,26 @@ class BlockingAsyncFuzzer:
         await asyncio.Event().wait()
 
 
+class RecordingAsyncFuzzer:
+    def __init__(self):
+        self.started = False
+
+    async def start(self):
+        self.started = True
+
+
+def create_controller(fuzzer):
+    controller = object.__new__(Controller)
+    controller.loop = asyncio.get_running_loop()
+    controller.pause_future = controller.loop.create_future()
+    controller.fuzzer = fuzzer
+    return controller
+
+
 class TestAsyncController(IsolatedAsyncioTestCase):
     async def test_quit_drains_cancelled_fuzzer_task(self):
-        controller = object.__new__(Controller)
-        controller.loop = asyncio.get_running_loop()
-        controller.pause_future = controller.loop.create_future()
+        controller = create_controller(BlockingAsyncFuzzer())
         controller.start_time = time.time()
-        controller.fuzzer = BlockingAsyncFuzzer()
 
         with patch.dict(options, {"max_time": 0, "target_max_time": 0}):
             run_task = controller.loop.create_task(
@@ -39,3 +52,50 @@ class TestAsyncController(IsolatedAsyncioTestCase):
 
         self.assertTrue(controller.fuzzer.task.done())
         self.assertTrue(controller.fuzzer.task.cancelled())
+
+    async def test_expired_scan_deadline_stops_before_starting_fuzzer(self):
+        fuzzer = RecordingAsyncFuzzer()
+        controller = create_controller(fuzzer)
+        controller.start_time = 90
+
+        with (
+            patch.dict(options, {"max_time": 5, "target_max_time": 0}),
+            patch("lib.controller.controller.time.time", return_value=100),
+        ):
+            with self.assertRaisesRegex(
+                QuitInterrupt, "Runtime exceeded the maximum set by the user"
+            ):
+                await controller.start_coroutines(start_time=100)
+
+        self.assertFalse(fuzzer.started)
+
+    async def test_expired_target_deadline_stops_before_starting_fuzzer(self):
+        fuzzer = RecordingAsyncFuzzer()
+        controller = create_controller(fuzzer)
+        controller.start_time = 100
+
+        with (
+            patch.dict(options, {"max_time": 0, "target_max_time": 5}),
+            patch("lib.controller.controller.time.time", return_value=100),
+        ):
+            with self.assertRaisesRegex(
+                SkipTargetInterrupt,
+                "Runtime for target exceeded the maximum set by the user",
+            ):
+                await controller.start_coroutines(start_time=90)
+
+        self.assertFalse(fuzzer.started)
+
+    async def test_expired_scan_deadline_wins_over_remaining_target_deadline(self):
+        fuzzer = RecordingAsyncFuzzer()
+        controller = create_controller(fuzzer)
+        controller.start_time = 90
+
+        with (
+            patch.dict(options, {"max_time": 5, "target_max_time": 20}),
+            patch("lib.controller.controller.time.time", return_value=100),
+        ):
+            with self.assertRaises(QuitInterrupt):
+                await controller.start_coroutines(start_time=95)
+
+        self.assertFalse(fuzzer.started)


### PR DESCRIPTION
## Summary

- reject expired `--max-time` and `--target-max-time` budgets before starting an async fuzzer task
- preserve scan-wide limit precedence when a target budget still has time remaining
- keep timeout and pause cleanup behavior intact
- register the async controller regression suite in `testing.py`

## Root cause

`start_coroutines()` discarded non-positive remaining budgets before calling `min()`. An expired sole deadline therefore raised `ValueError`, while an expired scan-wide deadline could be ignored when a target deadline remained positive.

## Validation

- `python -m unittest tests.controller.test_async_controller -v`
- `python testing.py` (170 passed on Python 3.12 and 3.14)
- `python -m unittest discover -s tests -q` (207 passed on Python 3.12 and 3.14)
- `python -m flake8 .`
- `codespell`
- `python -m compileall -q lib/controller/controller.py tests/controller/test_async_controller.py testing.py`
- `git diff --check`

Addresses audit finding #2.