### PR TITLE
Fix native raw HTTP fallback semantics

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -34,6 +55,27 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -70,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +149,8 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 name = "dirsearch_native"
 version = "0.1.0"
 dependencies = [
+ "brotli",
+ "flate2",
  "indexmap",
  "pyo3",
  "rayon",
@@ -134,6 +187,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -539,6 +602,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -980,6 +1053,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -9,9 +9,11 @@ name = "dirsearch_native"
 crate-type = ["cdylib"]
 
 [dependencies]
+brotli = "8.0"
+flate2 = "1.1"
 indexmap = "2.7"
 pyo3 = { version = "0.24", features = ["extension-module", "abi3-py313"] }
 rayon = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
 regex = "1.11"
-tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "time"] }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,3 +1,5 @@
+mod raw_http;
+
 use indexmap::IndexSet;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -5,8 +7,8 @@ use rayon::prelude::*;
 use regex::{Regex, RegexBuilder};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::fs;
-use std::io::{Read, Write};
-use std::net::TcpStream;
+#[cfg(test)]
+use std::io::Cursor;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -51,7 +53,17 @@ struct NativeHttpEngine {
 type NumericRange = (usize, usize);
 type TimeFilter = (String, f64);
 type HeaderPairs = Vec<(String, String)>;
-type RawHttpResponse = (u16, HeaderPairs, Vec<u8>, usize);
+type RawHttpResponse = raw_http::Response;
+
+struct RawHttpRequest<'a> {
+    base_url: &'a str,
+    path: String,
+    headers: &'a HeaderPairs,
+    timeout_secs: f64,
+    max_body_size: usize,
+    start: Instant,
+    cancelled: Arc<AtomicBool>,
+}
 
 #[derive(Clone, Eq, PartialEq)]
 struct NativeHttpEngineConfig {
@@ -665,6 +677,7 @@ impl NativeHttpEngine {
                     let raw_headers = raw_headers.clone();
                     let semaphore = semaphore.clone();
                     let filter_config = filter_config.clone();
+                    let request_cancelled = cancelled.clone();
                     tasks.spawn(async move {
                         let _permit = match semaphore.acquire_owned().await {
                             Ok(permit) => permit,
@@ -685,27 +698,19 @@ impl NativeHttpEngine {
                             let raw_base_url = base_url.clone();
                             let raw_path = path.clone();
                             let raw_filter_config = filter_config.clone();
-                            let raw_result = tokio::task::spawn_blocking(move || {
-                                raw_http_get(
-                                    &raw_base_url,
-                                    raw_path,
-                                    &raw_headers,
+                            raw_http_get(
+                                RawHttpRequest {
+                                    base_url: &raw_base_url,
+                                    path: raw_path,
+                                    headers: &raw_headers,
                                     timeout_secs,
                                     max_body_size,
                                     start,
-                                    raw_filter_config.as_ref(),
-                                )
-                            })
-                            .await;
-
-                            match raw_result {
-                                Ok(result) => result,
-                                Err(error) => native_error_result(
-                                    path,
-                                    start.elapsed().as_secs_f64() * 1000.0,
-                                    error.to_string(),
-                                ),
-                            }
+                                    cancelled: request_cancelled,
+                                },
+                                raw_filter_config.as_ref(),
+                            )
+                            .await
                         } else {
                             request_with_client(
                                 &client,
@@ -1100,37 +1105,30 @@ fn has_malformed_percent_escape(path: &str) -> bool {
     false
 }
 
-fn raw_http_get(
-    base_url: &str,
-    path: String,
-    headers: &[(String, String)],
-    timeout_secs: f64,
-    max_body_size: usize,
-    start: Instant,
+async fn raw_http_get(
+    request: RawHttpRequest<'_>,
     filter_config: &NativeFilterConfig,
 ) -> NativeHttpResult {
-    match raw_http_get_inner(base_url, &path, headers, timeout_secs, max_body_size) {
+    match raw_http_get_inner(&request).await {
         Ok((status, headers, body, length)) => native_http_result_with_length(
-            path,
+            request.path,
             status,
             headers,
             body,
             length,
-            start.elapsed().as_secs_f64() * 1000.0,
+            request.start.elapsed().as_secs_f64() * 1000.0,
             filter_config,
         ),
-        Err(error) => native_error_result(path, start.elapsed().as_secs_f64() * 1000.0, error),
+        Err(error) => native_error_result(
+            request.path,
+            request.start.elapsed().as_secs_f64() * 1000.0,
+            error,
+        ),
     }
 }
 
-fn raw_http_get_inner(
-    base_url: &str,
-    path: &str,
-    headers: &[(String, String)],
-    timeout_secs: f64,
-    max_body_size: usize,
-) -> Result<RawHttpResponse, String> {
-    let url = reqwest::Url::parse(base_url).map_err(|error| error.to_string())?;
+async fn raw_http_get_inner(request: &RawHttpRequest<'_>) -> Result<RawHttpResponse, String> {
+    let url = reqwest::Url::parse(request.base_url).map_err(|error| error.to_string())?;
     if url.scheme() != "http" {
         return Err("Raw HTTP path preservation only supports http:// URLs".to_string());
     }
@@ -1146,35 +1144,50 @@ fn raw_http_get_inner(
         Some(port) => format!("{host}:{port}"),
         None => host.clone(),
     };
-    let timeout = Duration::from_secs_f64(timeout_secs);
-    let mut stream =
-        TcpStream::connect((host.as_str(), port)).map_err(|error| error.to_string())?;
-    stream
-        .set_read_timeout(Some(timeout))
-        .map_err(|error| error.to_string())?;
-    stream
-        .set_write_timeout(Some(timeout))
-        .map_err(|error| error.to_string())?;
-
-    let target = raw_request_target(url.path(), path);
-    let mut request =
+    let target = raw_request_target(url.path(), &request.path);
+    let mut wire_request =
         format!("GET {target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n");
-    for (name, value) in headers {
-        request.push_str(name);
-        request.push_str(": ");
-        request.push_str(value);
-        request.push_str("\r\n");
+    for (name, value) in request.headers {
+        wire_request.push_str(name);
+        wire_request.push_str(": ");
+        wire_request.push_str(value);
+        wire_request.push_str("\r\n");
     }
-    request.push_str("\r\n");
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|error| error.to_string())?;
+    wire_request.push_str("\r\n");
 
-    let mut raw_response = Vec::new();
+    let timeout = Duration::from_secs_f64(request.timeout_secs);
+    let deadline = request
+        .start
+        .checked_add(timeout)
+        .ok_or_else(|| "Raw HTTP timeout exceeded the supported duration".to_string())?;
+    let stream = tokio::time::timeout_at(
+        tokio::time::Instant::from_std(deadline),
+        tokio::net::TcpStream::connect((host.as_str(), port)),
+    )
+    .await
+    .map_err(|_| "Raw HTTP connection timed out".to_string())?
+    .map_err(|error| error.to_string())?;
+    let stream = stream.into_std().map_err(|error| error.to_string())?;
     stream
-        .read_to_end(&mut raw_response)
+        .set_nonblocking(false)
         .map_err(|error| error.to_string())?;
-    parse_raw_http_response(raw_response, max_body_size)
+    let shutdown_stream = stream.try_clone().map_err(|error| error.to_string())?;
+    let mut shutdown_guard = raw_http::ShutdownOnDrop::new(shutdown_stream);
+    let cancelled = request.cancelled.clone();
+    let max_body_size = request.max_body_size;
+    let exchange = tokio::task::spawn_blocking(move || {
+        raw_http::exchange(
+            stream,
+            wire_request.as_bytes(),
+            deadline,
+            cancelled,
+            max_body_size,
+        )
+    })
+    .await
+    .map_err(|error| error.to_string())?;
+    shutdown_guard.disarm();
+    exchange
 }
 
 fn raw_request_target(base_path: &str, path: &str) -> String {
@@ -1187,37 +1200,12 @@ fn raw_request_target(base_path: &str, path: &str) -> String {
     target
 }
 
+#[cfg(test)]
 fn parse_raw_http_response(
     raw_response: Vec<u8>,
     max_body_size: usize,
 ) -> Result<RawHttpResponse, String> {
-    let header_end = raw_response
-        .windows(4)
-        .position(|window| window == b"\r\n\r\n")
-        .ok_or_else(|| "HTTP response did not contain a header terminator".to_string())?;
-    let header_bytes = &raw_response[..header_end];
-    let body_start = header_end + 4;
-    let body_bytes = &raw_response[body_start..];
-    let header_text = String::from_utf8_lossy(header_bytes);
-    let mut lines = header_text.split("\r\n");
-    let status_line = lines
-        .next()
-        .ok_or_else(|| "HTTP response did not contain a status line".to_string())?;
-    let status = status_line
-        .split_whitespace()
-        .nth(1)
-        .ok_or_else(|| "HTTP response status line did not contain a status code".to_string())?
-        .parse::<u16>()
-        .map_err(|error| error.to_string())?;
-    let headers = lines
-        .filter_map(|line| {
-            line.split_once(':')
-                .map(|(name, value)| (name.to_string(), value.trim_start().to_string()))
-        })
-        .collect::<Vec<_>>();
-    let length = body_bytes.len();
-    let body = body_bytes[..length.min(max_body_size)].to_vec();
-    Ok((status, headers, body, length))
+    raw_http::parse_response(Cursor::new(raw_response), max_body_size)
 }
 
 fn read_lines(path: &str) -> PyResult<Vec<String>> {
@@ -1350,6 +1338,7 @@ fn apply_case(path: String, lowercase: bool, uppercase: bool, capitalization: bo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     fn default_filter_config() -> NativeFilterConfig {
         NativeFilterConfig::new(
@@ -1403,6 +1392,151 @@ mod tests {
             "https://example.com/",
             "admin%3d..%1\\*"
         ));
+    }
+
+    fn raw_response(headers: &str, body: &[u8]) -> Vec<u8> {
+        let mut response = format!("HTTP/1.1 200 OK\r\n{headers}\r\n\r\n").into_bytes();
+        response.extend_from_slice(body);
+        response
+    }
+
+    #[test]
+    fn raw_http_parser_decodes_chunked_body_and_tracks_decoded_length() {
+        let response = raw_response(
+            "Transfer-Encoding: chunked",
+            b"4\r\nWiki\r\n5; extension=yes\r\npedia\r\n0\r\nX-Trailer: done\r\n\r\n",
+        );
+
+        let (_, _, body, length) = parse_raw_http_response(response, 80).unwrap();
+
+        assert_eq!(body, b"Wikipedia");
+        assert_eq!(length, 9);
+    }
+
+    #[test]
+    fn raw_http_parser_caps_chunked_body_without_losing_decoded_length() {
+        let response = raw_response(
+            "Transfer-Encoding: chunked",
+            b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n",
+        );
+
+        let (_, _, body, length) = parse_raw_http_response(response, 4).unwrap();
+
+        assert_eq!(body, b"Wiki");
+        assert_eq!(length, 9);
+    }
+
+    #[test]
+    fn raw_http_parser_honors_content_length_and_ignores_extra_bytes() {
+        let response = raw_response("Content-Length: 4", b"bodyEXTRA");
+
+        let (_, _, body, length) = parse_raw_http_response(response, 80).unwrap();
+
+        assert_eq!(body, b"body");
+        assert_eq!(length, 4);
+    }
+
+    #[test]
+    fn raw_http_parser_rejects_truncated_content_length() {
+        let response = raw_response("Content-Length: 5", b"four");
+
+        let error = parse_raw_http_response(response, 80).unwrap_err();
+
+        assert!(error.contains("ended before Content-Length"));
+    }
+
+    #[test]
+    fn raw_http_parser_rejects_truncated_chunked_body() {
+        let response = raw_response("Transfer-Encoding: chunked", b"5\r\nfour");
+
+        let error = parse_raw_http_response(response, 80).unwrap_err();
+
+        assert!(error.contains("chunked body"));
+    }
+
+    #[test]
+    fn raw_http_parser_decodes_gzip_before_body_filters() {
+        let gzip_hello_world = [
+            31, 139, 8, 0, 0, 0, 0, 0, 2, 3, 203, 72, 205, 201, 201, 87, 40, 207, 47, 202, 73, 1,
+            0, 133, 17, 74, 13, 11, 0, 0, 0,
+        ];
+        let response = raw_response(
+            &format!(
+                "Content-Encoding: gzip\r\nContent-Length: {}",
+                gzip_hello_world.len()
+            ),
+            &gzip_hello_world,
+        );
+
+        let (_, _, body, length) = parse_raw_http_response(response, 80).unwrap();
+
+        assert_eq!(body, b"hello world");
+        assert_eq!(length, 11);
+    }
+
+    #[test]
+    fn raw_http_parser_decodes_stacked_content_encodings() {
+        let mut gzip = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gzip.write_all(b"hello world").unwrap();
+        let gzip = gzip.finish().unwrap();
+        let mut compressed = Vec::new();
+        {
+            let mut brotli = brotli::CompressorWriter::new(&mut compressed, 4096, 5, 22);
+            brotli.write_all(&gzip).unwrap();
+        }
+        let response = raw_response("Content-Encoding: gzip, br", &compressed);
+
+        let (_, _, body, length) = parse_raw_http_response(response, 80).unwrap();
+
+        assert_eq!(body, b"hello world");
+        assert_eq!(length, 11);
+    }
+
+    #[test]
+    fn raw_http_parser_decodes_zlib_wrapped_deflate() {
+        let mut deflate =
+            flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        deflate.write_all(b"hello world").unwrap();
+        let compressed = deflate.finish().unwrap();
+        let response = raw_response("Content-Encoding: deflate", &compressed);
+
+        let (_, _, body, length) = parse_raw_http_response(response, 80).unwrap();
+
+        assert_eq!(body, b"hello world");
+        assert_eq!(length, 11);
+    }
+
+    #[test]
+    fn raw_http_parser_rejects_ambiguous_message_framing() {
+        let response = raw_response(
+            "Content-Length: 4\r\nTransfer-Encoding: chunked",
+            b"4\r\nbody\r\n0\r\n\r\n",
+        );
+
+        let error = parse_raw_http_response(response, 80).unwrap_err();
+
+        assert!(error.contains("both Transfer-Encoding and Content-Length"));
+    }
+
+    #[test]
+    fn raw_http_parser_bounds_response_headers() {
+        let response = raw_response(&format!("X-Large: {}", "a".repeat(70 * 1024)), b"");
+
+        let error = parse_raw_http_response(response, 80).unwrap_err();
+
+        assert!(error.contains("HTTP header line exceeded"));
+    }
+
+    #[test]
+    fn raw_http_parser_skips_informational_response() {
+        let response =
+            b"HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok".to_vec();
+
+        let (status, _, body, length) = parse_raw_http_response(response, 80).unwrap();
+
+        assert_eq!(status, 200);
+        assert_eq!(body, b"ok");
+        assert_eq!(length, 2);
     }
 
     #[test]

--- a/native/src/raw_http.rs
+++ b/native/src/raw_http.rs
@@ -1,0 +1,482 @@
+use brotli::Decompressor;
+use flate2::read::{GzDecoder, ZlibDecoder};
+use std::io::{self, BufReader, Read, Write};
+use std::net::{Shutdown, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const MAX_HEADER_SIZE: usize = 64 * 1024;
+const MAX_CHUNK_LINE_SIZE: usize = 8 * 1024;
+const IO_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+pub(crate) type HeaderPairs = Vec<(String, String)>;
+pub(crate) type Response = (u16, HeaderPairs, Vec<u8>, usize);
+
+pub(crate) struct ShutdownOnDrop {
+    stream: Option<TcpStream>,
+}
+
+impl ShutdownOnDrop {
+    pub(crate) fn new(stream: TcpStream) -> Self {
+        Self {
+            stream: Some(stream),
+        }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.stream = None;
+    }
+}
+
+impl Drop for ShutdownOnDrop {
+    fn drop(&mut self) {
+        if let Some(stream) = self.stream.take() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    }
+}
+
+pub(crate) fn exchange(
+    mut stream: TcpStream,
+    request: &[u8],
+    deadline: Instant,
+    cancelled: Arc<AtomicBool>,
+    max_body_size: usize,
+) -> Result<Response, String> {
+    write_all(&mut stream, request, deadline, cancelled.as_ref())
+        .map_err(|error| format!("Raw HTTP request write failed: {error}"))?;
+    let reader = DeadlineReader {
+        stream,
+        deadline,
+        cancelled,
+    };
+    parse_response(reader, max_body_size)
+}
+
+pub(crate) fn parse_response<R: Read + 'static>(
+    reader: R,
+    max_body_size: usize,
+) -> Result<Response, String> {
+    let mut reader = BufReader::new(reader);
+    let mut informational_responses = 0usize;
+    let (status, headers) = loop {
+        let response = read_head(&mut reader)?;
+        if (100..200).contains(&response.0) && response.0 != 101 {
+            informational_responses += 1;
+            if informational_responses > 8 {
+                return Err("HTTP response contained too many informational responses".to_string());
+            }
+            continue;
+        }
+        break response;
+    };
+
+    if status == 101 || status == 204 || status == 304 {
+        return Ok((status, headers, Vec::new(), 0));
+    }
+
+    let content_length = content_length(&headers)?;
+    let transfer_codings = comma_separated_header_values(&headers, "transfer-encoding");
+    let framing = if transfer_codings.is_empty() {
+        match content_length {
+            Some(length) => BodyReader::fixed(reader, length),
+            None => BodyReader::close_delimited(reader),
+        }
+    } else {
+        if content_length.is_some() {
+            return Err(
+                "HTTP response contains both Transfer-Encoding and Content-Length".to_string(),
+            );
+        }
+        if transfer_codings.len() != 1 || !transfer_codings[0].eq_ignore_ascii_case("chunked") {
+            return Err(format!(
+                "Unsupported HTTP Transfer-Encoding: {}",
+                transfer_codings.join(", ")
+            ));
+        }
+        BodyReader::chunked(reader)
+    };
+
+    let encodings = comma_separated_header_values(&headers, "content-encoding");
+    let mut decoded: Box<dyn Read> = Box::new(framing);
+    for encoding in encodings.iter().rev() {
+        decoded = if encoding.eq_ignore_ascii_case("identity") {
+            decoded
+        } else if encoding.eq_ignore_ascii_case("gzip") {
+            Box::new(GzDecoder::new(decoded))
+        } else if encoding.eq_ignore_ascii_case("deflate") {
+            Box::new(ZlibDecoder::new(decoded))
+        } else if encoding.eq_ignore_ascii_case("br") {
+            Box::new(Decompressor::new(decoded, 4096))
+        } else {
+            return Err(format!("Unsupported HTTP Content-Encoding: {encoding}"));
+        };
+    }
+    let (body, decoded_length) = collect_body(decoded, max_body_size).map_err(|error| {
+        if encodings.is_empty() {
+            error
+        } else {
+            format!(
+                "Failed to decode {} response body: {error}",
+                encodings.join(", ")
+            )
+        }
+    })?;
+
+    Ok((status, headers, body, decoded_length))
+}
+
+fn read_head<R: Read>(reader: &mut R) -> Result<(u16, HeaderPairs), String> {
+    let status_line = read_crlf_line(reader, MAX_HEADER_SIZE, "HTTP status line")?;
+    let status_text = std::str::from_utf8(&status_line)
+        .map_err(|_| "HTTP response status line is not valid UTF-8".to_string())?;
+    let mut status_parts = status_text.split_whitespace();
+    let version = status_parts
+        .next()
+        .ok_or_else(|| "HTTP response did not contain a status line".to_string())?;
+    if !version.starts_with("HTTP/") {
+        return Err("HTTP response status line did not start with HTTP/".to_string());
+    }
+    let status = status_parts
+        .next()
+        .ok_or_else(|| "HTTP response status line did not contain a status code".to_string())?
+        .parse::<u16>()
+        .map_err(|error| error.to_string())?;
+
+    let mut total_size = status_line.len() + 2;
+    let mut headers = Vec::new();
+    loop {
+        let remaining = MAX_HEADER_SIZE.saturating_sub(total_size);
+        if remaining < 2 {
+            return Err(format!(
+                "HTTP response headers exceeded {MAX_HEADER_SIZE} bytes"
+            ));
+        }
+        let line = read_crlf_line(reader, remaining, "HTTP header line")?;
+        total_size = total_size.saturating_add(line.len() + 2);
+        if line.is_empty() {
+            break;
+        }
+        if matches!(line.first(), Some(b' ' | b'\t')) {
+            return Err("Obsolete folded HTTP response headers are not supported".to_string());
+        }
+        let colon = line
+            .iter()
+            .position(|byte| *byte == b':')
+            .ok_or_else(|| "HTTP response header did not contain a colon".to_string())?;
+        let name = std::str::from_utf8(&line[..colon])
+            .map_err(|_| "HTTP response header name is not valid ASCII".to_string())?;
+        if name.is_empty() {
+            return Err("HTTP response header name is empty".to_string());
+        }
+        if !name.is_ascii() {
+            return Err("HTTP response header name is not valid ASCII".to_string());
+        }
+        let value = String::from_utf8_lossy(&line[colon + 1..]);
+        headers.push((name.to_string(), value.trim().to_string()));
+    }
+
+    Ok((status, headers))
+}
+
+fn content_length(headers: &HeaderPairs) -> Result<Option<usize>, String> {
+    let values = comma_separated_header_values(headers, "content-length");
+    if values.is_empty() {
+        return Ok(None);
+    }
+
+    let mut parsed = values.iter().map(|value| {
+        value
+            .parse::<usize>()
+            .map_err(|_| format!("Invalid HTTP Content-Length: {value}"))
+    });
+    let expected = parsed
+        .next()
+        .expect("content length values are not empty")?;
+    for value in parsed {
+        if value? != expected {
+            return Err("HTTP response contains conflicting Content-Length values".to_string());
+        }
+    }
+    Ok(Some(expected))
+}
+
+fn comma_separated_header_values(headers: &HeaderPairs, wanted_name: &str) -> Vec<String> {
+    headers
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case(wanted_name))
+        .flat_map(|(_, value)| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn collect_body<R: Read>(mut reader: R, max_body_size: usize) -> Result<(Vec<u8>, usize), String> {
+    let mut body = Vec::with_capacity(max_body_size.min(8192));
+    let mut decoded_length = 0usize;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        decoded_length = decoded_length
+            .checked_add(read)
+            .ok_or_else(|| "HTTP response body length overflowed usize".to_string())?;
+        let remaining = max_body_size.saturating_sub(body.len());
+        body.extend_from_slice(&buffer[..read.min(remaining)]);
+    }
+    Ok((body, decoded_length))
+}
+
+enum BodyReader<R> {
+    Empty,
+    Fixed {
+        reader: R,
+        remaining: usize,
+    },
+    CloseDelimited(R),
+    Chunked {
+        reader: R,
+        chunk_remaining: usize,
+        finished: bool,
+    },
+}
+
+impl<R> BodyReader<R> {
+    fn fixed(reader: R, remaining: usize) -> Self {
+        if remaining == 0 {
+            Self::Empty
+        } else {
+            Self::Fixed { reader, remaining }
+        }
+    }
+
+    fn close_delimited(reader: R) -> Self {
+        Self::CloseDelimited(reader)
+    }
+
+    fn chunked(reader: R) -> Self {
+        Self::Chunked {
+            reader,
+            chunk_remaining: 0,
+            finished: false,
+        }
+    }
+}
+
+impl<R: Read> Read for BodyReader<R> {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        if output.is_empty() {
+            return Ok(0);
+        }
+        match self {
+            Self::Empty => Ok(0),
+            Self::CloseDelimited(reader) => reader.read(output),
+            Self::Fixed { reader, remaining } => {
+                if *remaining == 0 {
+                    return Ok(0);
+                }
+                let read_size = output.len().min(*remaining);
+                let read = reader.read(&mut output[..read_size])?;
+                if read == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "HTTP response ended before Content-Length bytes were received",
+                    ));
+                }
+                *remaining -= read;
+                Ok(read)
+            }
+            Self::Chunked {
+                reader,
+                chunk_remaining,
+                finished,
+            } => {
+                if *finished {
+                    return Ok(0);
+                }
+                if *chunk_remaining == 0 {
+                    let line = read_crlf_line(reader, MAX_CHUNK_LINE_SIZE, "HTTP chunk size")
+                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+                    let size_text = std::str::from_utf8(
+                        line.split(|byte| *byte == b';').next().unwrap_or_default(),
+                    )
+                    .map_err(|_| {
+                        io::Error::new(io::ErrorKind::InvalidData, "HTTP chunk size is not UTF-8")
+                    })?
+                    .trim();
+                    if size_text.is_empty() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "HTTP chunked body contains an empty chunk size",
+                        ));
+                    }
+                    *chunk_remaining = usize::from_str_radix(size_text, 16).map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "HTTP chunked body contains an invalid chunk size",
+                        )
+                    })?;
+                    if *chunk_remaining == 0 {
+                        read_trailers(reader)?;
+                        *finished = true;
+                        return Ok(0);
+                    }
+                }
+
+                let read_size = output.len().min(*chunk_remaining);
+                let read = reader.read(&mut output[..read_size])?;
+                if read == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "HTTP response ended inside a chunked body",
+                    ));
+                }
+                *chunk_remaining -= read;
+                if *chunk_remaining == 0 {
+                    let mut terminator = [0u8; 2];
+                    reader.read_exact(&mut terminator).map_err(|error| {
+                        io::Error::new(
+                            error.kind(),
+                            format!("HTTP response ended inside a chunked body: {error}"),
+                        )
+                    })?;
+                    if terminator != *b"\r\n" {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "HTTP chunked body is missing a chunk terminator",
+                        ));
+                    }
+                }
+                Ok(read)
+            }
+        }
+    }
+}
+
+fn read_trailers<R: Read>(reader: &mut R) -> io::Result<()> {
+    let mut total_size = 0usize;
+    loop {
+        let remaining = MAX_HEADER_SIZE.saturating_sub(total_size);
+        if remaining < 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("HTTP response trailers exceeded {MAX_HEADER_SIZE} bytes"),
+            ));
+        }
+        let line = read_crlf_line(reader, remaining, "HTTP trailer")
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        total_size = total_size.saturating_add(line.len() + 2);
+        if line.is_empty() {
+            return Ok(());
+        }
+        if !line.contains(&b':') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP trailer did not contain a colon",
+            ));
+        }
+    }
+}
+
+fn read_crlf_line<R: Read>(reader: &mut R, limit: usize, context: &str) -> Result<Vec<u8>, String> {
+    let mut line = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let read = reader.read(&mut byte).map_err(|error| error.to_string())?;
+        if read == 0 {
+            return Err(format!("HTTP response ended before {context} was complete"));
+        }
+        line.push(byte[0]);
+        if line.len() > limit {
+            return Err(format!("{context} exceeded {limit} bytes"));
+        }
+        if byte[0] == b'\n' {
+            if line.len() < 2 || line[line.len() - 2] != b'\r' {
+                return Err(format!("{context} did not end with CRLF"));
+            }
+            line.truncate(line.len() - 2);
+            return Ok(line);
+        }
+    }
+}
+
+struct DeadlineReader {
+    stream: TcpStream,
+    deadline: Instant,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Read for DeadlineReader {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let timeout = remaining_poll_timeout(self.deadline, self.cancelled.as_ref())?;
+            self.stream.set_read_timeout(Some(timeout))?;
+            match self.stream.read(output) {
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    continue;
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                result => return result,
+            }
+        }
+    }
+}
+
+fn write_all(
+    stream: &mut TcpStream,
+    mut data: &[u8],
+    deadline: Instant,
+    cancelled: &AtomicBool,
+) -> io::Result<()> {
+    while !data.is_empty() {
+        let timeout = remaining_poll_timeout(deadline, cancelled)?;
+        stream.set_write_timeout(Some(timeout))?;
+        match stream.write(data) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write the raw HTTP request",
+                ));
+            }
+            Ok(written) => data = &data[written..],
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                ) => {}
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn remaining_poll_timeout(deadline: Instant, cancelled: &AtomicBool) -> io::Result<Duration> {
+    if cancelled.load(Ordering::Acquire) {
+        return Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "raw HTTP request was cancelled",
+        ));
+    }
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::TimedOut, "raw HTTP request timed out"))?;
+    if remaining.is_zero() {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "raw HTTP request timed out",
+        ));
+    }
+    Ok(remaining.min(IO_POLL_INTERVAL))
+}

--- a/tests/connection/test_native_engine.py
+++ b/tests/connection/test_native_engine.py
@@ -22,6 +22,8 @@ class StalledHTTPServer:
         self.listener.bind(("127.0.0.1", 0))
         self.listener.listen()
         self.release = threading.Event()
+        self.accepted = threading.Event()
+        self.peer_closed = threading.Event()
         self.thread = threading.Thread(target=self._serve, daemon=True)
         self.thread.start()
 
@@ -34,7 +36,15 @@ class StalledHTTPServer:
         try:
             connection, _ = self.listener.accept()
             with connection:
-                self.release.wait(timeout=5)
+                self.accepted.set()
+                connection.settimeout(0.05)
+                while not self.release.is_set():
+                    try:
+                        if connection.recv(4096) == b"":
+                            self.peer_closed.set()
+                            return
+                    except TimeoutError:
+                        continue
         except OSError:
             pass
 
@@ -42,6 +52,65 @@ class StalledHTTPServer:
         self.release.set()
         self.listener.close()
         self.thread.join(timeout=1)
+
+
+class RawResponseServer:
+    def __init__(self, response):
+        self.response = response
+        self.request_target = None
+        self.listener = socket.socket()
+        self.listener.bind(("127.0.0.1", 0))
+        self.listener.listen()
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self):
+        host, port = self.listener.getsockname()
+        return f"http://{host}:{port}/"
+
+    def _serve(self):
+        try:
+            connection, _ = self.listener.accept()
+            with connection:
+                request = bytearray()
+                while b"\r\n\r\n" not in request:
+                    chunk = connection.recv(4096)
+                    if not chunk:
+                        return
+                    request.extend(chunk)
+                self.request_target = request.split(b" ", 2)[1].decode("ascii")
+                connection.sendall(self.response)
+        except OSError:
+            pass
+
+    def close(self):
+        self.listener.close()
+        self.thread.join(timeout=1)
+
+
+class SlowBodyServer(RawResponseServer):
+    def __init__(self):
+        super().__init__(b"")
+
+    def _serve(self):
+        try:
+            connection, _ = self.listener.accept()
+            with connection:
+                request = bytearray()
+                while b"\r\n\r\n" not in request:
+                    chunk = connection.recv(4096)
+                    if not chunk:
+                        return
+                    request.extend(chunk)
+                connection.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n"
+                )
+                for _ in range(100):
+                    connection.sendall(b"x")
+                    time.sleep(0.05)
+        except OSError:
+            pass
 
 
 class KeepAliveHandler(BaseHTTPRequestHandler):
@@ -130,6 +199,136 @@ class TestNativeHttpEngine(TestCase):
 
         self.assertEqual(results, [])
         self.assertLess(elapsed, 2)
+
+    def test_explicit_cancellation_closes_raw_fallback_socket(self):
+        server = StalledHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=5)
+        cancel_timer = threading.Timer(0.1, engine.cancel)
+
+        try:
+            cancel_timer.start()
+            started = time.monotonic()
+            results = engine.scan(server.url, ["slow%1"])
+            elapsed = time.monotonic() - started
+            peer_closed = server.peer_closed.wait(timeout=1)
+        finally:
+            cancel_timer.join(timeout=1)
+            server.close()
+
+        self.assertEqual(results, [])
+        self.assertLess(elapsed, 2)
+        self.assertTrue(peer_closed)
+
+    def test_raw_fallback_uses_end_to_end_timeout(self):
+        server = StalledHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=0.2)
+
+        try:
+            started = time.monotonic()
+            results = engine.scan(server.url, ["slow%1"])
+            elapsed = time.monotonic() - started
+        finally:
+            server.close()
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].error)
+        self.assertIn("timed out", results[0].error.lower())
+        self.assertLess(elapsed, 2)
+
+    def test_raw_fallback_timeout_is_not_reset_by_slow_body_bytes(self):
+        server = SlowBodyServer()
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=0.2)
+
+        try:
+            started = time.monotonic()
+            results = engine.scan(server.url, ["slow%1"])
+            elapsed = time.monotonic() - started
+        finally:
+            server.close()
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNotNone(results[0].error)
+        self.assertIn("timed out", results[0].error.lower())
+        self.assertLess(elapsed, 1)
+
+    def test_raw_fallback_decodes_chunked_body_before_capping(self):
+        server = RawResponseServer(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+            b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n"
+        )
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=1)
+
+        try:
+            results = engine.scan(server.url, ["chunked%1"], max_body_size=4)
+        finally:
+            server.close()
+
+        self.assertEqual(server.request_target, "/chunked%1")
+        self.assertIsNone(results[0].error)
+        self.assertEqual(results[0].body, b"Wiki")
+        self.assertEqual(results[0].length, 9)
+
+    def test_raw_fallback_decodes_gzip_before_body_matching(self):
+        compressed = bytes(
+            [
+                31,
+                139,
+                8,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+                3,
+                203,
+                72,
+                205,
+                201,
+                201,
+                87,
+                40,
+                207,
+                47,
+                202,
+                73,
+                1,
+                0,
+                133,
+                17,
+                74,
+                13,
+                11,
+                0,
+                0,
+                0,
+            ]
+        )
+        server = RawResponseServer(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Encoding: gzip\r\n"
+            + f"Content-Length: {len(compressed)}\r\n".encode()
+            + b"Connection: close\r\n\r\n"
+            + compressed
+        )
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=1)
+
+        try:
+            results = engine.scan(
+                server.url,
+                ["gzip%1"],
+                matcher_mode="and",
+                match_words=[(2, 2)],
+                match_regex="hello world",
+            )
+        finally:
+            server.close()
+
+        self.assertIsNone(results[0].error)
+        self.assertFalse(results[0].filtered)
+        self.assertEqual(results[0].body, b"hello world")
 
     def test_python_signal_interrupts_active_scan(self):
         server = StalledHTTPServer()


### PR DESCRIPTION
## Summary

- apply one end-to-end timeout to raw fallback DNS, connect, write, headers, and body reads
- close the underlying raw socket when a native scan is cancelled or interrupted
- replace the unbounded `read_to_end()` parser with bounded streaming HTTP framing
- decode chunked transfer bodies and gzip, deflate, and Brotli content before body-based filters run
- reject truncated or ambiguous response framing instead of returning misleading body data
- preserve the existing HTTP-only, direct-connection, single-request fallback scope

## User-visible effect

Native scans that require exact raw request targets no longer hang past the configured timeout, leave blocking socket work behind after cancellation, or count chunk metadata/compressed bytes as response content. The decoded body is capped in memory while its full decoded length is still tracked.

## Tests

- `cargo fmt --manifest-path native/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path native/Cargo.toml` (22 passed)
- `cargo clippy --locked --manifest-path native/Cargo.toml --all-targets -- -D warnings`
- native extension rebuilt with Maturin on CPython 3.14
- `python -m unittest -v tests.connection.test_native_engine` (9 passed)
- `python testing.py` (208 passed)
- `git diff --check`
- GitHub CI passed CodeQL, Semgrep, the Python 3.11/3.14 Linux and Windows matrix, native backend validation, and threaded/async/native-rust Docker image builds

The local Docker daemon was unavailable, so release-image validation was completed by GitHub CI.
