### PR TITLE
Make request rate limiting atomic

### DIFF
--- a/lib/connection/rate_limiter.py
+++ b/lib/connection/rate_limiter.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections import deque
+from collections.abc import Awaitable, Callable
+
+
+RATE_WINDOW_SECONDS = 1.0
+RATE_WAIT_POLL_SECONDS = 0.1
+
+
+class RequestRateLimiter:
+    def __init__(
+        self,
+        clock: Callable[[], float] | None = None,
+        sleep: Callable[[float], None] | None = None,
+        async_sleep: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._clock = clock or time.monotonic
+        self._sleep = sleep or time.sleep
+        self._async_sleep = async_sleep or asyncio.sleep
+        self._request_times: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def wait(self, max_rate: int) -> None:
+        while (delay := self._reserve(max_rate)) is not None:
+            self._sleep(min(delay, RATE_WAIT_POLL_SECONDS))
+
+    async def wait_async(self, max_rate: int) -> None:
+        while (delay := self._reserve(max_rate)) is not None:
+            await self._async_sleep(min(delay, RATE_WAIT_POLL_SECONDS))
+
+    @property
+    def rate(self) -> int:
+        with self._lock:
+            self._discard_expired(self._clock())
+            return len(self._request_times)
+
+    def _reserve(self, max_rate: int) -> float | None:
+        with self._lock:
+            now = self._clock()
+            self._discard_expired(now)
+            if max_rate <= 0 or len(self._request_times) < max_rate:
+                self._request_times.append(now)
+                return None
+
+            return max(
+                0.0,
+                self._request_times[0] + RATE_WINDOW_SECONDS - now,
+            )
+
+    def _discard_expired(self, now: float) -> None:
+        cutoff = now - RATE_WINDOW_SECONDS
+        while self._request_times and self._request_times[0] <= cutoff:
+            self._request_times.popleft()

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import http.client
 import random
 import re
@@ -51,6 +50,7 @@ from lib.connection.proxy import (
     format_proxy_error,
     proxy_error_status,
 )
+from lib.connection.rate_limiter import RequestRateLimiter
 from lib.connection.response import AsyncResponse, Response
 from lib.core.data import options
 from lib.core.decorators import cached
@@ -309,7 +309,7 @@ class BaseRequester:
     def __init__(self) -> None:
         self._url: str = ""
         self._query: str = ""
-        self._rate = 0
+        self._rate_limiter = RequestRateLimiter()
         self.proxy_cred = options["proxy_auth"]
         self.headers = CaseInsensitiveDict(options["headers"])
         self.agents: list[str] = []
@@ -353,20 +353,13 @@ class BaseRequester:
     def set_header(self, key: str, value: str) -> None:
         self.headers[key] = value.lstrip()
 
-    def is_rate_exceeded(self) -> bool:
-        return self._rate >= options["max_rate"] > 0
-
-    def decrease_rate(self) -> None:
-        self._rate -= 1
-
-    def increase_rate(self) -> None:
-        self._rate += 1
-        threading.Timer(1, self.decrease_rate).start()
+    def wait_for_rate_limit(self) -> None:
+        self._rate_limiter.wait(options["max_rate"])
 
     @property
     @cached(RATE_UPDATE_DELAY)
     def rate(self) -> int:
-        return self._rate
+        return self._rate_limiter.rate
 
 
 class HTTPBearerAuth(AuthBase):
@@ -418,11 +411,7 @@ class Requester(BaseRequester):
 
     # :path: is expected not to start with "/"
     def request(self, path: str, proxy: str | None = None) -> Response:
-        # Pause if the request rate exceeded the maximum
-        while self.is_rate_exceeded():
-            time.sleep(0.1)
-
-        self.increase_rate()
+        self.wait_for_rate_limit()
 
         err_msg = None
         request_path = self.request_path(path)
@@ -628,10 +617,7 @@ class AsyncRequester(BaseRequester):
     async def request(
         self, path: str, session: httpx.AsyncClient | None = None, replay: bool = False
     ) -> AsyncResponse:
-        while self.is_rate_exceeded():
-            await asyncio.sleep(0.1)
-
-        self.increase_rate()
+        await self.wait_for_rate_limit()
 
         err_msg = None
         request_path = self.request_path(path)
@@ -716,6 +702,5 @@ class AsyncRequester(BaseRequester):
 
         raise RequestException(err_msg)
 
-    def increase_rate(self) -> None:
-        self._rate += 1
-        asyncio.get_running_loop().call_later(1, self.decrease_rate)
+    async def wait_for_rate_limit(self) -> None:
+        await self._rate_limiter.wait_async(options["max_rate"])

--- a/testing.py
+++ b/testing.py
@@ -26,6 +26,10 @@ from tests.connection.test_native_engine import TestNativeHttpEngine  # noqa: F4
 from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
 from tests.connection.test_proxy import TestProxyErrors  # noqa: F401
 from tests.connection.test_proxy_integration import TestProxyIntegration  # noqa: F401
+from tests.connection.test_rate_limiter import (  # noqa: F401
+    TestAsyncRequestRateLimiter,
+    TestRequestRateLimiter,
+)
 from tests.connection.test_requester import (  # noqa: F401
     TestAsyncRequesterElapsed,
     TestAsyncRequesterSSLHandling,
@@ -35,6 +39,7 @@ from tests.connection.test_requester import (  # noqa: F401
     TestRequesterErrorClassification,
     TestRequesterPathPreservation,
     TestRequesterProxyRouting,
+    TestRequesterRateLimiting,
     TestRequesterSSLHandling,
     TestSSLHelpers,
 )

--- a/tests/connection/test_rate_limiter.py
+++ b/tests/connection/test_rate_limiter.py
@@ -1,0 +1,148 @@
+import threading
+from unittest import IsolatedAsyncioTestCase, TestCase
+
+from lib.connection.rate_limiter import RequestRateLimiter
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, delay: float) -> None:
+        self.sleeps.append(delay)
+        self.now += delay
+
+    async def sleep_async(self, delay: float) -> None:
+        self.sleep(delay)
+
+
+class ControlledClock:
+    def __init__(self) -> None:
+        self._now = 0.0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> float:
+        with self._lock:
+            return self._now
+
+    def set(self, value: float) -> None:
+        with self._lock:
+            self._now = value
+
+
+class ControlledSleeper:
+    def __init__(self) -> None:
+        self._calls = 0
+        self._lock = threading.Lock()
+        self.first_waiters_ready = threading.Event()
+        self.release_first_waiters = threading.Event()
+        self.second_waiter_ready = threading.Event()
+        self.release_second_waiter = threading.Event()
+
+    def __call__(self, _delay: float) -> None:
+        with self._lock:
+            self._calls += 1
+            call = self._calls
+            if call == 2:
+                self.first_waiters_ready.set()
+            elif call == 3:
+                self.second_waiter_ready.set()
+
+        release = (
+            self.release_first_waiters
+            if call <= 2
+            else self.release_second_waiter
+        )
+        if not release.wait(timeout=1):
+            raise RuntimeError("rate limiter test sleeper was not released")
+
+
+class TestRequestRateLimiter(TestCase):
+    def test_unlimited_requests_are_recorded_without_sleeping(self):
+        clock = FakeClock()
+        limiter = RequestRateLimiter(clock=clock, sleep=clock.sleep)
+
+        for _ in range(3):
+            limiter.wait(max_rate=0)
+
+        self.assertEqual(clock.sleeps, [])
+        self.assertEqual(limiter.rate, 3)
+
+    def test_sync_wait_uses_a_rolling_one_second_window(self):
+        clock = FakeClock()
+        limiter = RequestRateLimiter(clock=clock, sleep=clock.sleep)
+
+        limiter.wait(max_rate=2)
+        limiter.wait(max_rate=2)
+        limiter.wait(max_rate=2)
+
+        self.assertAlmostEqual(clock.now, 1.0)
+        self.assertEqual(limiter.rate, 1)
+
+    def test_expired_requests_leave_the_reported_rate(self):
+        clock = FakeClock()
+        limiter = RequestRateLimiter(clock=clock, sleep=clock.sleep)
+        limiter.wait(max_rate=0)
+
+        clock.now = 1.0
+
+        self.assertEqual(limiter.rate, 0)
+
+    def test_concurrent_waiters_cannot_overbook_one_slot(self):
+        clock = ControlledClock()
+        sleeper = ControlledSleeper()
+        limiter = RequestRateLimiter(clock=clock, sleep=sleeper)
+        limiter.wait(max_rate=1)
+        completed = []
+        completed_lock = threading.Lock()
+        first_completed = threading.Event()
+
+        def wait_for_slot() -> None:
+            limiter.wait(max_rate=1)
+            with completed_lock:
+                completed.append(clock())
+                if len(completed) == 1:
+                    first_completed.set()
+
+        threads = [threading.Thread(target=wait_for_slot) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+
+        self.assertTrue(sleeper.first_waiters_ready.wait(timeout=1))
+        self.assertEqual(limiter.rate, 1)
+
+        clock.set(1.0)
+        sleeper.release_first_waiters.set()
+        self.assertTrue(sleeper.second_waiter_ready.wait(timeout=1))
+        self.assertTrue(first_completed.wait(timeout=1))
+        with completed_lock:
+            self.assertEqual(completed, [1.0])
+
+        clock.set(2.0)
+        sleeper.release_second_waiter.set()
+        for thread in threads:
+            thread.join(timeout=1)
+            self.assertFalse(thread.is_alive())
+
+        with completed_lock:
+            self.assertEqual(completed, [1.0, 2.0])
+
+
+class TestAsyncRequestRateLimiter(IsolatedAsyncioTestCase):
+    async def test_async_wait_uses_the_same_rolling_window(self):
+        clock = FakeClock()
+        limiter = RequestRateLimiter(
+            clock=clock,
+            async_sleep=clock.sleep_async,
+        )
+
+        await limiter.wait_async(max_rate=2)
+        await limiter.wait_async(max_rate=2)
+        await limiter.wait_async(max_rate=2)
+
+        self.assertAlmostEqual(clock.now, 1.0)
+        self.assertEqual(limiter.rate, 1)

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -30,6 +30,7 @@ import requests
 
 from lib.connection import requester as requester_module
 from lib.connection.native import NativeHTTPBackend
+from lib.connection.rate_limiter import RequestRateLimiter
 from lib.connection.requester import (
     AsyncRequester,
     Requester,
@@ -342,7 +343,7 @@ class TestRequesterErrorClassification(BaseRequesterTestCase):
 class TestRequesterElapsed(TestCase):
     def test_request_elapsed_includes_stream_read(self):
         requester = object.__new__(Requester)
-        requester._rate = 0
+        requester._rate_limiter = RequestRateLimiter()
         requester._url = "https://example.com/"
         requester.proxy_cred = None
         requester.headers = {}
@@ -354,6 +355,28 @@ class TestRequesterElapsed(TestCase):
                 response = requester.request("admin")
 
         self.assertEqual(response.elapsed, 0.25, "Sync elapsed should measure the full streamed request lifecycle")
+
+
+class TestRequesterRateLimiting(BaseRequesterTestCase):
+    def test_unlimited_requests_do_not_spawn_timer_threads(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+
+        try:
+            with (
+                patch.object(
+                    requester.session,
+                    "send",
+                    return_value=DummySyncResponse(),
+                ),
+                patch.object(requester_module.threading, "Timer") as timer,
+            ):
+                for path in ("first", "second", "third"):
+                    requester.request(path)
+        finally:
+            requester.session.close()
+
+        timer.assert_not_called()
 
 
 class TestRequesterPathPreservation(BaseRequesterTestCase):
@@ -395,7 +418,7 @@ class TestRequesterProxyRouting(BaseRequesterTestCase):
                     requester.set_url(f"{target_scheme}://origin.invalid/")
 
                     with (
-                        patch.object(requester, "increase_rate"),
+                        patch.object(requester, "wait_for_rate_limit"),
                         patch.object(
                             requester.session,
                             "send",
@@ -493,7 +516,7 @@ class TestAsyncRequesterSSLHandling(BaseRequesterTestCase, IsolatedAsyncioTestCa
 class TestAsyncRequesterElapsed(IsolatedAsyncioTestCase):
     async def test_request_elapsed_waits_for_stream_close(self):
         requester = object.__new__(AsyncRequester)
-        requester._rate = 0
+        requester._rate_limiter = RequestRateLimiter()
         requester._url = "https://example.com/"
         requester.proxy_cred = None
         requester.headers = {}


### PR DESCRIPTION
## Summary

- replace one timer/callback per request with a monotonic rolling one-second window
- reserve rate slots atomically so concurrent threaded workers cannot exceed `--max-rate`
- use the same limiter state and semantics for threaded and async requesters
- preserve rolling request-rate reporting without background expiry workers
- add deterministic sync, async, expiry, and concurrent-wakeup regressions

## Root cause

The synchronous requester checked `_rate` and incremented it as two separate operations. Concurrent workers could all observe available capacity before any worker incremented the counter, producing a burst above `--max-rate`.

Every synchronous request also started a new `threading.Timer`, even when `--max-rate=0`. The red regression shows three unlimited requests creating three timer threads. Async mode similarly scheduled one expiry callback per request.

## Behavior

The replacement stores only request start timestamps from the last second. A small lock protects pruning and slot reservation; no lock is held while sleeping or awaiting. Waiting remains interruptible in short intervals, unlimited mode never sleeps, and the displayed rate remains the number of starts in the rolling one-second window.

Native mode is intentionally unchanged. Master still rejects native `--max-rate`; a sustained limiter shared across native chunks is separate parity work and should not be mixed with this Python concurrency fix.

## Validation

- red regression on merged master: 3 unlimited requests created 3 timer threads
- focused limiter/requester/proxy tests: 44 passed, 8 native skips on Python 3.12
- deterministic concurrent slot test repeated 100 times successfully
- Python 3.12 `python testing.py`: 196 passed, 12 skipped
- Python 3.12 `python -m unittest discover`: 429 passed, 24 skipped
- Python 3.14 `python testing.py`: 196 passed
- Python 3.14 `python -m unittest discover`: 429 passed
- focused flake8 and codespell checks
- Python compileall and `git diff --check`
- built the wheel and verified `dirsearch/lib/connection/rate_limiter.py` is packaged

Addresses audit finding #4.
