### PR TITLE
Stop fuzzer workers after callback failures

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -345,6 +345,7 @@ class Fuzzer(BaseFuzzer):
             error_callbacks=error_callbacks,
         )
         self._exc: Exception | None = None
+        self._exc_lock = threading.Lock()
         self._threads = []
         self._play_event = threading.Event()
         self._quit_event = threading.Event()
@@ -405,12 +406,12 @@ class Fuzzer(BaseFuzzer):
             thread.start()
 
     def is_finished(self) -> bool:
-        if self._exc:
-            raise self._exc
-
         for thread in self._threads:
             if thread.is_alive():
                 return False
+
+        if self._exc:
+            raise self._exc
 
         return True
 
@@ -435,6 +436,12 @@ class Fuzzer(BaseFuzzer):
         self._quit_event.set()
         self.play()
 
+    def _stop_with_exception(self, exception: Exception) -> None:
+        with self._exc_lock:
+            if self._exc is None:
+                self._exc = exception
+        self.quit()
+
     def scan(self, path: str) -> None:
         try:
             response = self._requester.request(path)
@@ -458,7 +465,7 @@ class Fuzzer(BaseFuzzer):
                 break
 
             except Exception as e:
-                self._exc = e
+                self._stop_with_exception(e)
 
             finally:
                 time.sleep(options["delay"])
@@ -614,12 +621,20 @@ class AsyncFuzzer(BaseFuzzer):
         await self.setup_scanners()
         self.play()
 
+        tasks = []
         for _ in range(min(options["thread_count"], len(self._dictionary))):
             task = asyncio.create_task(self.task_proc())
+            tasks.append(task)
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
 
-        await asyncio.gather(*self._background_tasks)
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def play(self) -> None:
         self._play_event.set()
@@ -629,7 +644,7 @@ class AsyncFuzzer(BaseFuzzer):
         return True
 
     def quit(self) -> None:
-        for task in self._background_tasks:
+        for task in tuple(self._background_tasks):
             task.cancel()
 
     async def scan(self, path: str) -> None:

--- a/tests/core/test_fuzzer_lifecycle.py
+++ b/tests/core/test_fuzzer_lifecycle.py
@@ -1,0 +1,148 @@
+import asyncio
+import threading
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import patch
+
+from lib.core.data import options
+from lib.core.exceptions import RequestException, SkipTargetInterrupt
+from lib.core.fuzzer import AsyncFuzzer, Fuzzer
+
+
+class LifecycleDictionary:
+    def __init__(self, paths):
+        self.paths = list(paths)
+        self.index = 0
+        self.claimed = []
+
+    def __next__(self):
+        if self.index >= len(self.paths):
+            raise StopIteration
+
+        path = self.paths[self.index]
+        self.index += 1
+        return path
+
+    def __len__(self):
+        return len(self.paths)
+
+    def claim_next(self):
+        path = next(self)
+        self.claimed.append(path)
+        return path
+
+    def release_claim(self, path):
+        self.claimed.remove(path)
+
+
+class CoordinatedSyncRequester:
+    def __init__(self):
+        self.paths = []
+        self.blocked_request_started = threading.Event()
+        self.release_blocked_request = threading.Event()
+
+    def request(self, path):
+        self.paths.append(path)
+
+        if path == "fail":
+            if not self.blocked_request_started.wait(timeout=2):
+                raise AssertionError("sibling request did not start")
+        elif path == "blocked":
+            self.blocked_request_started.set()
+            if not self.release_blocked_request.wait(timeout=2):
+                raise AssertionError("blocked request was not released")
+
+        raise RequestException(path)
+
+
+class CoordinatedAsyncRequester:
+    def __init__(self):
+        self.paths = []
+        self.blocked_request_started = asyncio.Event()
+        self.blocked_request_cancelled = asyncio.Event()
+
+    async def request(self, path):
+        self.paths.append(path)
+
+        if path == "fail":
+            await self.blocked_request_started.wait()
+            raise RequestException(path)
+
+        self.blocked_request_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.blocked_request_cancelled.set()
+            raise
+
+
+class TestThreadedFuzzerLifecycle(TestCase):
+    def test_terminal_callback_failure_stops_intake_and_drains_siblings(self):
+        requester = CoordinatedSyncRequester()
+        callback_failed = threading.Event()
+
+        def stop_scan(error):
+            if str(error) == "fail":
+                callback_failed.set()
+                raise SkipTargetInterrupt("stop target")
+
+        fuzzer = Fuzzer(
+            requester,
+            LifecycleDictionary(["fail", "blocked", "after"]),
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(stop_scan,),
+        )
+        fuzzer.setup_scanners = lambda: None
+
+        with patch.dict(options, {"thread_count": 2, "delay": 0}):
+            fuzzer.start()
+            try:
+                self.assertTrue(callback_failed.wait(timeout=2))
+                try:
+                    finished = fuzzer.is_finished()
+                except SkipTargetInterrupt:
+                    self.fail("terminal failure surfaced before siblings drained")
+                self.assertFalse(finished)
+            finally:
+                requester.release_blocked_request.set()
+                for thread in fuzzer._threads:
+                    thread.join(timeout=2)
+
+        self.assertFalse(any(thread.is_alive() for thread in fuzzer._threads))
+        self.assertEqual(requester.paths, ["fail", "blocked"])
+        with self.assertRaisesRegex(SkipTargetInterrupt, "stop target"):
+            fuzzer.is_finished()
+
+
+class TestAsyncFuzzerLifecycle(IsolatedAsyncioTestCase):
+    async def test_terminal_callback_failure_cancels_and_drains_siblings(self):
+        requester = CoordinatedAsyncRequester()
+
+        def stop_scan(error):
+            if str(error) == "fail":
+                raise SkipTargetInterrupt("stop target")
+
+        fuzzer = AsyncFuzzer(
+            requester,
+            LifecycleDictionary(["fail", "blocked"]),
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(stop_scan,),
+        )
+
+        async def skip_scanners():
+            return None
+
+        fuzzer.setup_scanners = skip_scanners
+
+        with patch.dict(options, {"thread_count": 2, "delay": 0}):
+            with self.assertRaisesRegex(SkipTargetInterrupt, "stop target"):
+                await asyncio.wait_for(fuzzer.start(), timeout=2)
+
+        remaining_tasks = tuple(fuzzer._background_tasks)
+        try:
+            self.assertTrue(requester.blocked_request_cancelled.is_set())
+            self.assertFalse(any(not task.done() for task in remaining_tasks))
+        finally:
+            fuzzer.quit()
+            await asyncio.gather(*remaining_tasks, return_exceptions=True)


### PR DESCRIPTION
## Summary
- stop threaded intake after a callback raises a terminal exception and preserve the first failure
- delay threaded exception propagation until every sibling worker has exited
- cancel and await every owned async worker task before AsyncFuzzer.start returns
- add deterministic event-based lifecycle regression coverage for threaded and async parity

## Why
Callback-driven QuitInterrupt and SkipTargetInterrupt failures could leave other workers running. Threaded mode exposed the exception before siblings had stopped, while async gather propagated one failure without cancelling or awaiting the remaining tasks. The controller could then reset shared scan state while those workers were still active.

## Regression proof
Both new tests fail on the current master: threaded mode surfaces the failure while a sibling is blocked, and async mode leaves the blocked sibling task pending. They pass after this change and explicitly verify complete worker cleanup and no additional threaded request intake.

## Validation
- Python 3.12: python -m unittest discover -s tests -t . (312 passed, 18 skipped)
- Python 3.12: python testing.py (312 passed, 18 skipped)
- Python 3.14: python -m unittest discover -s tests -t . (312 passed, 18 skipped)
- lifecycle regression module repeated 25 times
- flake8 .
- codespell with repository skips plus the ignored local native build directory
- python -m compileall -q lib tests dirsearch.py testing.py
- git diff --check