### PR TITLE
Make pause and native wordlists signal-safe

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -58,6 +58,8 @@ from lib.core.settings import (
     EXTENSION_RECOGNITION_REGEX,
     MAX_CONSECUTIVE_REQUEST_ERRORS,
     NEW_LINE,
+    PAUSE_POLL_INTERVAL,
+    PAUSE_TIMEOUT_SECONDS,
     SIGINT_FORCE_QUIT_THRESHOLD,
     SIGINT_WINDOW_SECONDS,
     STANDARD_PORTS,
@@ -170,6 +172,7 @@ def format_session_path(path: str) -> str:
 class Controller:
     def __init__(self) -> None:
         self._handling_pause = False
+        self._pause_requested = False
         self._force_quit_handler = _create_force_quit_handler()
         self.loop = None  # Will be set if async mode is used
         self.response_stores = ()
@@ -396,8 +399,8 @@ class Controller:
         if options["async_mode"]:
             self.loop = asyncio.new_event_loop()
 
-        signal.signal(signal.SIGINT, lambda *_: self.handle_pause())
-        signal.signal(signal.SIGTERM, lambda *_: self.handle_pause())
+        signal.signal(signal.SIGINT, self.request_pause)
+        signal.signal(signal.SIGTERM, self.request_pause)
 
         while options["urls"]:
             url = options["urls"][0]
@@ -485,6 +488,10 @@ class Controller:
                 pass
 
             finally:
+                if not options["async_mode"]:
+                    self.fuzzer.quit()
+                    if not self.fuzzer.wait(timeout=PAUSE_TIMEOUT_SECONDS):
+                        raise QuitInterrupt("Could not stop scan workers safely")
                 self.dictionary.reset()
                 self.directories.pop(0)
 
@@ -523,15 +530,33 @@ class Controller:
 
         task = self.loop.create_task(self.fuzzer.start())
 
+        async def wait_for_pause_request() -> None:
+            while not getattr(self, "_pause_requested", False):
+                await asyncio.sleep(PAUSE_POLL_INTERVAL)
+
+        async def wait_for_completion() -> None:
+            pause_task = self.loop.create_task(wait_for_pause_request())
+            try:
+                while True:
+                    done, _ = await asyncio.wait(
+                        [self.pause_future, task, pause_task],
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if pause_task in done:
+                        self.handle_pause()
+                        if self.pause_future.done():
+                            return
+                        pause_task = self.loop.create_task(wait_for_pause_request())
+                        continue
+                    return
+            finally:
+                if not pause_task.done():
+                    pause_task.cancel()
+                await asyncio.gather(pause_task, return_exceptions=True)
+
         try:
             try:
-                await asyncio.wait_for(
-                    asyncio.wait(
-                        [self.pause_future, task],
-                        return_when=asyncio.FIRST_COMPLETED,
-                    ),
-                    timeout=timeout,
-                )
+                await asyncio.wait_for(wait_for_completion(), timeout=timeout)
             except asyncio.TimeoutError:
                 if timeout_error is None:
                     raise
@@ -549,20 +574,22 @@ class Controller:
 
     def process(self, start_time: float) -> None:
         while True:
-            while not self.fuzzer.is_finished():
-                now = time.time()
-                if now - self.start_time > options["max_time"] > 0:
-                    raise QuitInterrupt(
-                        "Runtime exceeded the maximum set by the user"
-                    )
-                if now - start_time > options["target_max_time"] > 0:
-                    raise SkipTargetInterrupt(
-                        "Runtime for target exceeded the maximum set by the user"
-                    )
+            if self._pause_requested:
+                self.handle_pause()
+            if self.fuzzer.is_finished():
+                return
 
-                time.sleep(0.5)
+            now = time.time()
+            if now - self.start_time > options["max_time"] > 0:
+                raise QuitInterrupt(
+                    "Runtime exceeded the maximum set by the user"
+                )
+            if now - start_time > options["target_max_time"] > 0:
+                raise SkipTargetInterrupt(
+                    "Runtime for target exceeded the maximum set by the user"
+                )
 
-            break
+            time.sleep(PAUSE_POLL_INTERVAL)
 
     def set_target(self, url: str) -> None:
         if options["request_backend"] == "native":
@@ -777,14 +804,29 @@ class Controller:
                 pass
         os._exit(1)
 
-    def handle_pause(self) -> None:
-        """Handle SIGINT (Ctrl+C) by pausing execution and showing options."""
-        if self._handling_pause:
+    def _stop_fuzzer(self) -> bool:
+        self.fuzzer.quit()
+        if options["async_mode"]:
+            return True
+        return self.fuzzer.wait(timeout=PAUSE_TIMEOUT_SECONDS)
+
+    def _finish_pause(self) -> None:
+        self._pause_requested = False
+        self._handling_pause = False
+        self._force_quit_handler.on_resume()
+
+    def request_pause(self, *_: object) -> None:
+        """Record a signal request without touching fuzzer or session state."""
+        if self._pause_requested or self._handling_pause:
             self._force_quit_handler.check_force_quit()
             return
 
-        self._handling_pause = True
+        self._pause_requested = True
         self._force_quit_handler.on_pause_start()
+
+    def handle_pause(self) -> None:
+        """Pause execution and show options from a safe orchestration point."""
+        self._handling_pause = True
 
         try:
             try:
@@ -830,6 +872,7 @@ class Controller:
                         session_file = format_session_path(input() or default_session_path)
 
                         self._export(session_file)
+                        self._stop_fuzzer()
                         quitexc = QuitInterrupt(f"Session saved to: {session_file}")
                         if options["async_mode"]:
                             self.pause_future.set_exception(quitexc)
@@ -837,6 +880,7 @@ class Controller:
                         else:
                             raise quitexc
                     elif option.lower() == "q":
+                        self._stop_fuzzer()
                         quitexc = QuitInterrupt("Canceled by the user")
                         if options["async_mode"]:
                             self.pause_future.set_exception(quitexc)
@@ -845,16 +889,18 @@ class Controller:
                             raise quitexc
 
                 elif option.lower() == "c":
-                    self._handling_pause = False
-                    self._force_quit_handler.on_resume()
+                    self._finish_pause()
                     self.fuzzer.play()
                     break
 
                 elif option.lower() == "n" and len(self.directories) > 1:
-                    self.fuzzer.quit()
+                    self._finish_pause()
+                    self._stop_fuzzer()
                     break
 
                 elif option.lower() == "s" and len(options["urls"]) > 1:
+                    self._finish_pause()
+                    self._stop_fuzzer()
                     skipexc = SkipTargetInterrupt("Target skipped by the user")
                     if options["async_mode"]:
                         self.pause_future.set_exception(skipexc)

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -94,6 +94,15 @@ class Dictionary:
         with self._lock:
             self._claimed.remove(path)
 
+    def requeue_claims(self) -> None:
+        """Move outstanding claims back to the front of the pending queue."""
+        with self._lock:
+            if not self._claimed:
+                return
+
+            self._extra[self._extra_index:self._extra_index] = self._claimed
+            self._claimed.clear()
+
     def __contains__(self, item: str) -> bool:
         return item in self._items
 

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -37,6 +37,8 @@ from lib.core.scanner import AsyncScanner, BaseScanner, Scanner
 from lib.core.settings import (
     DEFAULT_TEST_PREFIXES,
     DEFAULT_TEST_SUFFIXES,
+    PAUSE_POLL_INTERVAL,
+    PAUSE_TIMEOUT_SECONDS,
     WILDCARD_TEST_POINT_MARKER,
 )
 from lib.parse.url import clean_path
@@ -348,7 +350,9 @@ class Fuzzer(BaseFuzzer):
         self._threads = []
         self._play_event = threading.Event()
         self._quit_event = threading.Event()
-        self._pause_semaphore = threading.Semaphore(0)
+        self._pause_condition = threading.Condition(threading.Lock())
+        self._pause_generation = 0
+        self._paused_workers: dict[int, int] = {}
 
     def setup_scanners(self) -> None:
         # Default scanners (wildcard testers)
@@ -389,6 +393,9 @@ class Fuzzer(BaseFuzzer):
     def setup_threads(self) -> None:
         if self._threads:
             self._threads = []
+        with self._pause_condition:
+            self._pause_generation = 0
+            self._paused_workers.clear()
 
         for _ in range(options["thread_count"]):
             new_thread = threading.Thread(target=self.thread_proc)
@@ -400,6 +407,7 @@ class Fuzzer(BaseFuzzer):
         self.setup_threads()
         self.play()
         self._quit_event.clear()
+        self._exc = None
 
         for thread in self._threads:
             thread.start()
@@ -422,18 +430,45 @@ class Fuzzer(BaseFuzzer):
 
         Returns True if all threads paused successfully, False if timeout occurred.
         """
-        self._play_event.clear()
-        # Wait for all threads to stop (with timeout to avoid deadlock)
-        for thread in self._threads:
-            if thread.is_alive():
-                # Use timeout to prevent deadlock when threads are blocked on I/O
-                if not self._pause_semaphore.acquire(timeout=2):
+        deadline = time.monotonic() + PAUSE_TIMEOUT_SECONDS
+        with self._pause_condition:
+            self._pause_generation += 1
+            generation = self._pause_generation
+            self._play_event.clear()
+
+            while True:
+                alive_workers = {
+                    thread.ident for thread in self._threads if thread.is_alive()
+                }
+                if all(
+                    self._paused_workers.get(worker) == generation
+                    for worker in alive_workers
+                ):
+                    return True
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
                     return False
-        return True
+                self._pause_condition.wait(
+                    timeout=min(remaining, PAUSE_POLL_INTERVAL)
+                )
 
     def quit(self) -> None:
         self._quit_event.set()
         self.play()
+
+    def wait(self, timeout: float = PAUSE_TIMEOUT_SECONDS) -> bool:
+        deadline = time.monotonic() + timeout
+        for thread in self._threads:
+            thread.join(timeout=max(0, deadline - time.monotonic()))
+        return all(not thread.is_alive() for thread in self._threads)
+
+    def _wait_if_paused(self) -> None:
+        while not self._play_event.is_set():
+            with self._pause_condition:
+                self._paused_workers[threading.get_ident()] = self._pause_generation
+                self._pause_condition.notify_all()
+            self._play_event.wait()
 
     def scan(self, path: str) -> None:
         try:
@@ -449,9 +484,10 @@ class Fuzzer(BaseFuzzer):
         logger.info(f'THREAD-{threading.get_ident()} started"')
 
         while True:
+            path = None
             should_quit = False
             try:
-                path = next(self._dictionary)
+                path = self._dictionary.claim_next()
                 self.scan(self._base_path + path)
 
             except StopIteration:
@@ -461,12 +497,13 @@ class Fuzzer(BaseFuzzer):
                 self._exc = e
 
             finally:
+                if path is not None:
+                    self._dictionary.release_claim(path)
                 time.sleep(options["delay"])
 
                 if not self._play_event.is_set():
                     logger.info(f'THREAD-{threading.get_ident()} paused"')
-                    self._pause_semaphore.release()
-                    self._play_event.wait()
+                    self._wait_if_paused()
                     logger.info(f'THREAD-{threading.get_ident()} continued"')
 
                 if self._quit_event.is_set():
@@ -493,28 +530,41 @@ class NativeFuzzer(Fuzzer):
             not_found_callbacks=not_found_callbacks,
             error_callbacks=error_callbacks,
         )
-        self._finished = False
         self._native_backend: NativeHTTPBackend | None = None
+        self._paused_event = threading.Event()
 
     def start(self) -> None:
         self._native_backend = self._native_backend or NativeHTTPBackend()
         self.setup_scanners()
         self.play()
         self._quit_event.clear()
-        self._finished = False
+        self._exc = None
+        self._paused_event.clear()
+        self._threads = [threading.Thread(target=self._run_native, daemon=True)]
+        self._threads[0].start()
 
+    def _run_native(self) -> None:
         try:
             while not self._quit_event.is_set():
+                if not self._play_event.is_set():
+                    self._dictionary.requeue_claims()
+                    self._paused_event.set()
+                    self._play_event.wait()
+                    self._paused_event.clear()
+                    continue
+
                 paths = self._next_chunk()
                 if not paths:
                     break
+                if not self._play_event.is_set():
+                    continue
 
                 for path, response, error in self._native_backend.scan(
                     self._requester._url,
                     paths,
                     getattr(self._requester, "_query", ""),
                 ):
-                    if self._quit_event.is_set():
+                    if self._quit_event.is_set() or not self._play_event.is_set():
                         break
                     try:
                         if error is not None:
@@ -529,8 +579,12 @@ class NativeFuzzer(Fuzzer):
                     finally:
                         dictionary_path = lstrip_once(path, self._base_path)
                         self._dictionary.release_claim(dictionary_path)
+        except Exception as error:
+            self._exc = error
         finally:
-            self._finished = True
+            if not self._quit_event.is_set() and not self._play_event.is_set():
+                self._dictionary.requeue_claims()
+            self._paused_event.set()
 
     def _next_chunk(self) -> list[str]:
         chunk_size = max(1000, options["thread_count"] * 100)
@@ -542,8 +596,17 @@ class NativeFuzzer(Fuzzer):
                 break
         return paths
 
-    def is_finished(self) -> bool:
-        return self._finished
+    def pause(self) -> bool:
+        self._play_event.clear()
+        if self._native_backend is not None:
+            self._native_backend.cancel()
+        if self.is_finished():
+            return True
+        return self._paused_event.wait(timeout=PAUSE_TIMEOUT_SECONDS)
+
+    def play(self) -> None:
+        self._paused_event.clear()
+        super().play()
 
     def quit(self) -> None:
         super().quit()

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -192,6 +192,9 @@ SIGINT_WINDOW_SECONDS = 0.8
 # Number of rapid Ctrl+C presses required to force quit
 SIGINT_FORCE_QUIT_THRESHOLD = 3
 
+PAUSE_POLL_INTERVAL = 0.05
+PAUSE_TIMEOUT_SECONDS = 2.0
+
 URL_SAFE_CHARS = string.punctuation
 
 TEXT_CHARS = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,15 +6,18 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 use regex::{Regex, RegexBuilder};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use std::fs;
+use std::fs::File;
 #[cfg(test)]
 use std::io::Cursor;
+use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
 use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
 
 const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const WORDLIST_READ_CHUNK_SIZE: usize = 64 * 1024;
 
 #[pyclass]
 struct NativeHttpResult {
@@ -54,6 +57,21 @@ type NumericRange = (usize, usize);
 type TimeFilter = (String, f64);
 type HeaderPairs = Vec<(String, String)>;
 type RawHttpResponse = raw_http::Response;
+
+struct NativeWordlistConfig {
+    files: Vec<String>,
+    extensions: Vec<String>,
+    force_extensions: bool,
+    prefixes: Vec<String>,
+    suffixes: Vec<String>,
+    exclude_extensions: Vec<String>,
+    overwrite_exclude_extensions: Vec<String>,
+    lowercase: bool,
+    uppercase: bool,
+    capitalization: bool,
+    overwrite_extensions: bool,
+    max_size: Option<usize>,
+}
 
 struct RawHttpRequest<'a> {
     base_url: &'a str,
@@ -386,6 +404,7 @@ fn line_count(text: Option<&str>) -> usize {
     max_size=None,
 ))]
 fn generate_wordlist(
+    py: Python<'_>,
     files: Vec<String>,
     extensions: Vec<String>,
     force_extensions: bool,
@@ -399,58 +418,119 @@ fn generate_wordlist(
     overwrite_extensions: bool,
     max_size: Option<usize>,
 ) -> PyResult<Vec<String>> {
-    let file_lines: Vec<Vec<String>> = files
+    let config = NativeWordlistConfig {
+        files,
+        extensions,
+        force_extensions,
+        prefixes,
+        suffixes,
+        exclude_extensions,
+        overwrite_exclude_extensions,
+        lowercase,
+        uppercase,
+        capitalization,
+        overwrite_extensions,
+        max_size,
+    };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = cancelled.clone();
+
+    py.allow_threads(move || {
+        let worker = thread::spawn(move || generate_wordlist_inner(config, &worker_cancelled));
+        let mut signal_error = None;
+
+        while !worker.is_finished() {
+            if let Err(error) = Python::with_gil(|py| py.check_signals()) {
+                cancelled.store(true, Ordering::Release);
+                signal_error = Some(error);
+                break;
+            }
+            thread::sleep(SIGNAL_POLL_INTERVAL);
+        }
+
+        let result = worker
+            .join()
+            .map_err(|_| PyRuntimeError::new_err("Native wordlist worker panicked"))?;
+        if let Some(error) = signal_error {
+            return Err(error);
+        }
+        Python::with_gil(|py| py.check_signals())?;
+        result.map_err(PyRuntimeError::new_err)
+    })
+}
+
+fn generate_wordlist_inner(
+    config: NativeWordlistConfig,
+    cancelled: &AtomicBool,
+) -> Result<Vec<String>, String> {
+    let file_lines: Vec<Vec<String>> = config
+        .files
         .par_iter()
-        .map(|path| read_lines(path))
+        .map(|path| read_lines(path, cancelled))
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut wordlist = IndexSet::new();
     for lines in file_lines {
         for raw_line in lines {
+            check_wordlist_cancelled(cancelled)?;
             let line = lstrip_once(&raw_line, "/");
-            for expanded in expand_ext(&line, &extensions) {
-                if !is_valid(&expanded, &exclude_extensions) {
+            for expanded in expand_ext(&line, &config.extensions) {
+                check_wordlist_cancelled(cancelled)?;
+                if !is_valid(&expanded, &config.exclude_extensions) {
                     continue;
                 }
 
-                add_entry(&mut wordlist, expanded.clone(), max_size)?;
+                add_entry(&mut wordlist, expanded.clone(), config.max_size)?;
 
-                if force_extensions && !expanded.contains('.') && !expanded.ends_with('/') {
-                    add_entry(&mut wordlist, format!("{expanded}/"), max_size)?;
-                    for extension in &extensions {
-                        add_entry(&mut wordlist, format!("{expanded}.{extension}"), max_size)?;
+                if config.force_extensions && !expanded.contains('.') && !expanded.ends_with('/') {
+                    add_entry(&mut wordlist, format!("{expanded}/"), config.max_size)?;
+                    for extension in &config.extensions {
+                        check_wordlist_cancelled(cancelled)?;
+                        add_entry(
+                            &mut wordlist,
+                            format!("{expanded}.{extension}"),
+                            config.max_size,
+                        )?;
                     }
-                } else if overwrite_extensions
+                } else if config.overwrite_extensions
                     && should_overwrite_extension(
                         &expanded,
-                        &extensions,
-                        &overwrite_exclude_extensions,
+                        &config.extensions,
+                        &config.overwrite_exclude_extensions,
                     )
                 {
                     let base = expanded.split('.').next().unwrap_or_default();
-                    for extension in &extensions {
-                        add_entry(&mut wordlist, format!("{base}.{extension}"), max_size)?;
+                    for extension in &config.extensions {
+                        check_wordlist_cancelled(cancelled)?;
+                        add_entry(
+                            &mut wordlist,
+                            format!("{base}.{extension}"),
+                            config.max_size,
+                        )?;
                     }
                 }
             }
         }
     }
 
-    if !prefixes.is_empty() || !suffixes.is_empty() {
+    if !config.prefixes.is_empty() || !config.suffixes.is_empty() {
         let mut altered = IndexSet::new();
         for path in &wordlist {
-            for prefix in &prefixes {
+            check_wordlist_cancelled(cancelled)?;
+            for prefix in &config.prefixes {
+                check_wordlist_cancelled(cancelled)?;
                 if !path.starts_with('/') && !path.starts_with(prefix) {
-                    add_entry(&mut altered, format!("{prefix}{path}"), max_size)?;
+                    add_entry(&mut altered, format!("{prefix}{path}"), config.max_size)?;
                 }
             }
-            for suffix in &suffixes {
+            for suffix in &config.suffixes {
+                check_wordlist_cancelled(cancelled)?;
                 if !path.ends_with('/')
                     && !path.ends_with(suffix)
                     && !path.contains('?')
                     && !path.contains('#')
                 {
-                    add_entry(&mut altered, format!("{path}{suffix}"), max_size)?;
+                    add_entry(&mut altered, format!("{path}{suffix}"), config.max_size)?;
                 }
             }
         }
@@ -459,10 +539,16 @@ fn generate_wordlist(
         }
     }
 
-    let items = wordlist
-        .into_iter()
-        .map(|path| apply_case(path, lowercase, uppercase, capitalization))
-        .collect();
+    let mut items = Vec::with_capacity(wordlist.len());
+    for path in wordlist {
+        check_wordlist_cancelled(cancelled)?;
+        items.push(apply_case(
+            path,
+            config.lowercase,
+            config.uppercase,
+            config.capitalization,
+        ));
+    }
     Ok(items)
 }
 
@@ -1208,8 +1294,25 @@ fn parse_raw_http_response(
     raw_http::parse_response(Cursor::new(raw_response), max_body_size)
 }
 
-fn read_lines(path: &str) -> PyResult<Vec<String>> {
-    let content = fs::read(path).map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+fn check_wordlist_cancelled(cancelled: &AtomicBool) -> Result<(), String> {
+    if cancelled.load(Ordering::Acquire) {
+        return Err("Native wordlist generation cancelled".to_string());
+    }
+    Ok(())
+}
+
+fn read_lines(path: &str, cancelled: &AtomicBool) -> Result<Vec<String>, String> {
+    let mut file = File::open(path).map_err(|error| error.to_string())?;
+    let mut content = Vec::new();
+    let mut chunk = [0_u8; WORDLIST_READ_CHUNK_SIZE];
+    loop {
+        check_wordlist_cancelled(cancelled)?;
+        let count = file.read(&mut chunk).map_err(|error| error.to_string())?;
+        if count == 0 {
+            break;
+        }
+        content.extend_from_slice(&chunk[..count]);
+    }
     let content = String::from_utf8_lossy(&content);
     Ok(content.lines().map(str::to_string).collect())
 }
@@ -1305,13 +1408,13 @@ fn add_entry(
     wordlist: &mut IndexSet<String>,
     path: String,
     max_size: Option<usize>,
-) -> PyResult<()> {
+) -> Result<(), String> {
     wordlist.insert(path);
     if let Some(limit) = max_size {
         if wordlist.len() > limit {
-            return Err(PyRuntimeError::new_err(format!(
+            return Err(format!(
                 "Generated wordlist exceeded --wordlist-max-size ({limit})"
-            )));
+            ));
         }
     }
     Ok(())
@@ -1370,6 +1473,42 @@ mod tests {
 
     fn content_length(value: usize) -> Vec<(String, String)> {
         vec![("Content-Length".to_string(), value.to_string())]
+    }
+
+    #[test]
+    fn native_wordlist_generation_honors_cancellation() {
+        let path = std::env::temp_dir().join(format!(
+            "dirsearch-native-wordlist-{}-{}.txt",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "admin").unwrap();
+        drop(file);
+
+        let config = NativeWordlistConfig {
+            files: vec![path.to_string_lossy().into_owned()],
+            extensions: Vec::new(),
+            force_extensions: false,
+            prefixes: Vec::new(),
+            suffixes: Vec::new(),
+            exclude_extensions: Vec::new(),
+            overwrite_exclude_extensions: Vec::new(),
+            lowercase: false,
+            uppercase: false,
+            capitalization: false,
+            overwrite_extensions: false,
+            max_size: None,
+        };
+        let cancelled = AtomicBool::new(true);
+
+        let result = generate_wordlist_inner(config, &cancelled);
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(result.unwrap_err(), "Native wordlist generation cancelled");
     }
 
     #[test]

--- a/tests/controller/test_async_controller.py
+++ b/tests/controller/test_async_controller.py
@@ -32,6 +32,8 @@ def create_controller(fuzzer):
     controller.loop = asyncio.get_running_loop()
     controller.pause_future = controller.loop.create_future()
     controller.fuzzer = fuzzer
+    controller._pause_requested = False
+    controller._handling_pause = False
     return controller
 
 
@@ -94,6 +96,33 @@ class TestControllerCleanup(TestCase):
 
 
 class TestAsyncController(IsolatedAsyncioTestCase):
+    async def test_pause_request_is_serviced_by_async_orchestration_task(self):
+        controller = create_controller(BlockingAsyncFuzzer())
+        controller.start_time = time.time()
+        pause_handled = asyncio.Event()
+
+        def handle_pause():
+            controller._pause_requested = False
+            pause_handled.set()
+
+        controller.handle_pause = Mock(side_effect=handle_pause)
+
+        with patch.dict(options, {"max_time": 0, "target_max_time": 0}):
+            run_task = controller.loop.create_task(
+                controller.start_coroutines(time.time())
+            )
+            await controller.fuzzer.started.wait()
+            controller._pause_requested = True
+            await asyncio.wait_for(pause_handled.wait(), timeout=1)
+            controller.pause_future.set_exception(QuitInterrupt("quit"))
+
+            with self.assertRaisesRegex(QuitInterrupt, "quit"):
+                await run_task
+
+        controller.handle_pause.assert_called_once_with()
+        self.assertTrue(controller.fuzzer.task.done())
+        self.assertTrue(controller.fuzzer.task.cancelled())
+
     async def test_quit_drains_cancelled_fuzzer_task(self):
         controller = create_controller(BlockingAsyncFuzzer())
         controller.start_time = time.time()

--- a/tests/controller/test_pause_controller.py
+++ b/tests/controller/test_pause_controller.py
@@ -1,0 +1,216 @@
+import signal
+import subprocess
+import sys
+from unittest import skipUnless, TestCase
+from unittest.mock import Mock, patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.dictionary import Dictionary
+from lib.core.exceptions import QuitInterrupt, SkipTargetInterrupt
+
+
+def make_dictionary(items=()) -> Dictionary:
+    dictionary = object.__new__(Dictionary)
+    dictionary.__setstate__((list(items), 0, [], 0))
+    return dictionary
+
+
+class SignalItems(list):
+    def __init__(self, items, callback):
+        super().__init__(items)
+        self._callback = callback
+        self._called = False
+
+    def __len__(self):
+        if not self._called:
+            self._called = True
+            self._callback(signal.SIGINT, None)
+        return super().__len__()
+
+
+class TestPauseController(TestCase):
+    def make_controller(self):
+        controller = object.__new__(Controller)
+        controller._handling_pause = False
+        controller._pause_requested = False
+        controller._force_quit_handler = Mock()
+        return controller
+
+    def test_signal_handler_only_records_pause_request(self):
+        controller = self.make_controller()
+
+        controller.request_pause(signal.SIGINT, None)
+
+        self.assertTrue(controller._pause_requested)
+        controller._force_quit_handler.on_pause_start.assert_called_once_with()
+        controller._force_quit_handler.check_force_quit.assert_not_called()
+
+    def test_signal_during_dictionary_claim_returns_without_reentrant_lock(self):
+        controller = self.make_controller()
+        dictionary = make_dictionary(["admin"])
+        dictionary._items = SignalItems(dictionary._items, controller.request_pause)
+
+        path = dictionary.claim_next()
+
+        self.assertEqual(path, "admin")
+        self.assertTrue(controller._pause_requested)
+        self.assertEqual(dictionary.__getstate__()[1], 1)
+
+    def test_repeated_signal_uses_force_quit_policy(self):
+        controller = self.make_controller()
+        controller._pause_requested = True
+
+        controller.request_pause(signal.SIGINT, None)
+
+        controller._force_quit_handler.check_force_quit.assert_called_once_with()
+
+    def test_pause_continue_resets_signal_state_and_resumes_workers(self):
+        controller = self.make_controller()
+        controller._pause_requested = True
+        controller.directories = [""]
+        controller.fuzzer = Mock()
+        controller.fuzzer.pause.return_value = True
+
+        with (
+            patch.dict(options, {"urls": ["https://example.com"], "async_mode": False}),
+            patch("builtins.input", return_value="c"),
+            patch("lib.controller.controller.interface"),
+        ):
+            controller.handle_pause()
+
+        self.assertFalse(controller._pause_requested)
+        self.assertFalse(controller._handling_pause)
+        controller._force_quit_handler.on_resume.assert_called_once_with()
+        controller.fuzzer.play.assert_called_once_with()
+
+    def test_next_directory_clears_pause_before_stopping_workers(self):
+        controller = self.make_controller()
+        controller._pause_requested = True
+        controller.directories = ["first", "second"]
+        controller.fuzzer = Mock()
+        controller.fuzzer.pause.return_value = True
+        controller.fuzzer.wait.return_value = True
+
+        with (
+            patch.dict(options, {"urls": ["https://example.com"], "async_mode": False}),
+            patch("builtins.input", return_value="n"),
+            patch("lib.controller.controller.interface"),
+        ):
+            controller.handle_pause()
+
+        self.assertFalse(controller._pause_requested)
+        self.assertFalse(controller._handling_pause)
+        controller.fuzzer.quit.assert_called_once_with()
+        controller.fuzzer.wait.assert_called_once()
+
+    def test_skip_target_clears_pause_before_raising(self):
+        controller = self.make_controller()
+        controller._pause_requested = True
+        controller.directories = [""]
+        controller.fuzzer = Mock()
+        controller.fuzzer.pause.return_value = True
+        controller.fuzzer.wait.return_value = True
+
+        with (
+            patch.dict(
+                options,
+                {
+                    "urls": ["https://example.com", "https://example.net"],
+                    "async_mode": False,
+                },
+            ),
+            patch("builtins.input", return_value="s"),
+            patch("lib.controller.controller.interface"),
+            self.assertRaises(SkipTargetInterrupt),
+        ):
+            controller.handle_pause()
+
+        self.assertFalse(controller._pause_requested)
+        self.assertFalse(controller._handling_pause)
+
+    def test_pause_save_runs_from_safe_point_before_worker_shutdown(self):
+        controller = self.make_controller()
+        controller._pause_requested = True
+        controller.directories = [""]
+        events = []
+        controller.fuzzer = Mock()
+        controller.fuzzer.pause.side_effect = lambda: events.append("pause") or True
+        controller.fuzzer.quit.side_effect = lambda: events.append("quit")
+        controller.fuzzer.wait.side_effect = lambda **_: events.append("wait") or True
+        controller._export = Mock(side_effect=lambda _path: events.append("save"))
+
+        with (
+            patch.dict(
+                options,
+                {
+                    "urls": ["https://example.com"],
+                    "async_mode": False,
+                    "session_file": None,
+                },
+            ),
+            patch("builtins.input", side_effect=["q", "s", "session"]),
+            patch("lib.controller.controller.interface"),
+            self.assertRaises(QuitInterrupt),
+        ):
+            controller.handle_pause()
+
+        self.assertEqual(events, ["pause", "save", "quit", "wait"])
+
+    @skipUnless(hasattr(signal, "SIGUSR1"), "requires POSIX user signals")
+    def test_real_signal_during_claim_and_session_save_does_not_deadlock(self):
+        source = r'''
+import signal
+import tempfile
+from unittest.mock import Mock
+from lib.controller.controller import Controller
+from lib.controller.session import SessionStore
+from lib.core.dictionary import Dictionary
+
+controller = object.__new__(Controller)
+controller._handling_pause = False
+controller._pause_requested = False
+controller._force_quit_handler = Mock()
+dictionary = object.__new__(Dictionary)
+dictionary.__setstate__((["admin"], 0, [], 0))
+
+class SignalItems(list):
+    fired = False
+    def __len__(self):
+        if not self.fired:
+            self.fired = True
+            signal.raise_signal(signal.SIGUSR1)
+        return super().__len__()
+
+dictionary._items = SignalItems(dictionary._items)
+signal.signal(signal.SIGUSR1, controller.request_pause)
+assert dictionary.claim_next() == "admin"
+assert controller._pause_requested
+controller.dictionary = dictionary
+controller.start_time = 0
+controller.passed_urls = set()
+controller.directories = [""]
+controller.jobs_processed = 0
+controller.errors = 0
+controller.consecutive_errors = 0
+controller.base_path = ""
+controller.url = "https://example.com/"
+controller.old_session = False
+with tempfile.TemporaryDirectory() as directory:
+    SessionStore({}).save(controller, directory, "")
+    restored = SessionStore({}).load(directory)
+assert restored["dictionary"]["extra"] == ["admin"]
+print("signal-safe")
+'''
+
+        result = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=".",
+            text=True,
+            capture_output=True,
+            timeout=3,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "signal-safe")

--- a/tests/core/test_dictionary_concurrency.py
+++ b/tests/core/test_dictionary_concurrency.py
@@ -55,6 +55,18 @@ class BlockingItems(list):
 
 
 class TestDictionaryConcurrency(TestCase):
+    def test_requeue_claims_retries_only_unreleased_paths(self):
+        dictionary = make_dictionary(["first", "second", "third"])
+
+        first = dictionary.claim_next()
+        second = dictionary.claim_next()
+        dictionary.claim_next()
+        dictionary.release_claim(second)
+
+        dictionary.requeue_claims()
+
+        self.assertEqual(drain(dictionary), [first, "third"])
+
     def test_independent_dictionaries_do_not_share_operation_lock(self):
         first_entered = threading.Event()
         release_first = threading.Event()

--- a/tests/core/test_fuzzer_lifecycle.py
+++ b/tests/core/test_fuzzer_lifecycle.py
@@ -1,0 +1,340 @@
+import threading
+import time
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from lib.core.data import options
+from lib.core.dictionary import Dictionary
+from lib.core.exceptions import RequestException
+from lib.core.fuzzer import Fuzzer, NativeFuzzer
+
+
+TEST_TIMEOUT = 5
+
+
+def make_dictionary(paths):
+    dictionary = object.__new__(Dictionary)
+    dictionary.__setstate__((list(paths), 0, [], 0))
+    return dictionary
+
+
+def remaining_paths(state):
+    dictionary = object.__new__(Dictionary)
+    dictionary.__setstate__(state)
+    paths = []
+    while True:
+        try:
+            path = dictionary.claim_next()
+        except StopIteration:
+            return paths
+        dictionary.release_claim(path)
+        paths.append(path)
+
+
+class BlockingNativeBackend:
+    def __init__(self):
+        self.started = threading.Event()
+        self.cancelled = threading.Event()
+
+    def scan(self, _base_url, _paths, _query=""):
+        self.started.set()
+        if not self.cancelled.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("native test backend was not cancelled")
+        return
+        yield
+
+    def cancel(self):
+        self.cancelled.set()
+
+
+class ResumableNativeBackend:
+    def __init__(self):
+        self.calls = []
+        self.started = threading.Event()
+        self.cancelled = threading.Event()
+
+    def scan(self, _base_url, paths, _query=""):
+        paths = list(paths)
+        self.calls.append(paths)
+        if len(self.calls) == 1:
+            self.started.set()
+            if not self.cancelled.wait(timeout=TEST_TIMEOUT):
+                raise TimeoutError("native test backend was not cancelled")
+            return
+
+        for path in paths:
+            yield path, None, RequestException("expected test response")
+
+    def cancel(self):
+        self.cancelled.set()
+
+
+class UncooperativeNativeBackend:
+    def __init__(self):
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def scan(self, _base_url, _paths, _query=""):
+        self.started.set()
+        if not self.release.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("native test backend was not released")
+        return
+        yield
+
+    def cancel(self):
+        pass
+
+
+class TestFuzzerLifecycle(TestCase):
+    def test_threaded_snapshot_retries_active_request(self):
+        dictionary = make_dictionary(["admin"])
+        request_started = threading.Event()
+        release_request = threading.Event()
+        fuzzer = Fuzzer(
+            Mock(),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer.setup_scanners = lambda: None
+
+        def scan(_path):
+            request_started.set()
+            if not release_request.wait(timeout=TEST_TIMEOUT):
+                raise TimeoutError("threaded test request was not released")
+
+        fuzzer.scan = scan
+
+        with patch.dict(options, {"thread_count": 1, "delay": 0}):
+            fuzzer.start()
+            self.assertTrue(request_started.wait(timeout=TEST_TIMEOUT))
+            saved_state = dictionary.__getstate__()
+            release_request.set()
+            self.assertTrue(fuzzer.wait(timeout=TEST_TIMEOUT))
+
+        self.assertEqual(remaining_paths(saved_state), ["admin"])
+
+    def test_native_start_is_non_blocking_and_pause_requeues_chunk(self):
+        paths = ["admin", "login"]
+        dictionary = make_dictionary(paths)
+        backend = BlockingNativeBackend()
+        fuzzer = NativeFuzzer(
+            Mock(_url="https://example.com/"),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer._native_backend = backend
+        fuzzer.setup_scanners = lambda: None
+        start_returned = threading.Event()
+
+        def start_fuzzer():
+            fuzzer.start()
+            start_returned.set()
+
+        starter = threading.Thread(target=start_fuzzer)
+        with patch.dict(options, {"thread_count": 1}):
+            starter.start()
+            try:
+                self.assertTrue(backend.started.wait(timeout=TEST_TIMEOUT))
+                returned_without_scan = start_returned.wait(timeout=1)
+                paused = fuzzer.pause()
+                saved_state = dictionary.__getstate__()
+            finally:
+                fuzzer.quit()
+                backend.cancel()
+                starter.join(timeout=TEST_TIMEOUT)
+                fuzzer.wait(timeout=TEST_TIMEOUT)
+
+        self.assertTrue(returned_without_scan)
+        self.assertTrue(paused)
+        self.assertEqual(remaining_paths(saved_state), paths)
+        self.assertFalse(starter.is_alive())
+        self.assertTrue(fuzzer.is_finished())
+
+    def test_threaded_pause_uses_one_overall_deadline(self):
+        dictionary = make_dictionary([])
+        fuzzer = Fuzzer(
+            Mock(),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer._threads = [Mock(is_alive=Mock(return_value=True)) for _ in range(4)]
+
+        started = time.monotonic()
+        with patch("lib.core.fuzzer.PAUSE_TIMEOUT_SECONDS", 0.05):
+            paused = fuzzer.pause()
+        elapsed = time.monotonic() - started
+
+        self.assertFalse(paused)
+        self.assertLess(elapsed, 0.2)
+
+    def test_threaded_pause_continue_drains_workers(self):
+        dictionary = make_dictionary(["first", "second"])
+        first_started = threading.Event()
+        release_first = threading.Event()
+        pause_result = []
+        fuzzer = Fuzzer(
+            Mock(),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer.setup_scanners = lambda: None
+
+        def scan(path):
+            if path == "first":
+                first_started.set()
+                release_first.wait(timeout=TEST_TIMEOUT)
+
+        fuzzer.scan = scan
+
+        with patch.dict(options, {"thread_count": 1, "delay": 0}):
+            fuzzer.start()
+            pauser = threading.Thread(target=lambda: pause_result.append(fuzzer.pause()))
+            try:
+                self.assertTrue(first_started.wait(timeout=TEST_TIMEOUT))
+                pauser.start()
+                deadline = time.monotonic() + TEST_TIMEOUT
+                while fuzzer._play_event.is_set() and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                self.assertFalse(fuzzer._play_event.is_set())
+                release_first.set()
+                pauser.join(timeout=TEST_TIMEOUT)
+                self.assertEqual(pause_result, [True])
+                self.assertTrue(fuzzer._threads[0].is_alive())
+
+                fuzzer.play()
+                self.assertTrue(fuzzer.wait(timeout=TEST_TIMEOUT))
+            finally:
+                release_first.set()
+                fuzzer.quit()
+                pauser.join(timeout=TEST_TIMEOUT)
+                fuzzer.wait(timeout=TEST_TIMEOUT)
+
+        self.assertTrue(fuzzer.is_finished())
+        self.assertTrue(all(not thread.is_alive() for thread in fuzzer._threads))
+
+    def test_threaded_pause_does_not_reuse_late_acknowledgement(self):
+        dictionary = make_dictionary(["first", "second"])
+        first_started = threading.Event()
+        second_started = threading.Event()
+        release_first = threading.Event()
+        release_second = threading.Event()
+        fuzzer = Fuzzer(
+            Mock(),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer.setup_scanners = lambda: None
+
+        def scan(path):
+            if path == "first":
+                first_started.set()
+                release_first.wait(timeout=TEST_TIMEOUT)
+            else:
+                second_started.set()
+                release_second.wait(timeout=TEST_TIMEOUT)
+
+        fuzzer.scan = scan
+
+        with (
+            patch.dict(options, {"thread_count": 1, "delay": 0}),
+            patch("lib.core.fuzzer.PAUSE_TIMEOUT_SECONDS", 0.05),
+        ):
+            fuzzer.start()
+            try:
+                self.assertTrue(first_started.wait(timeout=TEST_TIMEOUT))
+                self.assertFalse(fuzzer.pause())
+                release_first.set()
+                with fuzzer._pause_condition:
+                    acknowledged = fuzzer._pause_condition.wait_for(
+                        lambda: fuzzer._paused_workers.get(
+                            fuzzer._threads[0].ident
+                        )
+                        == 1,
+                        timeout=TEST_TIMEOUT,
+                    )
+                self.assertTrue(acknowledged)
+
+                fuzzer.play()
+                self.assertTrue(second_started.wait(timeout=TEST_TIMEOUT))
+                self.assertFalse(fuzzer.pause())
+            finally:
+                release_first.set()
+                release_second.set()
+                fuzzer.quit()
+                self.assertTrue(fuzzer.wait(timeout=TEST_TIMEOUT))
+
+        self.assertTrue(fuzzer.is_finished())
+        self.assertTrue(all(not thread.is_alive() for thread in fuzzer._threads))
+
+    def test_native_pause_continue_retries_exact_unreturned_chunk(self):
+        paths = ["admin", "login"]
+        dictionary = make_dictionary(paths)
+        backend = ResumableNativeBackend()
+        fuzzer = NativeFuzzer(
+            Mock(_url="https://example.com/"),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer._native_backend = backend
+        fuzzer.setup_scanners = lambda: None
+
+        with patch.dict(options, {"thread_count": 1}):
+            fuzzer.start()
+            try:
+                self.assertTrue(backend.started.wait(timeout=TEST_TIMEOUT))
+                self.assertTrue(fuzzer.pause())
+                self.assertEqual(remaining_paths(dictionary.__getstate__()), paths)
+                fuzzer.play()
+                self.assertTrue(fuzzer.wait(timeout=TEST_TIMEOUT))
+            finally:
+                fuzzer.quit()
+                backend.cancel()
+                fuzzer.wait(timeout=TEST_TIMEOUT)
+
+        self.assertEqual(backend.calls, [paths, paths])
+        self.assertEqual(remaining_paths(dictionary.__getstate__()), [])
+        self.assertTrue(all(not thread.is_alive() for thread in fuzzer._threads))
+
+    def test_native_pause_timeout_preserves_claims_and_shutdown_drains_worker(self):
+        paths = ["admin", "login"]
+        dictionary = make_dictionary(paths)
+        backend = UncooperativeNativeBackend()
+        fuzzer = NativeFuzzer(
+            Mock(_url="https://example.com/"),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer._native_backend = backend
+        fuzzer.setup_scanners = lambda: None
+
+        with (
+            patch.dict(options, {"thread_count": 1}),
+            patch("lib.core.fuzzer.PAUSE_TIMEOUT_SECONDS", 0.05),
+        ):
+            fuzzer.start()
+            try:
+                self.assertTrue(backend.started.wait(timeout=TEST_TIMEOUT))
+                started = time.monotonic()
+                self.assertFalse(fuzzer.pause())
+                self.assertLess(time.monotonic() - started, 0.2)
+                self.assertEqual(remaining_paths(dictionary.__getstate__()), paths)
+            finally:
+                backend.release.set()
+                fuzzer.quit()
+                self.assertTrue(fuzzer.wait(timeout=TEST_TIMEOUT))
+
+        self.assertTrue(all(not thread.is_alive() for thread in fuzzer._threads))

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -123,6 +123,7 @@ class TestNativeFuzzer(TestCase):
         fuzzer = self.make_fuzzer(backend, dictionary, matches, misses, errors)
         fuzzer.start()
 
+        self.assertTrue(fuzzer.wait(timeout=5))
         self.assertTrue(fuzzer.is_finished())
         self.assertEqual(dictionary.index, 1)
         self.assertEqual(matches, [response])
@@ -141,6 +142,7 @@ class TestNativeFuzzer(TestCase):
         fuzzer = self.make_fuzzer(backend, dictionary, matches, misses, errors)
         fuzzer.start()
 
+        self.assertTrue(fuzzer.wait(timeout=5))
         self.assertEqual(matches, [])
         self.assertEqual(misses, [])
         self.assertEqual(errors, [error])
@@ -164,6 +166,7 @@ class TestNativeFuzzer(TestCase):
         fuzzer = self.make_fuzzer(backend, dictionary, matches, misses, errors)
         fuzzer.start()
 
+        self.assertTrue(fuzzer.wait(timeout=5))
         self.assertEqual(matches, [])
         self.assertEqual(misses, [response])
         self.assertEqual(errors, [])
@@ -175,6 +178,7 @@ class TestNativeFuzzer(TestCase):
         fuzzer = self.make_fuzzer(backend, dictionary, [], [], [])
 
         fuzzer.start()
+        self.assertTrue(fuzzer.wait(timeout=5))
         saved_state = dictionary.__getstate__()
 
         resumed = object.__new__(Dictionary)

--- a/tests/core/test_wordlist_backend.py
+++ b/tests/core/test_wordlist_backend.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
-from unittest import TestCase
+from unittest import skipUnless, TestCase
 
 from lib.core.data import options
 from lib.core.exceptions import WordlistBackendUnavailableError
@@ -36,6 +39,70 @@ class TestWordlistBackend(TestCase):
 
         self.assertIsInstance(backend, NativeWordlistBackend)
 
+    @skipUnless(os.name == "posix" and hasattr(os, "mkfifo"), "requires POSIX FIFO")
+    def test_native_generation_releases_gil_and_propagates_signal(self):
+        try:
+            get_wordlist_backend("native")
+        except WordlistBackendUnavailableError:
+            self.skipTest("native extension is not installed")
+
+        source = r'''
+import os
+import signal
+import tempfile
+import threading
+import time
+import dirsearch_native
+
+class NativeWordlistInterrupted(Exception):
+    pass
+
+with tempfile.TemporaryDirectory() as directory:
+    fifo = os.path.join(directory, "wordlist.fifo")
+    os.mkfifo(fifo)
+
+    def writer():
+        with open(fifo, "wb", buffering=0) as handle:
+            os.kill(os.getpid(), signal.SIGINT)
+            handle.write(b"admin\n")
+
+    previous = signal.getsignal(signal.SIGINT)
+    thread = threading.Thread(target=writer)
+    signal.signal(
+        signal.SIGINT,
+        lambda *_: (_ for _ in ()).throw(
+            NativeWordlistInterrupted("stop native wordlist")
+        ),
+    )
+    thread.start()
+    started = time.monotonic()
+    try:
+        try:
+            dirsearch_native.generate_wordlist([fifo], [])
+        except NativeWordlistInterrupted as error:
+            assert str(error) == "stop native wordlist"
+        else:
+            raise AssertionError("native generation ignored SIGINT")
+    finally:
+        signal.signal(signal.SIGINT, previous)
+        thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert time.monotonic() - started < 2
+    print("native-wordlist-interrupted")
+'''
+
+        result = subprocess.run(
+            [sys.executable, "-c", source],
+            text=True,
+            capture_output=True,
+            timeout=3,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "native-wordlist-interrupted")
+
     def test_native_matches_python_when_available(self):
         try:
             native = get_wordlist_backend("native")
@@ -67,6 +134,90 @@ class TestWordlistBackend(TestCase):
         finally:
             options.clear()
             options.update(original)
+
+    def test_native_preserves_unicode_and_replaces_invalid_bytes(self):
+        try:
+            native = get_wordlist_backend("native")
+        except WordlistBackendUnavailableError:
+            return
+
+        expected = ["管理/登录", "مسار/دخول", "पथ/लॉगिन", "broken-�"]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wordlist = Path(temp_dir) / "wordlist.txt"
+            wordlist.write_bytes(
+                "管理/登录\nمسار/دخول\nपथ/लॉगिन\n".encode("utf-8")
+                + b"broken-\xff\n"
+            )
+            options.update(
+                {
+                    "extensions": (),
+                    "exclude_extensions": (),
+                    "force_extensions": False,
+                    "overwrite_extensions": False,
+                    "prefixes": (),
+                    "suffixes": (),
+                    "lowercase": False,
+                    "uppercase": False,
+                    "capitalization": False,
+                    "wordlist_max_size": 500000,
+                }
+            )
+
+            self.assertEqual(native.generate([str(wordlist)]), expected)
+            self.assertEqual(
+                get_wordlist_backend("python").generate([str(wordlist)]),
+                expected,
+            )
+
+    def test_wordlist_backends_are_independent_of_request_stack(self):
+        backend_names = ["python"]
+        try:
+            get_wordlist_backend("native")
+        except WordlistBackendUnavailableError:
+            pass
+        else:
+            backend_names.append("native")
+
+        request_stacks = (
+            ("threaded", "python", False),
+            ("async", "python", True),
+            ("native", "native", False),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wordlist = Path(temp_dir) / "wordlist.txt"
+            wordlist.write_text("admin\n", encoding="utf-8")
+            options.update(
+                {
+                    "extensions": (),
+                    "exclude_extensions": (),
+                    "force_extensions": False,
+                    "overwrite_extensions": False,
+                    "prefixes": (),
+                    "suffixes": (),
+                    "lowercase": False,
+                    "uppercase": False,
+                    "capitalization": False,
+                    "wordlist_max_size": 500000,
+                }
+            )
+
+            for backend_name in backend_names:
+                for stack_name, request_backend, async_mode in request_stacks:
+                    with self.subTest(
+                        wordlist_backend=backend_name,
+                        request_stack=stack_name,
+                    ):
+                        options.update(
+                            {
+                                "wordlist_backend": backend_name,
+                                "request_backend": request_backend,
+                                "async_mode": async_mode,
+                            }
+                        )
+                        self.assertEqual(
+                            get_wordlist_backend().generate([str(wordlist)]),
+                            ["admin"],
+                        )
 
     def test_native_matches_python_for_generation_options_when_available(self):
         try:


### PR DESCRIPTION
## Summary

- defer pause UI, locks, and session writes out of Python signal handlers
- give threaded and native request workers recoverable claims and bounded pause/shutdown deadlines
- run NativeFuzzer on a dedicated worker and requeue only unreturned native claims after cancellation
- release the GIL during Rust wordlist generation, poll Python signals every 50 ms, and cancel cooperatively without partial results

This PR is stacked on #1616 and must merge into dictionary-concurrency first. It must not be merged directly into master.

## Recovery semantics

A native cancellation requeues every claimed path for which no response was delivered to Python. This is intentionally at-least-once: an ambiguous remote GET may be repeated if it completed remotely immediately before cancellation.

## Regression coverage

- bounded POSIX subprocess reproducer for a signal during claim_next followed by session save
- pause/continue, pause/save, repeated Ctrl+C policy, active callbacks, total timeout, late acknowledgements, and worker drain
- exact native claim requeue on cancellation and on an uncooperative timeout
- Python/native wordlist matrix across threaded, async, and native request stacks
- POSIX FIFO interruption proving Rust releases the GIL and propagates the original signal exception
- Unicode and replacement decoding coverage for Chinese, Arabic, Devanagari, and invalid bytes

## Validation

- Python 3.14 native suite: 334 tests passed
- Python 3.12 fallback suite: 334 tests passed, 19 native-only skips
- legacy testing.py runner: 334 tests passed
- Rust: 23 tests passed; cargo fmt clean
- flake8, codespell, and git diff checks clean
- packaged install and console entry point passed
- six CLI smoke scans passed for both wordlist backends across all three request stacks

The local Docker daemon was unavailable, so all three Docker stacks remain an explicit CI gate before this PR can be marked ready or merged.