### PR TITLE
Close streamed responses and requester sessions

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -409,6 +409,9 @@ class Requester(BaseRequester):
             else:
                 self.session.auth = HttpNtlmAuth(user, password)
 
+    def close(self) -> None:
+        self.session.close()
+
     # :path: is expected not to start with "/"
     def request(self, path: str, proxy: str | None = None) -> Response:
         self.wait_for_rate_limit()
@@ -461,13 +464,16 @@ class Requester(BaseRequester):
                     proxies=proxies,
                     stream=True,
                 )
-                if (
-                    proxies
-                    and origin_response.status_code == PROXY_AUTHENTICATION_REQUIRED
-                ):
+                try:
+                    if (
+                        proxies
+                        and origin_response.status_code
+                        == PROXY_AUTHENTICATION_REQUIRED
+                    ):
+                        raise RequestException("Proxy authentication required")
+                    response = Response(url, origin_response)
+                finally:
                     origin_response.close()
-                    raise RequestException("Proxy authentication required")
-                response = Response(url, origin_response)
                 response.elapsed = time.perf_counter() - start_time
 
                 log_msg = f'"{options["http_method"]} {response.url}" {response.status} - {response.length}B'
@@ -598,6 +604,13 @@ class AsyncRequester(BaseRequester):
             else:
                 self.session.auth = HttpxNtlmAuth(user, password)
 
+    async def close(self) -> None:
+        try:
+            if self.replay_session is not None:
+                await self.replay_session.aclose()
+        finally:
+            await self.session.aclose()
+
     async def replay_request(self, path: str, proxy: str) -> AsyncResponse:
         if self.replay_session is None:
             transport = httpx.AsyncHTTPTransport(
@@ -652,14 +665,16 @@ class AsyncRequester(BaseRequester):
                     stream=True,
                     follow_redirects=options["follow_redirects"],
                 )
-                if (
-                    using_proxy
-                    and xresponse.status_code == PROXY_AUTHENTICATION_REQUIRED
-                ):
+                try:
+                    if (
+                        using_proxy
+                        and xresponse.status_code
+                        == PROXY_AUTHENTICATION_REQUIRED
+                    ):
+                        raise RequestException("Proxy authentication required")
+                    response = await AsyncResponse.create(url, xresponse)
+                finally:
                     await xresponse.aclose()
-                    raise RequestException("Proxy authentication required")
-                response = await AsyncResponse.create(url, xresponse)
-                await xresponse.aclose()
                 # Measure the whole streamed request lifecycle so sync and async
                 # modes report the same thing.
                 response.elapsed = time.perf_counter() - start_time

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -177,7 +177,28 @@ class Controller:
             self.setup()
             self.old_session = False
 
-        self.run()
+        try:
+            self.run()
+        finally:
+            self._close_requester()
+
+    def _close_requester(self) -> None:
+        requester = getattr(self, "requester", None)
+        loop = getattr(self, "loop", None)
+
+        if requester is None:
+            if loop is not None:
+                loop.close()
+            return
+
+        if loop is None:
+            requester.close()
+            return
+
+        try:
+            loop.run_until_complete(requester.close())
+        finally:
+            loop.close()
 
     def _import(self, session_file: str) -> None:
         try:

--- a/testing.py
+++ b/testing.py
@@ -32,6 +32,7 @@ from tests.connection.test_rate_limiter import (  # noqa: F401
 )
 from tests.connection.test_requester import (  # noqa: F401
     TestAsyncRequesterElapsed,
+    TestAsyncRequesterResponseCleanup,
     TestAsyncRequesterSSLHandling,
     TestAsyncRequesterPathPreservation,
     TestNativeRequesterPathPreservation,
@@ -40,12 +41,16 @@ from tests.connection.test_requester import (  # noqa: F401
     TestRequesterPathPreservation,
     TestRequesterProxyRouting,
     TestRequesterRateLimiting,
+    TestRequesterResponseCleanup,
     TestRequesterSSLHandling,
     TestSSLHelpers,
 )
 from tests.connection.test_response import TestResponse  # noqa: F401
 from tests.connection.test_response import TestAsyncResponse  # noqa: F401
-from tests.controller.test_async_controller import TestAsyncController  # noqa: F401
+from tests.controller.test_async_controller import (  # noqa: F401
+    TestAsyncController,
+    TestControllerCleanup,
+)
 from tests.controller.test_session_store import TestSessionStore  # noqa: F401
 from tests.core.test_advanced_filters import TestAdvancedFilters  # noqa: F401
 from tests.core.test_async_fuzzer import TestAsyncFuzzer  # noqa: F401

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -29,6 +29,7 @@ import httpx
 import requests
 
 from lib.connection import requester as requester_module
+from lib.connection import response as response_module
 from lib.connection.native import NativeHTTPBackend
 from lib.connection.rate_limiter import RequestRateLimiter
 from lib.connection.requester import (
@@ -143,10 +144,30 @@ class DummySyncResponse:
     history = []
     encoding = "utf-8"
 
-    @staticmethod
-    def iter_content(chunk_size):
+    def __init__(self, error=None):
+        self.closed = False
+        self.error = error
+
+    def iter_content(self, chunk_size):
         del chunk_size
         yield b"body"
+        if self.error:
+            raise self.error
+
+    def close(self):
+        self.closed = True
+
+
+class MultiChunkSyncResponse(DummySyncResponse):
+    def __init__(self):
+        super().__init__()
+        self.read_second_chunk = False
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        yield b"body"
+        self.read_second_chunk = True
+        yield b"should-not-be-read"
 
 
 class DummySyncSession:
@@ -168,16 +189,30 @@ class DummyAsyncResponse:
     history = []
     encoding = "utf-8"
 
-    def __init__(self):
+    def __init__(self, error=None):
         self.closed = False
+        self.error = error
 
-    @staticmethod
-    async def aiter_bytes(chunk_size):
+    async def aiter_bytes(self, chunk_size):
         del chunk_size
         yield b"body"
+        if self.error:
+            raise self.error
 
     async def aclose(self):
         self.closed = True
+
+
+class MultiChunkAsyncResponse(DummyAsyncResponse):
+    def __init__(self):
+        super().__init__()
+        self.read_second_chunk = False
+
+    async def aiter_bytes(self, chunk_size):
+        del chunk_size
+        yield b"body"
+        self.read_second_chunk = True
+        yield b"should-not-be-read"
 
 
 class DummyAsyncSession:
@@ -188,10 +223,14 @@ class DummyAsyncSession:
 
     def __init__(self, response):
         self.response = response
+        self.closed = False
 
     async def send(self, request, **kwargs):
         del request, kwargs
         return self.response
+
+    async def aclose(self):
+        self.closed = True
 
 
 class BaseRequesterTestCase(TestCase):
@@ -379,6 +418,48 @@ class TestRequesterRateLimiting(BaseRequesterTestCase):
         timer.assert_not_called()
 
 
+class TestRequesterResponseCleanup(BaseRequesterTestCase):
+    def test_sync_response_closes_after_early_bounded_parse(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+        origin_response = MultiChunkSyncResponse()
+
+        try:
+            with (
+                patch.object(
+                    requester.session, "send", return_value=origin_response
+                ),
+                patch.object(response_module, "MAX_RESPONSE_SIZE", 4),
+            ):
+                response = requester.request("admin")
+        finally:
+            requester.session.close()
+
+        self.assertEqual(response.body, b"body")
+        self.assertFalse(origin_response.read_second_chunk)
+        self.assertTrue(origin_response.closed)
+
+    def test_sync_response_closes_when_body_parse_fails(self):
+        requester = Requester()
+        requester.set_url("http://example.com/")
+        origin_response = DummySyncResponse(
+            requests.exceptions.ChunkedEncodingError("incomplete body")
+        )
+
+        try:
+            with patch.object(
+                requester.session, "send", return_value=origin_response
+            ):
+                with self.assertRaisesRegex(
+                    RequestException, "Failed to read response body"
+                ):
+                    requester.request("admin")
+        finally:
+            requester.session.close()
+
+        self.assertTrue(origin_response.closed)
+
+
 class TestRequesterPathPreservation(BaseRequesterTestCase):
     def test_sync_requester_preserves_encoded_edge_case_targets(self):
         with RequestTargetServer() as server:
@@ -529,6 +610,54 @@ class TestAsyncRequesterElapsed(IsolatedAsyncioTestCase):
 
         self.assertEqual(response.elapsed, 0.5, "Async elapsed should measure the full streamed request lifecycle")
         self.assertTrue(requester.session.response.closed, "Streamed async responses should be closed before elapsed is used")
+
+
+class TestAsyncRequesterResponseCleanup(
+    BaseRequesterTestCase, IsolatedAsyncioTestCase
+):
+    async def test_async_response_closes_when_body_parse_fails(self):
+        requester = AsyncRequester()
+        requester.set_url("http://example.com/")
+        origin_response = DummyAsyncResponse(
+            httpx.RemoteProtocolError("incomplete body")
+        )
+        requester.session.send = AsyncMock(return_value=origin_response)
+
+        try:
+            with self.assertRaisesRegex(
+                RequestException, "Failed to read response body"
+            ):
+                await requester.request("admin")
+        finally:
+            await requester.session.aclose()
+
+        self.assertTrue(origin_response.closed)
+
+    async def test_async_response_closes_after_early_bounded_parse(self):
+        requester = AsyncRequester()
+        requester.set_url("http://example.com/")
+        origin_response = MultiChunkAsyncResponse()
+        requester.session.send = AsyncMock(return_value=origin_response)
+
+        try:
+            with patch.object(response_module, "MAX_RESPONSE_SIZE", 4):
+                response = await requester.request("admin")
+        finally:
+            await requester.session.aclose()
+
+        self.assertEqual(response.body, b"body")
+        self.assertFalse(origin_response.read_second_chunk)
+        self.assertTrue(origin_response.closed)
+
+    async def test_close_closes_primary_and_replay_sessions(self):
+        requester = object.__new__(AsyncRequester)
+        requester.session = DummyAsyncSession(DummyAsyncResponse())
+        requester.replay_session = DummyAsyncSession(DummyAsyncResponse())
+
+        await requester.close()
+
+        self.assertTrue(requester.session.closed)
+        self.assertTrue(requester.replay_session.closed)
 
 
 class TestAsyncRequesterPathPreservation(BaseRequesterTestCase, IsolatedAsyncioTestCase):

--- a/tests/controller/test_async_controller.py
+++ b/tests/controller/test_async_controller.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
-from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import Mock, patch
 
 from lib.controller.controller import Controller
 from lib.core.data import options
@@ -33,6 +33,64 @@ def create_controller(fuzzer):
     controller.pause_future = controller.loop.create_future()
     controller.fuzzer = fuzzer
     return controller
+
+
+class RecordingLoop:
+    def __init__(self):
+        self.closed = False
+
+    def run_until_complete(self, awaitable):
+        return asyncio.run(awaitable)
+
+    def close(self):
+        self.closed = True
+
+
+class RecordingAsyncRequester:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class TestControllerCleanup(TestCase):
+    def test_sync_requester_closes_after_run_failure(self):
+        requester = Mock()
+
+        def fail_run(controller):
+            controller.requester = requester
+            raise RuntimeError("scan failed")
+
+        with (
+            patch.dict(options, {"session_file": None}),
+            patch.object(Controller, "setup"),
+            patch.object(Controller, "run", new=fail_run),
+            self.assertRaisesRegex(RuntimeError, "scan failed"),
+        ):
+            Controller()
+
+        requester.close.assert_called_once_with()
+
+    def test_async_requester_and_event_loop_close_after_run_failure(self):
+        requester = RecordingAsyncRequester()
+        loop = RecordingLoop()
+
+        def fail_run(controller):
+            controller.requester = requester
+            controller.loop = loop
+            raise RuntimeError("scan failed")
+
+        with (
+            patch.dict(options, {"session_file": None}),
+            patch.object(Controller, "setup"),
+            patch.object(Controller, "run", new=fail_run),
+            self.assertRaisesRegex(RuntimeError, "scan failed"),
+        ):
+            Controller()
+
+        self.assertTrue(requester.closed)
+        self.assertTrue(loop.closed)
 
 
 class TestAsyncController(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- close every synchronous streamed response after parsing, including early body cutoffs and parser failures
- close every asynchronous streamed response in a `finally` block so parser failures cannot leak connections
- give sync and async requesters explicit client-session teardown APIs
- close primary and replay async clients plus the controller event loop on normal completion and exceptional exit
- register deterministic response and controller cleanup regressions in the legacy test runner

## Root cause

The synchronous requester parsed a streamed `requests.Response` into a detached dirsearch response but never closed the original response. Early exits at the response-size or binary-body limits could therefore leave pooled connections checked out.

The asynchronous requester closed its `httpx.Response` only after `AsyncResponse.create()` returned successfully. A decoding, protocol, or streamed-body exception skipped `aclose()`. The controller also never closed the long-lived requester clients, optional replay client, or async event loop.

## Resource ownership

The requester owns the transport response returned by its client. Parsing now occurs inside a narrow `try/finally`, and elapsed time continues to include stream teardown. The controller owns requester/client lifetime and closes it from `Controller.__init__` regardless of how `run()` exits. Async replay and primary clients are both attempted, and the event loop closes even if async client cleanup raises.

## Regression evidence

Against merged master, five cleanup regressions failed:

- synchronous response after successful parsing remained open
- synchronous response after a body-read failure remained open
- asynchronous response after a body-read failure remained open
- synchronous controller failure left the requester client open
- asynchronous controller failure left the requester client and event loop open

All now pass, with additional coverage for early bounded sync/async parsing and primary plus replay client teardown.

## Validation

- focused cleanup regressions: 7 passed
- requester, response, proxy integration, and controller suites: 61 passed, 8 native skips on Python 3.12
- Python 3.12 `python testing.py`: 203 passed, 12 skipped
- Python 3.12 `python -m unittest discover`: 441 passed, 24 skipped
- rebuilt the native extension from current master
- native proxy integration matrix: 12 passed
- Python 3.14 `python testing.py`: 203 passed
- Python 3.14 `python -m unittest discover`: 441 passed
- focused flake8 and codespell checks
- Python compileall and `git diff --check`
- built the Python wheel and verified both changed runtime modules are packaged

Addresses audit finding #5.