### PR TITLE
Use canonical unittest discovery in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         echo https://self-signed.badssl.com | python3 dirsearch.py -w ./tests/static/wordlist.txt --stdin --max-time 8 --auth u:p --auth-type basic --scheme http --target-max-time 9
 
     - name: Unit Test
-      run: python3 testing.py
+      run: python -m unittest discover -s tests -t .
 
     - name: Lint
       run: |
@@ -68,4 +68,4 @@ jobs:
       run: |
         python -c "import dirsearch_native"
         python -m unittest tests.connection.test_requester.TestNativeRequesterPathPreservation
-        python testing.py
+        python -m unittest discover -s tests -t .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Build, Test, and Development Commands
 - `python3 dirsearch.py -u https://example.com -w tests/static/wordlist.txt -q`: quick local CLI smoke test.
-- `python3 testing.py`: legacy unit/integration test runner used by CI.
+- `python -m unittest discover -s tests -t .`: canonical unit/integration test runner used by CI.
 - `python3 -m unittest tests.connection.test_requester tests.connection.test_dns tests.core.test_scanner`: focused regression pass.
 - `python3 -m pip install .`: validate packaged install and console entrypoints.
 - `docker compose -f - build dirsearch` with `build.network: host`: verify Docker release images, matching the GitHub workflow.

--- a/lib/report/sqlite_report.py
+++ b/lib/report/sqlite_report.py
@@ -47,6 +47,7 @@ class SQLiteReport(SQLReportMixin, BaseReport):
         try:
             conn.cursor().execute("PRAGMA integrity_check")
         except sqlite3.DatabaseError as error:
+            conn.close()
             raise ValueError(
                 f"{file} is not empty or is not a valid SQLite database"
             ) from error

--- a/testing.py
+++ b/testing.py
@@ -18,67 +18,24 @@
 #
 #  Author: Mauro Soria
 
+from pathlib import Path
 import unittest
 
-from tests.connection.test_dns import TestDNS  # noqa: F401
-from tests.connection.test_native_backend import TestNativeHTTPBackend  # noqa: F401
-from tests.connection.test_native_engine import TestNativeHttpEngine  # noqa: F401
-from tests.connection.test_native_response import TestNativeResponse  # noqa: F401
-from tests.connection.test_proxy import TestProxyErrors  # noqa: F401
-from tests.connection.test_proxy_integration import TestProxyIntegration  # noqa: F401
-from tests.connection.test_rate_limiter import (  # noqa: F401
-    TestAsyncRequestRateLimiter,
-    TestRequestRateLimiter,
-)
-from tests.connection.test_requester import (  # noqa: F401
-    TestAsyncRequesterElapsed,
-    TestAsyncRequesterResponseCleanup,
-    TestAsyncRequesterSSLHandling,
-    TestAsyncRequesterPathPreservation,
-    TestNativeRequesterPathPreservation,
-    TestRequesterElapsed,
-    TestRequesterErrorClassification,
-    TestRequesterPathPreservation,
-    TestRequesterProxyRouting,
-    TestRequesterRateLimiting,
-    TestRequesterResponseCleanup,
-    TestRequesterSSLHandling,
-    TestSSLHelpers,
-)
-from tests.connection.test_response import TestResponse  # noqa: F401
-from tests.connection.test_response import TestAsyncResponse  # noqa: F401
-from tests.controller.test_async_controller import (  # noqa: F401
-    TestAsyncController,
-    TestControllerCleanup,
-)
-from tests.controller.test_session_store import TestSessionStore  # noqa: F401
-from tests.core.test_advanced_filters import TestAdvancedFilters  # noqa: F401
-from tests.core.test_async_fuzzer import TestAsyncFuzzer  # noqa: F401
-from tests.core.test_dictionary_templates import TestDictionaryTemplates  # noqa: F401
-from tests.core.test_fuzzer_filter_stacks import (  # noqa: F401
-    TestAsyncFuzzerFilterStack,
-    TestNativeFuzzerFilterStack,
-    TestSyncFuzzerFilterStack,
-)
-from tests.core.test_importable_api import TestImportableAPI  # noqa: F401
-from tests.core.test_native_fuzzer import TestNativeFuzzer  # noqa: F401
-from tests.core.test_request_backend import TestRequestBackend  # noqa: F401
-from tests.core.test_scanner import TestScanner  # noqa: F401
-from tests.core.test_wordlist_backend import TestWordlistBackend  # noqa: F401
-from tests.parse.test_cmdline import TestCommandLineHelp  # noqa: F401
-from tests.parse.test_config import TestConfigParser  # noqa: F401
-from tests.parse.test_headers import TestHeadersParser  # noqa: F401
-from tests.parse.test_rawrequest import TestRawRequestParser  # noqa: F401
-from tests.parse.test_url import TestURLParsers  # noqa: F401
-from tests.utils.test_common import TestCommonUtils  # noqa: F401
-from tests.utils.test_crawl import TestCrawl  # noqa: F401
-from tests.utils.test_diff import TestDiff  # noqa: F401
-from tests.utils.test_mimetype import TestMimeTypeUtils  # noqa: F401
-from tests.utils.test_random import TestRandom  # noqa: F401
-from tests.utils.test_schemedet import TestSchemedet  # noqa: F401
-from tests.utils.test_terminal import TestTerminalOutput  # noqa: F401
-from tests.test_optional_db_dependencies import TestOptionalDBDependencies  # noqa: F401
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+TEST_ROOT = PROJECT_ROOT / "tests"
+
+
+def discover_tests():
+    return unittest.TestLoader().discover(
+        str(TEST_ROOT), pattern="test_*.py", top_level_dir=str(PROJECT_ROOT)
+    )
+
+
+def main():
+    result = unittest.TextTestRunner().run(discover_tests())
+    return 0 if result.wasSuccessful() else 1
 
 
 if __name__ == "__main__":
-    unittest.main()
+    raise SystemExit(main())

--- a/tests/test_report_exception_handling.py
+++ b/tests/test_report_exception_handling.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 from lib.core.exceptions import FileExistsException, InvalidRawRequest
 from lib.parse.rawrequest import parse_raw
@@ -37,6 +38,20 @@ class TestReportExceptionHandling(TestCase):
                 SQLiteReport().connect(str(database))
 
         self.assertIsInstance(context.exception.__cause__, sqlite3.DatabaseError)
+
+    def test_sqlite_report_closes_connection_after_validation_failure(self):
+        connection = Mock()
+        connection.cursor.return_value.execute.side_effect = sqlite3.DatabaseError
+
+        with TemporaryDirectory() as directory:
+            database = str(Path(directory, "report.sqlite"))
+            with patch(
+                "lib.report.sqlite_report.sqlite3.connect", return_value=connection
+            ):
+                with self.assertRaisesRegex(ValueError, "valid SQLite database"):
+                    SQLiteReport().connect(database)
+
+        connection.close.assert_called_once_with()
 
     def test_raw_request_malformed_input_preserves_invalid_request_type(self):
         with TemporaryDirectory() as directory:

--- a/tests/test_test_discovery.py
+++ b/tests/test_test_discovery.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import unittest
+
+import testing
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TEST_ROOT = PROJECT_ROOT / "tests"
+
+
+def iter_test_cases(suite):
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            yield from iter_test_cases(item)
+        else:
+            yield item
+
+
+def expected_test_modules():
+    return {
+        ".".join(path.relative_to(PROJECT_ROOT).with_suffix("").parts)
+        for path in TEST_ROOT.rglob("test_*.py")
+    }
+
+
+def discovered_test_modules(suite):
+    return {test.__class__.__module__ for test in iter_test_cases(suite)}
+
+
+class TestTestDiscovery(unittest.TestCase):
+    def test_all_test_modules_are_discoverable(self):
+        suite = unittest.TestLoader().discover(
+            str(TEST_ROOT), top_level_dir=str(PROJECT_ROOT)
+        )
+
+        self.assertEqual(discovered_test_modules(suite), expected_test_modules())
+
+    def test_legacy_runner_uses_the_canonical_discovery_suite(self):
+        suite = testing.discover_tests()
+
+        self.assertEqual(discovered_test_modules(suite), expected_test_modules())
+
+    def test_ci_runs_canonical_test_discovery(self):
+        workflow = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+        command = "python -m unittest discover -s tests -t ."
+
+        self.assertEqual(workflow.count(command), 2)
+        self.assertNotIn("python3 testing.py", workflow)


### PR DESCRIPTION
## Summary

- replace the hand-maintained `testing.py` import list with automatic `unittest` discovery
- make `tests/controller` discoverable so controller lifecycle/session regressions run normally
- use the same canonical discovery command in standard and native CI jobs
- retain `testing.py` as a compatibility wrapper over the canonical suite
- add regression checks that every `test_*.py` module is discoverable and CI cannot drift back to the manual runner
- close SQLite report connections when integrity validation fails, fixing a Windows file-handle leak exposed by the expanded suite

## Coverage change

Before this change, `testing.py` ran 208 tests. Direct discovery found 243, while another 7 controller tests were invisible because the directory lacked a package marker. The corrected pre-regression total was therefore 250 tests.

After adding the discovery guards and SQLite cleanup regression, all supported entrypoints consistently run 254 tests. Root-level discovery also runs 254 once instead of importing the manual suite a second time.

## Tests

- focused discovery/report regressions: 8 passed
- Python 3.12 canonical discovery: 254 passed, 17 skipped native-only tests
- Python 3.14 canonical discovery with native extension: 254 passed
- `python testing.py`: 254 passed
- root `python -m unittest discover`: 254 passed
- `python -m compileall -q testing.py tests`
- `flake8 .`
- `codespell -S CONTRIBUTORS.md,./db/categories/*,./build,./native/target`
- `cargo fmt --manifest-path native/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path native/Cargo.toml` (22 passed)
- `cargo clippy --locked --manifest-path native/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

The first expanded CI run exposed the SQLite connection leak on Windows. The second commit adds a deterministic close assertion and the production cleanup; the refreshed matrix validates the fix on Windows.
