### PR TITLE
Fix HTTP/HTTPS proxy routing across request engines

### DIFF
--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from typing import Any
 
+from lib.connection.proxy import (
+    PROXY_AUTHENTICATION_REQUIRED,
+    format_proxy_error,
+    is_proxy_connect_rejection,
+    proxy_error_status,
+)
 from lib.connection.response import NativeResponse
 from lib.core.data import options
 from lib.core.exceptions import RequestException
@@ -59,7 +65,23 @@ class NativeHTTPBackend:
 
         for path, quoted_path, result in zip(raw_paths, quoted_paths, results):
             if result.error is not None:
-                yield path, None, RequestException(result.error)
+                error_message = result.error
+                if (
+                    options["proxies"]
+                    and (
+                        proxy_error_status(error_message) is not None
+                        or is_proxy_connect_rejection(error_message)
+                    )
+                ):
+                    error_message = format_proxy_error(error_message)
+                yield path, None, RequestException(error_message)
+                continue
+
+            if (
+                options["proxies"]
+                and result.status == PROXY_AUTHENTICATION_REQUIRED
+            ):
+                yield path, None, RequestException("Proxy authentication required")
                 continue
 
             yield (

--- a/lib/connection/proxy.py
+++ b/lib/connection/proxy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import re
+
+
+PROXY_AUTHENTICATION_REQUIRED = 407
+_HTTP_STATUS_PATTERNS = (
+    re.compile(
+        r"(?:HTTP(?:/[0-9.]+)?|status(?: code)?|"
+        r"tunnel(?: connection)? (?:failed|unsuccessful))"
+        r"\s*:?\s*([1-5][0-9]{2})\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"^\s*([1-5][0-9]{2})(?:\s|$)"),
+)
+
+
+def proxy_error_status(error: BaseException | str) -> int | None:
+    for message in _error_messages(error):
+        for pattern in _HTTP_STATUS_PATTERNS:
+            match = pattern.search(message)
+            if match:
+                return int(match.group(1))
+
+    return None
+
+
+def is_proxy_connect_rejection(error: BaseException | str) -> bool:
+    return any(
+        "tunnel error: unsuccessful" in message.lower()
+        for message in _error_messages(error)
+    )
+
+
+def _error_messages(error: BaseException | str):
+    pending: list[BaseException | str] = [error]
+    seen = set()
+
+    while pending:
+        current = pending.pop()
+        if isinstance(current, BaseException):
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+            for attr in ("__cause__", "__context__"):
+                chained = getattr(current, attr, None)
+                if chained is not None:
+                    pending.append(chained)
+
+        yield str(current)
+
+
+def format_proxy_error(error: BaseException | str) -> str:
+    status = proxy_error_status(error)
+    if status == PROXY_AUTHENTICATION_REQUIRED:
+        return "Proxy authentication required"
+    if status is not None:
+        return f"Proxy connection failed with HTTP {status}"
+    if is_proxy_connect_rejection(error):
+        return "Proxy CONNECT request was rejected"
+    return "Cannot establish the proxy connection"

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -46,6 +46,11 @@ except ImportError:
     SSLCertVerificationError = None
 
 from lib.connection.dns import cached_getaddrinfo
+from lib.connection.proxy import (
+    PROXY_AUTHENTICATION_REQUIRED,
+    format_proxy_error,
+    proxy_error_status,
+)
 from lib.connection.response import AsyncResponse, Response
 from lib.core.data import options
 from lib.core.decorators import cached
@@ -199,6 +204,7 @@ def _is_timeout_error(exc: Exception) -> bool:
             (
                 requests.exceptions.Timeout,
                 urllib3.exceptions.TimeoutError,
+                httpx.TimeoutException,
                 socket.timeout,
             ),
         ):
@@ -466,6 +472,12 @@ class Requester(BaseRequester):
                     proxies=proxies,
                     stream=True,
                 )
+                if (
+                    proxies
+                    and origin_response.status_code == PROXY_AUTHENTICATION_REQUIRED
+                ):
+                    origin_response.close()
+                    raise RequestException("Proxy authentication required")
                 response = Response(url, origin_response)
                 response.elapsed = time.perf_counter() - start_time
 
@@ -478,29 +490,27 @@ class Requester(BaseRequester):
 
                 return response
 
+            except RequestException:
+                raise
             except Exception as e:
                 logger.exception(e)
 
                 if e == socket.gaierror:
                     err_msg = "Couldn't resolve DNS"
+                elif _is_timeout_error(e):
+                    err_msg = f"Request timeout: {url}"
                 elif _is_ssl_error(e):
                     err_msg = _format_ssl_error(e, url)
                 elif isinstance(e, requests.exceptions.TooManyRedirects):
                     err_msg = f"Too many redirects: {url}"
-                elif "ProxyError" in str(e):
-                    if proxy:
-                        err_msg = f"Error with the proxy: {proxy}"
-                    else:
-                        err_msg = "Error with the system proxy"
-                    # Prevent from reusing it in the future
-                    if proxy in options["proxies"] and len(options["proxies"]) > 1:
-                        options["proxies"].remove(proxy)
+                elif isinstance(e, requests.exceptions.ProxyError):
+                    err_msg = format_proxy_error(e)
+                    if proxy_error_status(e) in (407, 429):
+                        raise RequestException(err_msg) from e
                 elif "InvalidURL" in str(e):
                     err_msg = f"Invalid URL: {url}"
                 elif "InvalidProxyURL" in str(e):
                     err_msg = f"Invalid proxy URL: {proxy}"
-                elif _is_timeout_error(e):
-                    err_msg = f"Request timeout: {url}"
                 elif _is_response_read_error(e):
                     err_msg = f"Failed to read response body: {url}"
                 elif "ConnectionError" in str(e):
@@ -628,6 +638,7 @@ class AsyncRequester(BaseRequester):
         quoted_request_path = safequote(request_path)
         url = self._url + quoted_request_path
         session = session or self.session
+        using_proxy = replay or bool(options["proxies"])
 
         for _ in range(options["max_retries"] + 1):
             try:
@@ -655,6 +666,12 @@ class AsyncRequester(BaseRequester):
                     stream=True,
                     follow_redirects=options["follow_redirects"],
                 )
+                if (
+                    using_proxy
+                    and xresponse.status_code == PROXY_AUTHENTICATION_REQUIRED
+                ):
+                    await xresponse.aclose()
+                    raise RequestException("Proxy authentication required")
                 response = await AsyncResponse.create(url, xresponse)
                 await xresponse.aclose()
                 # Measure the whole streamed request lifecycle so sync and async
@@ -670,10 +687,14 @@ class AsyncRequester(BaseRequester):
 
                 return response
 
+            except RequestException:
+                raise
             except Exception as e:
                 logger.exception(e)
 
-                if isinstance(e, httpx.ConnectError) and not _is_ssl_error(e):
+                if _is_timeout_error(e):
+                    err_msg = f"Request timeout: {url}"
+                elif isinstance(e, httpx.ConnectError) and not _is_ssl_error(e):
                     if str(e).startswith("[Errno -2]"):
                         err_msg = "Couldn't resolve DNS"
                     else:
@@ -683,11 +704,11 @@ class AsyncRequester(BaseRequester):
                 elif isinstance(e, httpx.TooManyRedirects):
                     err_msg = f"Too many redirects: {url}"
                 elif isinstance(e, httpx.ProxyError):
-                    err_msg = "Cannot establish the proxy connection"
+                    err_msg = format_proxy_error(e)
+                    if proxy_error_status(e) in (407, 429):
+                        raise RequestException(err_msg) from e
                 elif isinstance(e, httpx.InvalidURL):
                     err_msg = f"Invalid URL: {url}"
-                elif isinstance(e, httpx.TimeoutException):
-                    err_msg = f"Request timeout: {url}"
                 elif _is_response_read_error(e):
                     err_msg = f"Failed to read response body: {url}"
                 else:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -529,7 +529,9 @@ class ProxyRoatingTransport(httpx.AsyncBaseTransport):
         ]
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        request.extensions["target"] = str(request.url).encode()
+        # Let httpcore choose absolute-form for forwarding and authority/origin-form
+        # for CONNECT tunnels. A custom target overrides all three request forms.
+        request.extensions.pop("target", None)
         transport = random.choice(self._transports)
         return await transport.handle_async_request(request)
 
@@ -561,7 +563,7 @@ class AsyncRequester(BaseRequester):
         if options["auth"]:
             self.set_auth(options["auth_type"], options["auth"])
 
-    def parse_proxy(self, proxy: str) -> str:
+    def parse_proxy(self, proxy: str) -> str | httpx.Proxy | None:
         if not proxy:
             return None
 
@@ -571,6 +573,12 @@ class AsyncRequester(BaseRequester):
         if self.proxy_cred and "@" not in proxy:
             # socks5://localhost:9050 => socks5://[credential]@localhost:9050
             proxy = proxy.replace("://", f"://{self.proxy_cred}@", 1)
+
+        if proxy.startswith("https://"):
+            proxy_ssl_context = ssl.create_default_context()
+            proxy_ssl_context.check_hostname = False
+            proxy_ssl_context.verify_mode = ssl.CERT_NONE
+            return httpx.Proxy(proxy, ssl_context=proxy_ssl_context)
 
         return proxy
 

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -436,9 +436,8 @@ class Requester(BaseRequester):
                         # socks5://localhost:9050 => socks5://[credential]@localhost:9050
                         proxy_url = proxy_url.replace("://", f"://{self.proxy_cred}@", 1)
 
+                    proxies["http"] = proxy_url
                     proxies["https"] = proxy_url
-                    if not proxy_url.startswith("https://"):
-                        proxies["http"] = proxy_url
                 except IndexError:
                     pass
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -903,7 +903,14 @@ async fn request_with_client(
                 last_error = None;
                 break;
             }
-            Err(error) => last_error = Some(error.to_string()),
+            Err(error) => {
+                let error = format_error_chain(&error);
+                let retryable = !error.contains("tunnel error: unsuccessful");
+                last_error = Some(error);
+                if !retryable {
+                    break;
+                }
+            }
         }
     }
     let response = match response {
@@ -946,6 +953,17 @@ async fn request_with_client(
         start.elapsed().as_secs_f64() * 1000.0,
         filter_config,
     )
+}
+
+fn format_error_chain(error: &dyn std::error::Error) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(error) = source {
+        message.push_str(": ");
+        message.push_str(&error.to_string());
+        source = error.source();
+    }
+    message
 }
 
 #[cfg(test)]

--- a/testing.py
+++ b/testing.py
@@ -32,6 +32,7 @@ from tests.connection.test_requester import (  # noqa: F401
     TestRequesterElapsed,
     TestRequesterErrorClassification,
     TestRequesterPathPreservation,
+    TestRequesterProxyRouting,
     TestRequesterSSLHandling,
     TestSSLHelpers,
 )

--- a/testing.py
+++ b/testing.py
@@ -24,6 +24,7 @@ from tests.connection.test_dns import TestDNS  # noqa: F401
 from tests.connection.test_native_backend import TestNativeHTTPBackend  # noqa: F401
 from tests.connection.test_native_engine import TestNativeHttpEngine  # noqa: F401
 from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
+from tests.connection.test_proxy_integration import TestProxyIntegration  # noqa: F401
 from tests.connection.test_requester import (  # noqa: F401
     TestAsyncRequesterElapsed,
     TestAsyncRequesterSSLHandling,

--- a/testing.py
+++ b/testing.py
@@ -24,6 +24,7 @@ from tests.connection.test_dns import TestDNS  # noqa: F401
 from tests.connection.test_native_backend import TestNativeHTTPBackend  # noqa: F401
 from tests.connection.test_native_engine import TestNativeHttpEngine  # noqa: F401
 from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
+from tests.connection.test_proxy import TestProxyErrors  # noqa: F401
 from tests.connection.test_proxy_integration import TestProxyIntegration  # noqa: F401
 from tests.connection.test_requester import (  # noqa: F401
     TestAsyncRequesterElapsed,

--- a/tests/connection/proxy_server.py
+++ b/tests/connection/proxy_server.py
@@ -97,7 +97,7 @@ class ForwardProxyHandler(BaseHTTPRequestHandler):
             upstream.close()
 
         self.send_response(response.status)
-        self.send_header("Content-Type", response.getheader("Content-Type", "text/plain"))
+        self.send_header("Content-Type", "text/plain")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Connection", "close")
         self.end_headers()
@@ -176,6 +176,7 @@ class LocalHTTPServer:
         self.server = RecordingHTTPServer(("127.0.0.1", 0), handler_class)
         if scheme == "https":
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
             context.load_cert_chain(certificate, private_key)
             self.server.socket = context.wrap_socket(
                 self.server.socket,

--- a/tests/connection/proxy_server.py
+++ b/tests/connection/proxy_server.py
@@ -23,6 +23,7 @@ from cryptography.x509.oid import NameOID
 IO_TIMEOUT = 3
 TUNNEL_TIMEOUT = 5
 LOCAL_HOSTS = {"127.0.0.1", "localhost"}
+PROXY_BEHAVIORS = {"forward", "drop", "rate_limit", "timeout"}
 
 
 class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
@@ -33,25 +34,77 @@ class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     def __init__(self, server_address, handler_class):
         super().__init__(server_address, handler_class)
         self._events = []
+        self._proxy_authorizations = []
         self._events_lock = threading.Lock()
+        self._proxy_behavior = "forward"
+        self._required_proxy_authorization = None
+        self._stall_release = threading.Event()
 
     def record(self, method: str, target: str) -> None:
         with self._events_lock:
             self._events.append((method, target))
 
+    def record_proxy_authorization(self, authorization: str | None) -> None:
+        with self._events_lock:
+            self._proxy_authorizations.append(authorization)
+
     def clear_events(self) -> None:
         with self._events_lock:
             self._events.clear()
+            self._proxy_authorizations.clear()
 
     @property
     def events(self) -> list[tuple[str, str]]:
         with self._events_lock:
             return list(self._events)
 
+    @property
+    def proxy_authorizations(self) -> list[str | None]:
+        with self._events_lock:
+            return list(self._proxy_authorizations)
+
+    def configure_proxy(
+        self,
+        behavior: str = "forward",
+        required_authorization: str | None = None,
+    ) -> None:
+        if behavior not in PROXY_BEHAVIORS:
+            raise ValueError(f"Unsupported proxy behavior: {behavior}")
+
+        with self._events_lock:
+            previous_stall = self._stall_release
+            self._stall_release = threading.Event()
+            self._proxy_behavior = behavior
+            self._required_proxy_authorization = required_authorization
+        previous_stall.set()
+
+    def begin_proxy_request(
+        self,
+        method: str,
+        target: str,
+        authorization: str | None,
+    ) -> tuple[str, str | None, threading.Event]:
+        with self._events_lock:
+            self._events.append((method, target))
+            self._proxy_authorizations.append(authorization)
+            return (
+                self._proxy_behavior,
+                self._required_proxy_authorization,
+                self._stall_release,
+            )
+
+    def release_stalled_requests(self) -> None:
+        with self._events_lock:
+            stall_release = self._stall_release
+        stall_release.set()
+
 
 class TargetHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.server.record("GET", self.path)
+        self.server.record_proxy_authorization(
+            self.headers.get("Proxy-Authorization")
+        )
         body = f"reached:{self.path}".encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/plain")
@@ -66,7 +119,9 @@ class TargetHandler(BaseHTTPRequestHandler):
 
 class ForwardProxyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        self.server.record("GET", self.path)
+        if not self._begin_proxy_request("GET"):
+            return
+
         target = urlsplit(self.path)
         if (
             target.scheme != "http"
@@ -104,7 +159,9 @@ class ForwardProxyHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_CONNECT(self):
-        self.server.record("CONNECT", self.path)
+        if not self._begin_proxy_request("CONNECT"):
+            return
+
         host, separator, port = self.path.rpartition(":")
         if not separator or host not in LOCAL_HOSTS:
             self.send_error(403, "Proxy target is outside the local test stack")
@@ -129,6 +186,68 @@ class ForwardProxyHandler(BaseHTTPRequestHandler):
             self._relay(upstream)
         finally:
             upstream.close()
+
+    def _begin_proxy_request(self, method: str) -> bool:
+        behavior, required_authorization, stall_release = (
+            self.server.begin_proxy_request(
+                method,
+                self.path,
+                self.headers.get("Proxy-Authorization"),
+            )
+        )
+
+        if (
+            required_authorization is not None
+            and self.headers.get("Proxy-Authorization") != required_authorization
+        ):
+            self._send_proxy_response(
+                407,
+                b"proxy authentication required",
+                {"Proxy-Authenticate": 'Basic realm="dirsearch-test"'},
+            )
+            return False
+
+        if behavior == "timeout":
+            stall_release.wait(TUNNEL_TIMEOUT)
+            self.close_connection = True
+            return False
+
+        if behavior == "drop":
+            self.close_connection = True
+            try:
+                self.connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self.connection.close()
+            return False
+
+        if behavior == "rate_limit":
+            self._send_proxy_response(
+                429,
+                b"proxy rate limit",
+                {
+                    "Proxy-Status": "dirsearch-test; error=connection_limit",
+                    "Retry-After": "1",
+                },
+            )
+            return False
+
+        return True
+
+    def _send_proxy_response(
+        self,
+        status: int,
+        body: bytes,
+        headers: dict[str, str],
+    ) -> None:
+        self.send_response(status)
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
 
     def _relay(self, upstream: socket.socket) -> None:
         downstream = self.connection
@@ -203,10 +322,22 @@ class LocalHTTPServer:
     def events(self) -> list[tuple[str, str]]:
         return self.server.events
 
+    @property
+    def proxy_authorizations(self) -> list[str | None]:
+        return self.server.proxy_authorizations
+
     def clear_events(self) -> None:
         self.server.clear_events()
 
+    def configure_proxy(
+        self,
+        behavior: str = "forward",
+        required_authorization: str | None = None,
+    ) -> None:
+        self.server.configure_proxy(behavior, required_authorization)
+
     def close(self) -> None:
+        self.server.release_stalled_requests()
         self.server.shutdown()
         self.server.server_close()
         self.thread.join(timeout=IO_TIMEOUT)

--- a/tests/connection/proxy_server.py
+++ b/tests/connection/proxy_server.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import http.client
+import ipaddress
+import select
+import socket
+import socketserver
+import ssl
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+IO_TIMEOUT = 3
+TUNNEL_TIMEOUT = 5
+LOCAL_HOSTS = {"127.0.0.1", "localhost"}
+
+
+class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+    allow_reuse_address = True
+    block_on_close = True
+    daemon_threads = False
+
+    def __init__(self, server_address, handler_class):
+        super().__init__(server_address, handler_class)
+        self._events = []
+        self._events_lock = threading.Lock()
+
+    def record(self, method: str, target: str) -> None:
+        with self._events_lock:
+            self._events.append((method, target))
+
+    def clear_events(self) -> None:
+        with self._events_lock:
+            self._events.clear()
+
+    @property
+    def events(self) -> list[tuple[str, str]]:
+        with self._events_lock:
+            return list(self._events)
+
+
+class TargetHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.server.record("GET", self.path)
+        body = f"reached:{self.path}".encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *args):
+        del args
+
+
+class ForwardProxyHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.server.record("GET", self.path)
+        target = urlsplit(self.path)
+        if (
+            target.scheme != "http"
+            or target.hostname not in LOCAL_HOSTS
+            or target.port is None
+        ):
+            self.send_error(403, "Proxy target is outside the local test stack")
+            return
+
+        request_target = urlunsplit(("", "", target.path or "/", target.query, ""))
+        upstream = http.client.HTTPConnection(
+            target.hostname,
+            target.port,
+            timeout=IO_TIMEOUT,
+        )
+        try:
+            upstream.request(
+                "GET",
+                request_target,
+                headers={"Host": target.netloc, "Connection": "close"},
+            )
+            response = upstream.getresponse()
+            body = response.read()
+        except OSError:
+            self.send_error(502, "Local test target is unavailable")
+            return
+        finally:
+            upstream.close()
+
+        self.send_response(response.status)
+        self.send_header("Content-Type", response.getheader("Content-Type", "text/plain"))
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_CONNECT(self):
+        self.server.record("CONNECT", self.path)
+        host, separator, port = self.path.rpartition(":")
+        if not separator or host not in LOCAL_HOSTS:
+            self.send_error(403, "Proxy target is outside the local test stack")
+            return
+
+        try:
+            port_number = int(port)
+            upstream = socket.create_connection(
+                (host, port_number),
+                timeout=IO_TIMEOUT,
+            )
+        except (OSError, ValueError):
+            self.send_error(502, "Local test target is unavailable")
+            return
+
+        self.send_response(200, "Connection Established")
+        self.end_headers()
+        self.wfile.flush()
+        self.close_connection = True
+
+        try:
+            self._relay(upstream)
+        finally:
+            upstream.close()
+
+    def _relay(self, upstream: socket.socket) -> None:
+        downstream = self.connection
+        downstream.settimeout(IO_TIMEOUT)
+        upstream.settimeout(IO_TIMEOUT)
+        connections = (downstream, upstream)
+        deadline = time.monotonic() + TUNNEL_TIMEOUT
+
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select(connections, (), (), 0.1)
+            if (
+                isinstance(downstream, ssl.SSLSocket)
+                and downstream.pending()
+                and downstream not in readable
+            ):
+                readable.append(downstream)
+
+            for source in readable:
+                try:
+                    data = source.recv(65536)
+                except (BlockingIOError, ssl.SSLWantReadError):
+                    continue
+                if not data:
+                    return
+
+                destination = upstream if source is downstream else downstream
+                try:
+                    destination.sendall(data)
+                except OSError:
+                    return
+
+    def log_message(self, _format, *args):
+        del args
+
+
+class LocalHTTPServer:
+    def __init__(
+        self,
+        handler_class,
+        scheme: str,
+        certificate: Path | None = None,
+        private_key: Path | None = None,
+    ) -> None:
+        self.scheme = scheme
+        self.server = RecordingHTTPServer(("127.0.0.1", 0), handler_class)
+        if scheme == "https":
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(certificate, private_key)
+            self.server.socket = context.wrap_socket(
+                self.server.socket,
+                server_side=True,
+            )
+
+        self.thread = threading.Thread(
+            target=self.server.serve_forever,
+            name=f"dirsearch-test-{scheme}-server",
+        )
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        host, port = self.server.server_address
+        return f"{self.scheme}://{host}:{port}/"
+
+    @property
+    def authority(self) -> str:
+        host, port = self.server.server_address
+        return f"{host}:{port}"
+
+    @property
+    def events(self) -> list[tuple[str, str]]:
+        return self.server.events
+
+    def clear_events(self) -> None:
+        self.server.clear_events()
+
+    def close(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=IO_TIMEOUT)
+        if self.thread.is_alive():
+            raise RuntimeError(f"{self.scheme} test server did not stop")
+
+
+class ProxyTestStack:
+    def __enter__(self):
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        certificate, private_key = _create_test_certificate(
+            Path(self._temporary_directory.name)
+        )
+        self._servers = []
+        try:
+            self.http_target = self._start(TargetHandler, "http")
+            self.https_target = self._start(
+                TargetHandler,
+                "https",
+                certificate,
+                private_key,
+            )
+            self.http_proxy = self._start(ForwardProxyHandler, "http")
+            self.https_proxy = self._start(
+                ForwardProxyHandler,
+                "https",
+                certificate,
+                private_key,
+            )
+        except Exception:
+            self.close()
+            raise
+        return self
+
+    def _start(self, handler_class, scheme, certificate=None, private_key=None):
+        server = LocalHTTPServer(
+            handler_class,
+            scheme,
+            certificate,
+            private_key,
+        )
+        self._servers.append(server)
+        return server
+
+    @property
+    def proxies(self) -> tuple[LocalHTTPServer, LocalHTTPServer]:
+        return self.http_proxy, self.https_proxy
+
+    @property
+    def targets(self) -> tuple[LocalHTTPServer, LocalHTTPServer]:
+        return self.http_target, self.https_target
+
+    def close(self) -> None:
+        errors = []
+        for server in reversed(getattr(self, "_servers", [])):
+            try:
+                server.close()
+            except Exception as error:
+                errors.append(error)
+        self._servers = []
+
+        temporary_directory = getattr(self, "_temporary_directory", None)
+        if temporary_directory is not None:
+            temporary_directory.cleanup()
+            self._temporary_directory = None
+
+        if errors:
+            raise errors[0]
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+def _create_test_certificate(directory: Path) -> tuple[Path, Path]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(1)
+        .not_valid_before(datetime(2020, 1, 1, tzinfo=timezone.utc))
+        .not_valid_after(datetime(2040, 1, 1, tzinfo=timezone.utc))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .sign(private_key, hashes.SHA256())
+    )
+
+    certificate_path = directory / "certificate.pem"
+    private_key_path = directory / "private-key.pem"
+    certificate_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    private_key_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return certificate_path, private_key_path

--- a/tests/connection/test_native_backend.py
+++ b/tests/connection/test_native_backend.py
@@ -137,3 +137,19 @@ class TestNativeHTTPBackend(TestCase):
         self.assertEqual(len(fake_native.engines), 1)
         self.assertEqual(len(fake_native.engines[0].calls), 2)
         self.assertTrue(fake_native.engines[0].cancelled)
+
+    def test_origin_407_remains_a_response_without_a_proxy(self):
+        fake_native = FakeNativeModule()
+        options["proxies"] = []
+
+        with (
+            patch.dict("sys.modules", {"dirsearch_native": fake_native}),
+            patch.object(FakeNativeResult, "status", 407),
+        ):
+            backend = NativeHTTPBackend()
+            rows = list(backend.scan("https://example.com/", ["admin"]))
+
+        self.assertEqual(len(rows), 1)
+        _, response, error = rows[0]
+        self.assertIsNone(error)
+        self.assertEqual(response.status, 407)

--- a/tests/connection/test_proxy.py
+++ b/tests/connection/test_proxy.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+from lib.connection.proxy import (
+    format_proxy_error,
+    is_proxy_connect_rejection,
+    proxy_error_status,
+)
+
+
+class TestProxyErrors(TestCase):
+    def test_extracts_status_from_connect_failure(self):
+        error = RuntimeError("Tunnel connection failed: 429 Too Many Requests")
+
+        self.assertEqual(proxy_error_status(error), 429)
+        self.assertEqual(
+            format_proxy_error(error),
+            "Proxy connection failed with HTTP 429",
+        )
+
+    def test_extracts_status_from_nested_bare_status(self):
+        cause = RuntimeError("407 Proxy Authentication Required")
+        error = RuntimeError("proxy connection failed")
+        error.__cause__ = cause
+
+        self.assertEqual(proxy_error_status(error), 407)
+        self.assertEqual(format_proxy_error(error), "Proxy authentication required")
+
+    def test_does_not_treat_url_numbers_as_http_status(self):
+        error = "error sending request for url (http://127.0.0.1:429/path/500)"
+
+        self.assertIsNone(proxy_error_status(error))
+        self.assertEqual(
+            format_proxy_error(error),
+            "Cannot establish the proxy connection",
+        )
+
+    def test_formats_connect_rejection_when_client_discards_status(self):
+        error = "client error (Connect): tunnel error: unsuccessful"
+
+        self.assertTrue(is_proxy_connect_rejection(error))
+        self.assertEqual(
+            format_proxy_error(error),
+            "Proxy CONNECT request was rejected",
+        )

--- a/tests/connection/test_proxy_integration.py
+++ b/tests/connection/test_proxy_integration.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import time
 import warnings
 from unittest import TestCase, skipUnless
 
@@ -7,6 +9,7 @@ from urllib3.exceptions import InsecureRequestWarning
 from lib.connection.native import NativeHTTPBackend
 from lib.connection.requester import AsyncRequester, Requester
 from lib.core.data import options
+from lib.core.exceptions import RequestException
 from tests.connection.proxy_server import ProxyTestStack
 
 
@@ -14,6 +17,15 @@ try:
     import dirsearch_native
 except ImportError:
     dirsearch_native = None
+
+
+PROXY_CREDENTIAL = "proxy-user:proxy-password"
+INVALID_PROXY_CREDENTIAL = "wrong:credentials"
+PROXY_AUTHORIZATION = "Basic " + base64.b64encode(
+    PROXY_CREDENTIAL.encode()
+).decode()
+PROXY_FAILURE_TIMEOUT = 0.2
+PROXY_CASE_DEADLINE = 2
 
 
 class TestProxyIntegration(TestCase):
@@ -58,16 +70,9 @@ class TestProxyIntegration(TestCase):
             with self.subTest(proxy=proxy.scheme, target=target.scheme):
                 path = f"sync-{proxy.scheme}-proxy-{target.scheme}-target"
                 self._prepare_case(proxy, target)
-                options["proxies"] = [proxy.url]
-                requester = Requester()
-                requester.set_url(target.url)
-                try:
-                    with warnings.catch_warnings():
-                        warnings.simplefilter("ignore", InsecureRequestWarning)
-                        response = requester.request(path)
-                finally:
-                    requester.session.close()
+                response, error, _ = self._sync_request(proxy, target, path)
 
+                self.assertIsNone(error)
                 self._assert_case(proxy, target, path, response)
 
     def test_async_engine_uses_http_and_https_proxies_for_both_targets(self):
@@ -78,14 +83,9 @@ class TestProxyIntegration(TestCase):
             with self.subTest(proxy=proxy.scheme, target=target.scheme):
                 path = f"async-{proxy.scheme}-proxy-{target.scheme}-target"
                 self._prepare_case(proxy, target)
-                options["proxies"] = [proxy.url]
-                requester = AsyncRequester()
-                requester.set_url(target.url)
-                try:
-                    response = await requester.request(path)
-                finally:
-                    await requester.session.aclose()
+                response, error, _ = await self._async_request(proxy, target, path)
 
+                self.assertIsNone(error)
                 self._assert_case(proxy, target, path, response)
 
     @skipUnless(
@@ -98,33 +98,337 @@ class TestProxyIntegration(TestCase):
             with self.subTest(proxy=proxy.scheme, target=target.scheme):
                 path = f"native-{proxy.scheme}-proxy-{target.scheme}-target"
                 self._prepare_case(proxy, target)
-                options["proxies"] = [proxy.url]
-                backend = NativeHTTPBackend()
-                rows = list(backend.scan(target.url, [path]))
-
-                self.assertEqual(len(rows), 1)
-                _, response, error = rows[0]
+                response, error, _ = self._native_request(proxy, target, path)
                 self.assertIsNone(error)
                 self._assert_case(proxy, target, path, response)
+
+    def test_sync_engine_authenticates_http_and_https_proxies(self):
+        for proxy, target in self._cases():
+            with self.subTest(proxy=proxy.scheme, target=target.scheme):
+                path = f"sync-auth-{proxy.scheme}-{target.scheme}"
+                self._prepare_authenticated_case(proxy, target)
+                options["proxy_auth"] = PROXY_CREDENTIAL
+                try:
+                    response, error, _ = self._sync_request(proxy, target, path)
+                finally:
+                    proxy.configure_proxy()
+
+                self.assertIsNone(error)
+                self._assert_case(proxy, target, path, response)
+                self.assertEqual(proxy.proxy_authorizations, [PROXY_AUTHORIZATION])
+
+    def test_async_engine_authenticates_http_and_https_proxies(self):
+        asyncio.run(self._test_async_engine_authentication())
+
+    async def _test_async_engine_authentication(self):
+        for proxy, target in self._cases():
+            with self.subTest(proxy=proxy.scheme, target=target.scheme):
+                path = f"async-auth-{proxy.scheme}-{target.scheme}"
+                self._prepare_authenticated_case(proxy, target)
+                options["proxy_auth"] = PROXY_CREDENTIAL
+                try:
+                    response, error, _ = await self._async_request(
+                        proxy, target, path
+                    )
+                finally:
+                    proxy.configure_proxy()
+
+                self.assertIsNone(error)
+                self._assert_case(proxy, target, path, response)
+                self.assertEqual(proxy.proxy_authorizations, [PROXY_AUTHORIZATION])
+
+    @skipUnless(
+        dirsearch_native is not None
+        and hasattr(dirsearch_native, "NativeHttpEngine"),
+        "native extension is not installed",
+    )
+    def test_native_engine_authenticates_http_and_https_proxies(self):
+        for proxy, target in self._cases():
+            with self.subTest(proxy=proxy.scheme, target=target.scheme):
+                path = f"native-auth-{proxy.scheme}-{target.scheme}"
+                self._prepare_authenticated_case(proxy, target)
+                options["proxy_auth"] = PROXY_CREDENTIAL
+                try:
+                    response, error, _ = self._native_request(proxy, target, path)
+                finally:
+                    proxy.configure_proxy()
+
+                self.assertIsNone(error)
+                self._assert_case(proxy, target, path, response)
+                self.assertEqual(proxy.proxy_authorizations, [PROXY_AUTHORIZATION])
+
+    def test_sync_engine_rejects_missing_and_invalid_proxy_credentials(self):
+        for credential in (None, INVALID_PROXY_CREDENTIAL):
+            for proxy, target in self._cases():
+                with self.subTest(
+                    credential=credential,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    path = f"sync-rejected-auth-{proxy.scheme}-{target.scheme}"
+                    self._prepare_authenticated_case(proxy, target)
+                    options["proxy_auth"] = credential
+                    try:
+                        response, error, _ = self._sync_request(proxy, target, path)
+                    finally:
+                        proxy.configure_proxy()
+
+                    self._assert_authentication_rejected(
+                        proxy, target, response, error
+                    )
+
+    def test_async_engine_rejects_missing_and_invalid_proxy_credentials(self):
+        asyncio.run(self._test_async_engine_rejected_authentication())
+
+    async def _test_async_engine_rejected_authentication(self):
+        for credential in (None, INVALID_PROXY_CREDENTIAL):
+            for proxy, target in self._cases():
+                with self.subTest(
+                    credential=credential,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    path = f"async-rejected-auth-{proxy.scheme}-{target.scheme}"
+                    self._prepare_authenticated_case(proxy, target)
+                    options["proxy_auth"] = credential
+                    try:
+                        response, error, _ = await self._async_request(
+                            proxy, target, path
+                        )
+                    finally:
+                        proxy.configure_proxy()
+
+                    self._assert_authentication_rejected(
+                        proxy, target, response, error
+                    )
+
+    @skipUnless(
+        dirsearch_native is not None
+        and hasattr(dirsearch_native, "NativeHttpEngine"),
+        "native extension is not installed",
+    )
+    def test_native_engine_rejects_missing_and_invalid_proxy_credentials(self):
+        for credential in (None, INVALID_PROXY_CREDENTIAL):
+            for proxy, target in self._cases():
+                with self.subTest(
+                    credential=credential,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    path = f"native-rejected-auth-{proxy.scheme}-{target.scheme}"
+                    self._prepare_authenticated_case(proxy, target)
+                    options["proxy_auth"] = credential
+                    try:
+                        response, error, _ = self._native_request(
+                            proxy, target, path
+                        )
+                    finally:
+                        proxy.configure_proxy()
+
+                    self._assert_authentication_rejected(
+                        proxy,
+                        target,
+                        response,
+                        error,
+                        connect_status_available=False,
+                    )
+
+    def test_sync_engine_bounds_proxy_failures_and_handles_429(self):
+        for behavior, proxy, target in self._failure_cases():
+            with self.subTest(
+                behavior=behavior,
+                proxy=proxy.scheme,
+                target=target.scheme,
+            ):
+                path = f"sync-{behavior}-{proxy.scheme}-{target.scheme}"
+                self._prepare_failure_case(proxy, target, behavior)
+                try:
+                    result = self._sync_request(proxy, target, path)
+                finally:
+                    proxy.configure_proxy()
+
+                self._assert_failure_case(behavior, proxy, target, result)
+
+    def test_async_engine_bounds_proxy_failures_and_handles_429(self):
+        asyncio.run(self._test_async_engine_proxy_failures())
+
+    async def _test_async_engine_proxy_failures(self):
+        for behavior, proxy, target in self._failure_cases():
+            with self.subTest(
+                behavior=behavior,
+                proxy=proxy.scheme,
+                target=target.scheme,
+            ):
+                path = f"async-{behavior}-{proxy.scheme}-{target.scheme}"
+                self._prepare_failure_case(proxy, target, behavior)
+                try:
+                    result = await self._async_request(proxy, target, path)
+                finally:
+                    proxy.configure_proxy()
+
+                self._assert_failure_case(behavior, proxy, target, result)
+
+    @skipUnless(
+        dirsearch_native is not None
+        and hasattr(dirsearch_native, "NativeHttpEngine"),
+        "native extension is not installed",
+    )
+    def test_native_engine_bounds_proxy_failures_and_handles_429(self):
+        for behavior, proxy, target in self._failure_cases():
+            with self.subTest(
+                behavior=behavior,
+                proxy=proxy.scheme,
+                target=target.scheme,
+            ):
+                path = f"native-{behavior}-{proxy.scheme}-{target.scheme}"
+                self._prepare_failure_case(proxy, target, behavior)
+                try:
+                    result = self._native_request(proxy, target, path)
+                finally:
+                    proxy.configure_proxy()
+
+                self._assert_failure_case(
+                    behavior,
+                    proxy,
+                    target,
+                    result,
+                    connect_status_available=False,
+                )
 
     def _cases(self):
         for proxy in self.stack.proxies:
             for target in self.stack.targets:
                 yield proxy, target
 
+    def _failure_cases(self):
+        for behavior in ("timeout", "drop", "rate_limit"):
+            for proxy, target in self._cases():
+                yield behavior, proxy, target
+
     @staticmethod
     def _prepare_case(proxy, target):
+        proxy.configure_proxy()
         proxy.clear_events()
         target.clear_events()
+        options["proxy_auth"] = None
+
+    def _prepare_authenticated_case(self, proxy, target):
+        self._prepare_case(proxy, target)
+        options["max_retries"] = 1
+        proxy.configure_proxy(required_authorization=PROXY_AUTHORIZATION)
+
+    def _prepare_failure_case(self, proxy, target, behavior):
+        self._prepare_case(proxy, target)
+        options["timeout"] = PROXY_FAILURE_TIMEOUT
+        options["max_retries"] = 1
+        proxy.configure_proxy(behavior=behavior)
+
+    @staticmethod
+    def _sync_request(proxy, target, path):
+        options["proxies"] = [proxy.url]
+        requester = Requester()
+        requester.set_url(target.url)
+        started = time.monotonic()
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", InsecureRequestWarning)
+                try:
+                    return requester.request(path), None, time.monotonic() - started
+                except RequestException as error:
+                    return None, error, time.monotonic() - started
+        finally:
+            requester.session.close()
+
+    @staticmethod
+    async def _async_request(proxy, target, path):
+        options["proxies"] = [proxy.url]
+        requester = AsyncRequester()
+        requester.set_url(target.url)
+        started = time.monotonic()
+        try:
+            try:
+                response = await requester.request(path)
+                return response, None, time.monotonic() - started
+            except RequestException as error:
+                return None, error, time.monotonic() - started
+        finally:
+            await requester.session.aclose()
+
+    @staticmethod
+    def _native_request(proxy, target, path):
+        options["proxies"] = [proxy.url]
+        backend = NativeHTTPBackend()
+        started = time.monotonic()
+        rows = list(backend.scan(target.url, [path]))
+        elapsed = time.monotonic() - started
+
+        if len(rows) != 1:
+            raise AssertionError(f"Expected one native result, got {len(rows)}")
+        _, response, error = rows[0]
+        return response, error, elapsed
 
     def _assert_case(self, proxy, target, path, response):
         self.assertIsNotNone(response)
         self.assertEqual(response.status, 200)
         self.assertEqual(response.body, f"reached:/{path}".encode())
         self.assertEqual(target.events, [("GET", f"/{path}")])
+        self.assertEqual(target.proxy_authorizations, [None])
 
-        if target.scheme == "http":
-            expected_proxy_event = ("GET", target.url + path)
+        self.assertEqual(proxy.events, [self._expected_proxy_event(target, path)])
+
+    def _assert_authentication_rejected(
+        self,
+        proxy,
+        target,
+        response,
+        error,
+        connect_status_available=True,
+    ):
+        self.assertIsNone(response)
+        self.assertIsNotNone(error)
+        if target.scheme == "https" and not connect_status_available:
+            self.assertEqual(str(error), "Proxy CONNECT request was rejected")
         else:
-            expected_proxy_event = ("CONNECT", target.authority)
-        self.assertEqual(proxy.events, [expected_proxy_event])
+            self.assertEqual(str(error), "Proxy authentication required")
+        self.assertEqual(target.events, [])
+        self.assertEqual(len(proxy.events), 1, "Proxy rejection must not be retried")
+
+    def _assert_failure_case(
+        self,
+        behavior,
+        proxy,
+        target,
+        result,
+        connect_status_available=True,
+    ):
+        response, error, elapsed = result
+        self.assertLess(elapsed, PROXY_CASE_DEADLINE)
+        self.assertEqual(target.events, [])
+        expected_attempts = 2 if behavior in ("timeout", "drop") else 1
+        self.assertEqual(len(proxy.events), expected_attempts)
+
+        if behavior == "rate_limit" and target.scheme == "http":
+            self.assertIsNone(error)
+            self.assertIsNotNone(response)
+            self.assertEqual(response.status, 429)
+            self.assertEqual(response.headers.get("retry-after"), "1")
+            self.assertIn("connection_limit", response.headers.get("proxy-status"))
+            return
+
+        self.assertIsNone(response)
+        self.assertIsNotNone(error)
+        if behavior == "timeout":
+            self.assertIn("timeout", str(error).lower().replace("timed out", "timeout"))
+        elif behavior == "rate_limit":
+            expected = (
+                "Proxy connection failed with HTTP 429"
+                if connect_status_available
+                else "Proxy CONNECT request was rejected"
+            )
+            self.assertEqual(str(error), expected)
+
+    @staticmethod
+    def _expected_proxy_event(target, path):
+        if target.scheme == "http":
+            return "GET", target.url + path
+        return "CONNECT", target.authority

--- a/tests/connection/test_proxy_integration.py
+++ b/tests/connection/test_proxy_integration.py
@@ -1,0 +1,130 @@
+import asyncio
+import warnings
+from unittest import TestCase, skipUnless
+
+from urllib3.exceptions import InsecureRequestWarning
+
+from lib.connection.native import NativeHTTPBackend
+from lib.connection.requester import AsyncRequester, Requester
+from lib.core.data import options
+from tests.connection.proxy_server import ProxyTestStack
+
+
+try:
+    import dirsearch_native
+except ImportError:
+    dirsearch_native = None
+
+
+class TestProxyIntegration(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stack_context = ProxyTestStack()
+        cls.stack = cls.stack_context.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.stack_context.__exit__(None, None, None)
+
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "proxies": [],
+                "headers": {},
+                "data": None,
+                "cert_file": None,
+                "key_file": None,
+                "network_interface": None,
+                "random_agents": False,
+                "auth": None,
+                "auth_type": None,
+                "max_retries": 0,
+                "max_rate": 0,
+                "thread_count": 2,
+                "follow_redirects": False,
+                "http_method": "GET",
+                "timeout": 3,
+                "proxy_auth": None,
+            }
+        )
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_sync_engine_uses_http_and_https_proxies_for_both_targets(self):
+        for proxy, target in self._cases():
+            with self.subTest(proxy=proxy.scheme, target=target.scheme):
+                path = f"sync-{proxy.scheme}-proxy-{target.scheme}-target"
+                self._prepare_case(proxy, target)
+                options["proxies"] = [proxy.url]
+                requester = Requester()
+                requester.set_url(target.url)
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", InsecureRequestWarning)
+                        response = requester.request(path)
+                finally:
+                    requester.session.close()
+
+                self._assert_case(proxy, target, path, response)
+
+    def test_async_engine_uses_http_and_https_proxies_for_both_targets(self):
+        asyncio.run(self._test_async_engine())
+
+    async def _test_async_engine(self):
+        for proxy, target in self._cases():
+            with self.subTest(proxy=proxy.scheme, target=target.scheme):
+                path = f"async-{proxy.scheme}-proxy-{target.scheme}-target"
+                self._prepare_case(proxy, target)
+                options["proxies"] = [proxy.url]
+                requester = AsyncRequester()
+                requester.set_url(target.url)
+                try:
+                    response = await requester.request(path)
+                finally:
+                    await requester.session.aclose()
+
+                self._assert_case(proxy, target, path, response)
+
+    @skipUnless(
+        dirsearch_native is not None
+        and hasattr(dirsearch_native, "NativeHttpEngine"),
+        "native extension is not installed",
+    )
+    def test_native_engine_uses_http_and_https_proxies_for_both_targets(self):
+        for proxy, target in self._cases():
+            with self.subTest(proxy=proxy.scheme, target=target.scheme):
+                path = f"native-{proxy.scheme}-proxy-{target.scheme}-target"
+                self._prepare_case(proxy, target)
+                options["proxies"] = [proxy.url]
+                backend = NativeHTTPBackend()
+                rows = list(backend.scan(target.url, [path]))
+
+                self.assertEqual(len(rows), 1)
+                _, response, error = rows[0]
+                self.assertIsNone(error)
+                self._assert_case(proxy, target, path, response)
+
+    def _cases(self):
+        for proxy in self.stack.proxies:
+            for target in self.stack.targets:
+                yield proxy, target
+
+    @staticmethod
+    def _prepare_case(proxy, target):
+        proxy.clear_events()
+        target.clear_events()
+
+    def _assert_case(self, proxy, target, path, response):
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, f"reached:/{path}".encode())
+        self.assertEqual(target.events, [("GET", f"/{path}")])
+
+        if target.scheme == "http":
+            expected_proxy_event = ("GET", target.url + path)
+        else:
+            expected_proxy_event = ("CONNECT", target.authority)
+        self.assertEqual(proxy.events, [expected_proxy_event])

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -366,6 +366,38 @@ class TestRequesterPathPreservation(BaseRequesterTestCase):
             self.assertEqual(server.targets, [b"/admin?debug=true"])
 
 
+class TestRequesterProxyRouting(BaseRequesterTestCase):
+    def test_proxy_scheme_never_bypasses_target_scheme(self):
+        for proxy_scheme in ("http", "https"):
+            proxy_url = f"{proxy_scheme}://proxy.invalid:8080"
+            options["proxies"] = [proxy_url]
+
+            for target_scheme in ("http", "https"):
+                with self.subTest(
+                    proxy_scheme=proxy_scheme,
+                    target_scheme=target_scheme,
+                ):
+                    requester = Requester()
+                    requester.set_url(f"{target_scheme}://origin.invalid/")
+
+                    with (
+                        patch.object(requester, "increase_rate"),
+                        patch.object(
+                            requester.session,
+                            "send",
+                            return_value=DummySyncResponse(),
+                        ) as send,
+                    ):
+                        requester.request("admin")
+
+                    prepared_request = send.call_args.args[0]
+                    proxies = send.call_args.kwargs["proxies"]
+                    self.assertEqual(
+                        requests.utils.select_proxy(prepared_request.url, proxies),
+                        proxy_url,
+                    )
+
+
 class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCase):
     async def test_async_connect_error_with_ssl_cause_uses_ssl_message(self):
         requester = AsyncRequester()

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -279,6 +279,20 @@ class TestRequesterSSLHandling(BaseRequesterTestCase):
 
 
 class TestRequesterErrorClassification(BaseRequesterTestCase):
+    def test_sync_origin_407_remains_a_response_without_a_proxy(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+        response = DummySyncResponse()
+        response.status_code = 407
+
+        try:
+            with patch.object(requester.session, "send", return_value=response):
+                result = requester.request("admin")
+        finally:
+            requester.session.close()
+
+        self.assertEqual(result.status, 407)
+
     def test_sync_too_many_redirects_uses_specific_message(self):
         requester = Requester()
         requester.set_url("http://example.com/")
@@ -399,6 +413,20 @@ class TestRequesterProxyRouting(BaseRequesterTestCase):
 
 
 class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCase):
+    async def test_async_origin_407_remains_a_response_without_a_proxy(self):
+        requester = AsyncRequester()
+        requester.set_url("http://example.com/")
+        response = DummyAsyncResponse()
+        response.status_code = 407
+        requester.session.send = AsyncMock(return_value=response)
+
+        try:
+            result = await requester.request("admin")
+        finally:
+            await requester.session.aclose()
+
+        self.assertEqual(result.status, 407)
+
     async def test_async_connect_error_with_ssl_cause_uses_ssl_message(self):
         requester = AsyncRequester()
         requester.set_url("https://example.com/")


### PR DESCRIPTION
## Summary

- route synchronous HTTP targets through explicitly configured HTTPS proxies
- let HTTPX generate the correct absolute, CONNECT-authority, and tunneled origin request forms
- configure HTTPX HTTPS-proxy TLS consistently with dirsearch target TLS verification behavior
- classify proxy authentication and CONNECT rejection errors consistently without changing direct-origin 407 responses
- stop retrying explicit proxy 407/429 rejections while retaining bounded retries for timeouts and disconnects
- add a local integration matrix for success, authentication, timeout, disconnect, and rate-limit behavior across threaded, async, and native engines

## Root causes

The Requests proxy dictionary is keyed by the target URL scheme, but the synchronous requester only populated the `http` key when the proxy URL itself was not HTTPS. HTTP targets therefore connected directly instead of using an HTTPS proxy.

The async rotating transport forced one custom request target for both forward-proxy and CONNECT flows. That produced an invalid CONNECT target for HTTPS origins. HTTPX also requires a dedicated proxy SSL context for an HTTPS proxy; the target `verify=False` context is not automatically reused for the proxy TLS connection.

Proxy errors were previously classified inconsistently. Async HTTPS-proxy timeouts could be reported as SSL failures, CONNECT 407/429 details were discarded, HTTP-forwarded 407 responses were treated as scan results, and explicit proxy rejections consumed the retry budget.

## Integration coverage

The test stack is entirely local and binds random ports on `127.0.0.1`. It starts HTTP and HTTPS targets plus HTTP and HTTPS forward proxies, implements bounded CONNECT tunneling, generates an ephemeral self-signed certificate at runtime, records proxy and target events, and verifies all server threads stop.

Every engine covers HTTP and HTTPS proxies against both HTTP and HTTPS targets for:

- successful forwarding and CONNECT tunneling
- valid Basic proxy authentication
- missing and invalid proxy credentials
- proxy response timeout
- connection drop before a response
- proxy-generated HTTP 429 with `Retry-After` and `Proxy-Status`

The assertions prove that credentials reach the proxy but not the target, rejected requests never reach the target, explicit 407/429 rejections are not retried, and timeout/drop retries remain bounded by `max_retries`.

## 407 and 429 behavior

- Forward-proxy 407 responses now fail with `Proxy authentication required`; direct-origin 407 responses remain normal scan responses.
- A forward-proxy 429 for an HTTP target remains a normal 429 response, including rate-limit headers. It is not safe to infer that every forwarded 429 came from the proxy.
- A CONNECT 429 becomes `Proxy connection failed with HTTP 429` in threaded and async modes and is not retried.
- reqwest/hyper-util discards the CONNECT response status in native mode. Native therefore reports `Proxy CONNECT request was rejected` and does not retry that explicit rejection; HTTP-forwarded native 407/429 responses retain their exact status.

## Validation

- native-enabled proxy integration suite: 12 tests passed; repeated three times successfully
- Python 3.14 `python testing.py`: 190 passed
- Python 3.14 `python -m unittest discover`: 417 passed
- Python 3.12 `python testing.py`: 190 passed, 12 skipped
- Python 3.12 `python -m unittest discover`: 417 passed, 24 skipped
- focused proxy/error regression suite: 19 passed
- Rust unit tests: 11 passed
- `cargo fmt --manifest-path native/Cargo.toml -- --check`
- `cargo clippy --manifest-path native/Cargo.toml --all-targets -- -D warnings`
- focused flake8 and codespell checks
- Python compileall and `git diff --check`

Addresses audit finding #3.
