### PR TITLE
Scope DNS overrides to each requester

### DIFF
--- a/lib/connection/dns.py
+++ b/lib/connection/dns.py
@@ -18,24 +18,24 @@
 
 from __future__ import annotations
 
-import threading
-
 
 class DNSResolver:
-    """Requester-owned hostname overrides used by the --ip option."""
+    """Requester-owned hostname overrides used by the --ip option.
+
+    The controller configures overrides between targets before request workers
+    start. Connection workers only read this mapping, so the hot path does not
+    require synchronization.
+    """
 
     def __init__(self) -> None:
         self._overrides: dict[tuple[str, int], str] = {}
-        self._lock = threading.Lock()
 
     @staticmethod
     def _key(host: str, port: int) -> tuple[str, int]:
         return host.rstrip(".").casefold(), port
 
     def add_override(self, host: str, port: int, address: str) -> None:
-        with self._lock:
-            self._overrides[self._key(host, port)] = address
+        self._overrides[self._key(host, port)] = address
 
     def resolve(self, host: str, port: int) -> str:
-        with self._lock:
-            return self._overrides.get(self._key(host, port), host)
+        return self._overrides.get(self._key(host, port), host)

--- a/lib/connection/dns.py
+++ b/lib/connection/dns.py
@@ -18,24 +18,24 @@
 
 from __future__ import annotations
 
-from socket import getaddrinfo
-from typing import Any
-
-_dns_cache: dict[tuple[str, int], list[Any]] = {}
+import threading
 
 
-def cache_dns(domain: str, port: int, addr: str) -> None:
-    _dns_cache[domain, port] = getaddrinfo(addr, port)
+class DNSResolver:
+    """Requester-owned hostname overrides used by the --ip option."""
 
+    def __init__(self) -> None:
+        self._overrides: dict[tuple[str, int], str] = {}
+        self._lock = threading.Lock()
 
-def cached_getaddrinfo(*args: Any, **kwargs: int) -> list[Any]:
-    """
-    Replacement for socket.getaddrinfo, they are the same but this function
-    does cache the answer to improve the performance
-    """
+    @staticmethod
+    def _key(host: str, port: int) -> tuple[str, int]:
+        return host.rstrip(".").casefold(), port
 
-    host, port = args[:2]
-    if (host, port) not in _dns_cache:
-        _dns_cache[host, port] = getaddrinfo(*args, **kwargs)
+    def add_override(self, host: str, port: int, address: str) -> None:
+        with self._lock:
+            self._overrides[self._key(host, port)] = address
 
-    return _dns_cache[host, port]
+    def resolve(self, host: str, port: int) -> str:
+        with self._lock:
+            return self._overrides.get(self._key(host, port), host)

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     SSLCertVerificationError = None
 
-from lib.connection.dns import cached_getaddrinfo
+from lib.connection.dns import DNSResolver
 from lib.connection.proxy import (
     PROXY_AUTHENTICATION_REQUIRED,
     format_proxy_error,
@@ -70,9 +70,6 @@ from lib.utils.mimetype import guess_mimetype
 
 # Disable InsecureRequestWarning from urllib3
 urllib3.disable_warnings(urllib3.exceptions.SecurityWarning)
-# Use custom `socket.getaddrinfo` for `requests` which supports DNS caching
-socket.getaddrinfo = cached_getaddrinfo
-
 _request_target_state = threading.local()
 
 
@@ -85,7 +82,23 @@ def _join_request_target(base_url: str, quoted_path: str) -> str:
 # urllib3 encodes origin-form targets before writing them to the socket. Keep
 # the already-quoted dirsearch target for direct requests so fuzzed characters
 # such as malformed percent escapes and backslashes reach the server unchanged.
-class PathPreservingHTTPConnection(urllib3_connection.HTTPConnection):
+class _ScopedDNSConnection:
+    def __init__(self, *args, dns_resolver: DNSResolver, **kwargs):
+        self._dns_resolver = dns_resolver
+        super().__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        original_host = self._dns_host
+        self._dns_host = self._dns_resolver.resolve(original_host, self.port)
+        try:
+            return super()._new_conn()
+        finally:
+            self._dns_host = original_host
+
+
+class PathPreservingHTTPConnection(
+    _ScopedDNSConnection, urllib3_connection.HTTPConnection
+):
     def request(self, method, url, body=None, headers=None, *args, **kwargs):
         target = getattr(_request_target_state, "target", None)
         if target:
@@ -94,7 +107,9 @@ class PathPreservingHTTPConnection(urllib3_connection.HTTPConnection):
         return super().request(method, url, body, headers, *args, **kwargs)
 
 
-class PathPreservingHTTPSConnection(urllib3_connection.HTTPSConnection):
+class PathPreservingHTTPSConnection(
+    _ScopedDNSConnection, urllib3_connection.HTTPSConnection
+):
     def request(self, method, url, body=None, headers=None, *args, **kwargs):
         target = getattr(_request_target_state, "target", None)
         if target:
@@ -111,18 +126,34 @@ class PathPreservingHTTPSConnectionPool(urllib3_connectionpool.HTTPSConnectionPo
     ConnectionCls = PathPreservingHTTPSConnection
 
 
+class PathPreservingPoolManager(urllib3_poolmanager.PoolManager):
+    def __init__(self, *args, dns_resolver: DNSResolver, **kwargs):
+        self._dns_resolver = dns_resolver
+        super().__init__(*args, **kwargs)
+        self.pool_classes_by_scheme = {
+            "http": PathPreservingHTTPConnectionPool,
+            "https": PathPreservingHTTPSConnectionPool,
+        }
+
+    def _new_pool(self, scheme, host, port, request_context=None):
+        pool = super()._new_pool(scheme, host, port, request_context)
+        pool.conn_kw["dns_resolver"] = self._dns_resolver
+        return pool
+
+
 class PathPreservingSocketOptionsAdapter(SocketOptionsAdapter):
+    def __init__(self, **kwargs):
+        self._dns_resolver = kwargs.pop("dns_resolver")
+        super().__init__(**kwargs)
+
     def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = urllib3_poolmanager.PoolManager(
+        self.poolmanager = PathPreservingPoolManager(
             num_pools=connections,
             maxsize=maxsize,
             block=block,
             socket_options=self.socket_options,
+            dns_resolver=self._dns_resolver,
         )
-        self.poolmanager.pool_classes_by_scheme = {
-            "http": PathPreservingHTTPConnectionPool,
-            "https": PathPreservingHTTPSConnectionPool,
-        }
 
     def request_url(self, request: requests.PreparedRequest, proxies: dict[str, str]) -> str:
         target = getattr(request, "_dirsearch_request_target", None)
@@ -309,6 +340,7 @@ class BaseRequester:
     def __init__(self) -> None:
         self._url: str = ""
         self._query: str = ""
+        self._dns_resolver = DNSResolver()
         self._rate_limiter = RequestRateLimiter()
         self.proxy_cred = options["proxy_auth"]
         self.headers = CaseInsensitiveDict(options["headers"])
@@ -346,6 +378,9 @@ class BaseRequester:
 
     def set_query(self, query: str) -> None:
         self._query = query
+
+    def set_ip(self, host: str, port: int, address: str) -> None:
+        self._dns_resolver.add_override(host, port, address)
 
     def request_path(self, path: str) -> str:
         return append_query_string(path, getattr(self, "_query", ""))
@@ -386,6 +421,7 @@ class Requester(BaseRequester):
                     max_retries=0,
                     pool_maxsize=options["thread_count"],
                     socket_options=self._socket_options,
+                    dns_resolver=self._dns_resolver,
                 ),
             )
 
@@ -527,6 +563,39 @@ class HTTPXBearerAuth(httpx.Auth):
         yield request
 
 
+class ScopedDNSAsyncTransport(httpx.AsyncBaseTransport):
+    def __init__(
+        self,
+        transport: httpx.AsyncBaseTransport,
+        dns_resolver: DNSResolver,
+    ) -> None:
+        self._transport = transport
+        self._dns_resolver = dns_resolver
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        port = request.url.port
+        address = self._dns_resolver.resolve(host, port)
+        if address == host:
+            return await self._transport.handle_async_request(request)
+
+        extensions = dict(request.extensions)
+        if request.url.scheme == "https":
+            extensions["sni_hostname"] = host
+
+        resolved_request = httpx.Request(
+            request.method,
+            request.url.copy_with(host=address),
+            headers=request.headers.raw,
+            stream=request.stream,
+            extensions=extensions,
+        )
+        return await self._transport.handle_async_request(resolved_request)
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
 class ProxyRoatingTransport(httpx.AsyncBaseTransport):
     def __init__(self, proxies: list[str], **kwargs: Any) -> None:
         self._transports = [
@@ -556,7 +625,10 @@ class AsyncRequester(BaseRequester):
                 [self.parse_proxy(p) for p in options["proxies"]], **tpargs
             )
             if options["proxies"]
-            else httpx.AsyncHTTPTransport(**tpargs)
+            else ScopedDNSAsyncTransport(
+                httpx.AsyncHTTPTransport(**tpargs),
+                self._dns_resolver,
+            )
         )
 
         self.session = httpx.AsyncClient(

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -31,7 +31,6 @@ from typing import Any
 
 from urllib.parse import urlparse
 
-from lib.connection.dns import cache_dns
 from lib.connection.response import BaseResponse
 from lib.core.data import blacklists, options
 from lib.core.decorators import locked
@@ -576,21 +575,29 @@ class Controller:
         elif not 0 < port < 65536:
             raise InvalidURLException(f"Invalid port number: {port}")
 
-        if options["ip"]:
-            cache_dns(parsed.hostname, port, options["ip"])
-
         try:
             # If no scheme is found, detect it by port number
             scheme = (
                 parsed.scheme
                 if parsed.scheme != UNKNOWN
-                else detect_scheme(parsed.hostname, port)
+                else detect_scheme(
+                    parsed.hostname,
+                    port,
+                    connect_host=options["ip"],
+                )
             )
         except ValueError:
             # If the user neither provides the port nor scheme, guess them based
             # on standard website characteristics
-            scheme = detect_scheme(parsed.hostname, 443)
+            scheme = detect_scheme(
+                parsed.hostname,
+                443,
+                connect_host=options["ip"],
+            )
             port = STANDARD_PORTS[scheme]
+
+        if options["ip"]:
+            self.requester.set_ip(parsed.hostname, port, options["ip"])
 
         self.url = f"{scheme}://{parsed.hostname}"
 

--- a/lib/utils/schemedet.py
+++ b/lib/utils/schemedet.py
@@ -22,7 +22,7 @@ import socket
 from lib.core.settings import SOCKET_TIMEOUT
 
 
-def detect_scheme(host, port):
+def detect_scheme(host, port, connect_host=None):
     if not port:
         raise ValueError
 
@@ -31,7 +31,7 @@ def detect_scheme(host, port):
     conn = ssl.create_default_context().wrap_socket(s, server_hostname=host)
 
     try:
-        conn.connect((host, port))
+        conn.connect((connect_host or host, port))
         return "https"
     except OSError:
         return "http"

--- a/tests/connection/proxy_server.py
+++ b/tests/connection/proxy_server.py
@@ -34,7 +34,9 @@ class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     def __init__(self, server_address, handler_class):
         super().__init__(server_address, handler_class)
         self._events = []
+        self._host_headers = []
         self._proxy_authorizations = []
+        self._server_names = []
         self._events_lock = threading.Lock()
         self._proxy_behavior = "forward"
         self._required_proxy_authorization = None
@@ -48,10 +50,20 @@ class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
         with self._events_lock:
             self._proxy_authorizations.append(authorization)
 
+    def record_host_header(self, host: str | None) -> None:
+        with self._events_lock:
+            self._host_headers.append(host)
+
+    def record_server_name(self, server_name: str | None) -> None:
+        with self._events_lock:
+            self._server_names.append(server_name)
+
     def clear_events(self) -> None:
         with self._events_lock:
             self._events.clear()
+            self._host_headers.clear()
             self._proxy_authorizations.clear()
+            self._server_names.clear()
 
     @property
     def events(self) -> list[tuple[str, str]]:
@@ -62,6 +74,16 @@ class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     def proxy_authorizations(self) -> list[str | None]:
         with self._events_lock:
             return list(self._proxy_authorizations)
+
+    @property
+    def host_headers(self) -> list[str | None]:
+        with self._events_lock:
+            return list(self._host_headers)
+
+    @property
+    def server_names(self) -> list[str | None]:
+        with self._events_lock:
+            return list(self._server_names)
 
     def configure_proxy(
         self,
@@ -102,6 +124,7 @@ class RecordingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
 class TargetHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.server.record("GET", self.path)
+        self.server.record_host_header(self.headers.get("Host"))
         self.server.record_proxy_authorization(
             self.headers.get("Proxy-Authorization")
         )
@@ -297,6 +320,11 @@ class LocalHTTPServer:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             context.minimum_version = ssl.TLSVersion.TLSv1_2
             context.load_cert_chain(certificate, private_key)
+            context.set_servername_callback(
+                lambda _socket, server_name, _context: self.server.record_server_name(
+                    server_name
+                )
+            )
             self.server.socket = context.wrap_socket(
                 self.server.socket,
                 server_side=True,
@@ -325,6 +353,14 @@ class LocalHTTPServer:
     @property
     def proxy_authorizations(self) -> list[str | None]:
         return self.server.proxy_authorizations
+
+    @property
+    def host_headers(self) -> list[str | None]:
+        return self.server.host_headers
+
+    @property
+    def server_names(self) -> list[str | None]:
+        return self.server.server_names
 
     def clear_events(self) -> None:
         self.server.clear_events()

--- a/tests/connection/test_dns.py
+++ b/tests/connection/test_dns.py
@@ -19,7 +19,9 @@
 import asyncio
 import subprocess
 import sys
+import threading
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from unittest import TestCase
 from urllib.parse import urlsplit
 
@@ -59,6 +61,28 @@ class TestDNSIsolation(TestCase):
         self.assertEqual(first.resolve(FORCED_HOST, 443), "192.0.2.10")
         self.assertEqual(first.resolve(FORCED_HOST, 80), FORCED_HOST)
         self.assertEqual(second.resolve(FORCED_HOST, 443), FORCED_HOST)
+
+    def test_resolve_does_not_serialize_connection_workers(self):
+        barrier = threading.Barrier(2)
+
+        class ConcurrentReadMapping(dict):
+            def get(self, key, default=None):
+                barrier.wait(timeout=2)
+                return super().get(key, default)
+
+        resolver = DNSResolver()
+        resolver.add_override(FORCED_HOST, 443, "192.0.2.10")
+        resolver._overrides = ConcurrentReadMapping(resolver._overrides)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(
+                executor.map(
+                    lambda _: resolver.resolve(FORCED_HOST, 443),
+                    range(2),
+                )
+            )
+
+        self.assertEqual(results, ["192.0.2.10", "192.0.2.10"])
 
 
 class TestDNSOverrideIntegration(TestCase):

--- a/tests/connection/test_dns.py
+++ b/tests/connection/test_dns.py
@@ -16,18 +16,142 @@
 #
 #  Author: Mauro Soria
 
+import asyncio
+import subprocess
+import sys
+import warnings
 from unittest import TestCase
-from socket import getaddrinfo
+from urllib.parse import urlsplit
 
-from lib.connection.dns import cache_dns, cached_getaddrinfo
-from lib.core.settings import DUMMY_DOMAIN
+from urllib3.exceptions import InsecureRequestWarning
+
+from lib.connection.dns import DNSResolver
+from lib.connection.requester import AsyncRequester, Requester
+from lib.core.data import options
+from tests.connection.proxy_server import ProxyTestStack
 
 
-class TestDNS(TestCase):
-    def test_cache_dns(self):
-        cache_dns(DUMMY_DOMAIN, 80, "127.0.0.1")
-        self.assertEqual(
-            cached_getaddrinfo(DUMMY_DOMAIN, 80),
-            getaddrinfo("127.0.0.1", 80),
-            "Adding DNS cache doesn't work",
+FORCED_HOST = "forced-origin.invalid"
+
+
+class TestDNSIsolation(TestCase):
+    def test_importing_requester_does_not_replace_socket_getaddrinfo(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import socket; original = socket.getaddrinfo; "
+                "import lib.connection.requester; "
+                "raise SystemExit(socket.getaddrinfo is not original)",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
         )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_overrides_are_isolated_by_requester_and_port(self):
+        first = DNSResolver()
+        second = DNSResolver()
+        first.add_override(FORCED_HOST, 443, "192.0.2.10")
+
+        self.assertEqual(first.resolve(FORCED_HOST, 443), "192.0.2.10")
+        self.assertEqual(first.resolve(FORCED_HOST, 80), FORCED_HOST)
+        self.assertEqual(second.resolve(FORCED_HOST, 443), FORCED_HOST)
+
+
+class TestDNSOverrideIntegration(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stack_context = ProxyTestStack()
+        cls.stack = cls.stack_context.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.stack_context.__exit__(None, None, None)
+
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "proxies": [],
+                "headers": {},
+                "data": None,
+                "cert_file": None,
+                "key_file": None,
+                "network_interface": None,
+                "random_agents": False,
+                "auth": None,
+                "auth_type": None,
+                "max_retries": 0,
+                "max_rate": 0,
+                "thread_count": 2,
+                "follow_redirects": False,
+                "http_method": "GET",
+                "timeout": 3,
+                "proxy_auth": None,
+            }
+        )
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    @staticmethod
+    def forced_url(target):
+        parsed = urlsplit(target.url)
+        return f"{parsed.scheme}://{FORCED_HOST}:{parsed.port}/"
+
+    def test_sync_requester_scopes_ip_override_to_its_own_connections(self):
+        for target in self.stack.targets:
+            with self.subTest(scheme=target.scheme):
+                target.clear_events()
+                requester = Requester()
+                requester.set_ip(FORCED_HOST, urlsplit(target.url).port, "127.0.0.1")
+                requester.set_url(self.forced_url(target))
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", InsecureRequestWarning)
+                        response = requester.request("sync-ip-override")
+                finally:
+                    requester.close()
+
+                self.assertEqual(response.status, 200)
+                self.assertEqual(
+                    target.events,
+                    [("GET", "/sync-ip-override")],
+                )
+                self.assertEqual(
+                    target.host_headers,
+                    [f"{FORCED_HOST}:{urlsplit(target.url).port}"],
+                )
+                if target.scheme == "https":
+                    self.assertEqual(target.server_names, [FORCED_HOST])
+
+    def test_async_requester_scopes_ip_override_to_its_own_connections(self):
+        asyncio.run(self._test_async_requester_ip_override())
+
+    async def _test_async_requester_ip_override(self):
+        for target in self.stack.targets:
+            with self.subTest(scheme=target.scheme):
+                target.clear_events()
+                requester = AsyncRequester()
+                requester.set_ip(FORCED_HOST, urlsplit(target.url).port, "127.0.0.1")
+                requester.set_url(self.forced_url(target))
+                try:
+                    response = await requester.request("async-ip-override")
+                finally:
+                    await requester.close()
+
+                self.assertEqual(response.status, 200)
+                self.assertEqual(
+                    target.events,
+                    [("GET", "/async-ip-override")],
+                )
+                self.assertEqual(
+                    target.host_headers,
+                    [f"{FORCED_HOST}:{urlsplit(target.url).port}"],
+                )
+                if target.scheme == "https":
+                    self.assertEqual(target.server_names, [FORCED_HOST])

--- a/tests/controller/test_target_dns.py
+++ b/tests/controller/test_target_dns.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Author: Mauro Soria
+
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+
+
+class TestControllerTargetDNS(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "request_backend": "python",
+                "scheme": None,
+                "ip": "192.0.2.10",
+            }
+        )
+        self.controller = object.__new__(Controller)
+        self.controller.requester = Mock()
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_ip_override_uses_detected_default_port(self):
+        with patch(
+            "lib.controller.controller.detect_scheme",
+            side_effect=(ValueError, "https"),
+        ) as detect_scheme:
+            self.controller.set_target("forced-origin.invalid")
+
+        self.assertEqual(
+            detect_scheme.call_args_list,
+            [
+                call(
+                    "forced-origin.invalid",
+                    None,
+                    connect_host="192.0.2.10",
+                ),
+                call(
+                    "forced-origin.invalid",
+                    443,
+                    connect_host="192.0.2.10",
+                ),
+            ],
+        )
+        self.controller.requester.set_ip.assert_called_once_with(
+            "forced-origin.invalid",
+            443,
+            "192.0.2.10",
+        )
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://forced-origin.invalid/"
+        )

--- a/tests/utils/test_schemedet.py
+++ b/tests/utils/test_schemedet.py
@@ -23,7 +23,7 @@ from lib.utils.schemedet import detect_scheme
 
 
 class TestSchemedet(TestCase):
-    def run_probe(self, connect_error=None):
+    def run_probe(self, connect_error=None, connect_host=None):
         raw_socket = Mock()
         connection = Mock()
         connection.connect.side_effect = connect_error
@@ -35,7 +35,7 @@ class TestSchemedet(TestCase):
         ) as socket_factory, patch(
             "lib.utils.schemedet.ssl.create_default_context", return_value=context
         ) as context_factory:
-            scheme = detect_scheme("example.test", 443)
+            scheme = detect_scheme("example.test", 443, connect_host=connect_host)
 
         socket_factory.assert_called_once_with()
         raw_socket.settimeout.assert_called_once_with(SOCKET_TIMEOUT)
@@ -43,7 +43,9 @@ class TestSchemedet(TestCase):
         context.wrap_socket.assert_called_once_with(
             raw_socket, server_hostname="example.test"
         )
-        connection.connect.assert_called_once_with(("example.test", 443))
+        connection.connect.assert_called_once_with(
+            ((connect_host or "example.test"), 443)
+        )
         connection.close.assert_called_once_with()
 
         return scheme
@@ -53,3 +55,6 @@ class TestSchemedet(TestCase):
 
     def test_falls_back_to_http_when_tls_connection_fails(self):
         self.assertEqual(self.run_probe(OSError("network unavailable")), "http")
+
+    def test_connects_to_explicit_address_without_changing_tls_hostname(self):
+        self.assertEqual(self.run_probe(connect_host="192.0.2.10"), "https")


### PR DESCRIPTION
## Summary

- remove the import-time replacement of process-wide `socket.getaddrinfo`
- replace the unbounded, incomplete DNS cache with requester-owned `--ip` overrides
- keep override reads lock-free for threaded connection workers
- preserve the original Host header and TLS SNI while connecting to the selected address
- route scheme detection through the selected address and apply the detected default port

Normal DNS resolution is now delegated to the HTTP libraries and operating system instead of being cached globally with a host/port-only key. The controller installs overrides between targets before request workers start, so workers only perform an unsynchronized dictionary read.

## Regression coverage

- importing the requester leaves `socket.getaddrinfo` unchanged
- overrides are isolated by requester and port
- two connection workers can resolve concurrently without serialization
- threaded and async engines reach forced HTTP and HTTPS targets
- HTTP Host and HTTPS SNI remain the requested hostname
- scheme detection connects to the override without changing TLS hostname
- controller wiring stores the override under the final detected port

## Validation

- Python 3.12: 260 tests passed, 17 native-only tests skipped
- Python 3.14 with native extension: 260 tests passed
- focused resolver concurrency regression repeated 50 times
- focused requester, DNS, scheme-detection, and controller suites: 41 passed, 4 skipped
- flake8, codespell, compileall, and `git diff --check`
