### PR TITLE
Enforce time limits during native scans

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -25,6 +25,7 @@ import shutil
 import signal
 import sys
 import re
+import threading
 import time
 from types import SimpleNamespace
 from typing import Any
@@ -477,6 +478,8 @@ class Controller:
                     # https://stackoverflow.com/a/64230941
                     self.pause_future = self.loop.create_future()
                     self.loop.run_until_complete(self.start_coroutines(start_time))
+                elif options["request_backend"] == "native":
+                    self.start_native_fuzzer(start_time)
                 else:
                     self.fuzzer.start()
                     self.process(start_time)
@@ -491,7 +494,9 @@ class Controller:
                 self.jobs_processed += 1
                 self.old_session = False
 
-    async def start_coroutines(self, start_time: float) -> None:
+    def get_time_limit(
+        self, start_time: float
+    ) -> tuple[float | None, Exception | None]:
         now = time.time()
         time_limits = []
 
@@ -517,9 +522,40 @@ class Controller:
                 raise limit_error
 
         if time_limits:
-            timeout, timeout_error = min(time_limits, key=lambda limit: limit[0])
-        else:
-            timeout, timeout_error = None, None
+            return min(time_limits, key=lambda limit: limit[0])
+
+        return None, None
+
+    def start_native_fuzzer(self, start_time: float) -> None:
+        timeout, timeout_error = self.get_time_limit(start_time)
+        if timeout is None:
+            self.fuzzer.start()
+            return
+
+        deadline_reached = threading.Event()
+
+        def stop_at_deadline() -> None:
+            deadline_reached.set()
+            self.fuzzer.quit()
+
+        timer = threading.Timer(timeout, stop_at_deadline)
+        timer.daemon = True
+        timer.start()
+        try:
+            self.fuzzer.start()
+        finally:
+            timer.cancel()
+            timer.join()
+
+        if deadline_reached.is_set():
+            raise timeout_error
+
+        # The scan may finish after the deadline before the timer callback
+        # gets scheduled. Recheck here so a late completion cannot win.
+        self.get_time_limit(start_time)
+
+    async def start_coroutines(self, start_time: float) -> None:
+        timeout, timeout_error = self.get_time_limit(start_time)
 
         task = self.loop.create_task(self.fuzzer.start())
 

--- a/tests/controller/test_native_controller.py
+++ b/tests/controller/test_native_controller.py
@@ -1,0 +1,176 @@
+import threading
+import time
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.exceptions import QuitInterrupt, SkipTargetInterrupt
+
+
+class BlockingNativeFuzzer:
+    def __init__(self):
+        self.started = threading.Event()
+        self.stopped = threading.Event()
+        self.base_paths = []
+        self.quit_calls = 0
+
+    def set_base_path(self, path):
+        self.base_paths.append(path)
+
+    def start(self):
+        self.started.set()
+        if not self.stopped.wait(timeout=2):
+            raise TimeoutError("native test fuzzer was not stopped")
+
+    def is_finished(self):
+        return self.stopped.is_set()
+
+    def quit(self):
+        self.quit_calls += 1
+        self.stopped.set()
+
+
+class SuppressedTimer:
+    def __init__(self, _timeout, _callback):
+        self.daemon = False
+
+    def start(self):
+        pass
+
+    def cancel(self):
+        pass
+
+    def join(self):
+        pass
+
+
+def create_controller(fuzzer):
+    controller = object.__new__(Controller)
+    controller.start_time = time.time()
+    controller.directories = [""]
+    controller.old_session = True
+    controller.fuzzer = fuzzer
+    controller.dictionary = Mock()
+    controller.jobs_processed = 0
+    return controller
+
+
+class TestNativeControllerDeadlines(TestCase):
+    def assert_deadline_stops_native_fuzzer(
+        self, *, max_time, target_max_time, error_type, message
+    ):
+        fuzzer = BlockingNativeFuzzer()
+        controller = create_controller(fuzzer)
+        errors = []
+
+        def run_controller():
+            try:
+                controller.start()
+            except BaseException as error:
+                errors.append(error)
+
+        worker = threading.Thread(target=run_controller)
+        with patch.dict(
+            options,
+            {
+                "async_mode": False,
+                "request_backend": "native",
+                "max_time": max_time,
+                "target_max_time": target_max_time,
+            },
+        ):
+            worker.start()
+            try:
+                self.assertTrue(fuzzer.started.wait(timeout=1))
+                worker.join(timeout=0.5)
+                completed_at_deadline = not worker.is_alive()
+            finally:
+                fuzzer.quit()
+                worker.join(timeout=1)
+
+        self.assertTrue(completed_at_deadline, "native scan ignored its deadline")
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], error_type)
+        self.assertEqual(str(errors[0]), message)
+        self.assertGreaterEqual(fuzzer.quit_calls, 1)
+        controller.dictionary.reset.assert_called_once_with()
+
+    def test_completed_native_scan_is_not_cancelled(self):
+        fuzzer = BlockingNativeFuzzer()
+        fuzzer.stopped.set()
+        controller = create_controller(fuzzer)
+
+        with patch.dict(
+            options,
+            {
+                "async_mode": False,
+                "request_backend": "native",
+                "max_time": 1,
+                "target_max_time": 0,
+            },
+        ):
+            controller.start()
+
+        self.assertEqual(fuzzer.quit_calls, 0)
+        controller.dictionary.reset.assert_called_once_with()
+
+    def test_expired_max_time_stops_before_starting_native_fuzzer(self):
+        fuzzer = BlockingNativeFuzzer()
+        controller = create_controller(fuzzer)
+        controller.start_time -= 1
+
+        with (
+            patch.dict(
+                options,
+                {
+                    "async_mode": False,
+                    "request_backend": "native",
+                    "max_time": 0.05,
+                    "target_max_time": 0,
+                },
+            ),
+            self.assertRaisesRegex(
+                QuitInterrupt, "Runtime exceeded the maximum set by the user"
+            ),
+        ):
+            controller.start()
+
+        self.assertFalse(fuzzer.started.is_set())
+        self.assertEqual(fuzzer.quit_calls, 0)
+        controller.dictionary.reset.assert_called_once_with()
+
+    def test_late_native_completion_cannot_beat_delayed_timer_callback(self):
+        fuzzer = BlockingNativeFuzzer()
+        fuzzer.stopped.set()
+        controller = create_controller(fuzzer)
+        controller.start_time = 0
+
+        with (
+            patch.dict(options, {"max_time": 1, "target_max_time": 0}),
+            patch("lib.controller.controller.threading.Timer", SuppressedTimer),
+            patch("lib.controller.controller.time.time", side_effect=[0, 2]),
+            self.assertRaisesRegex(
+                QuitInterrupt, "Runtime exceeded the maximum set by the user"
+            ),
+        ):
+            controller.start_native_fuzzer(start_time=0)
+
+        self.assertEqual(fuzzer.quit_calls, 0)
+
+    def test_max_time_interrupts_active_native_scan(self):
+        self.assert_deadline_stops_native_fuzzer(
+            max_time=0.05,
+            target_max_time=0,
+            error_type=QuitInterrupt,
+            message="Runtime exceeded the maximum set by the user",
+        )
+
+    def test_target_max_time_interrupts_active_native_scan(self):
+        self.assert_deadline_stops_native_fuzzer(
+            max_time=0,
+            target_max_time=0.05,
+            error_type=SkipTargetInterrupt,
+            message="Runtime for target exceeded the maximum set by the user",
+        )


### PR DESCRIPTION
## Summary
- enforce `--max-time` and `--target-max-time` while a native batch is active
- reuse one deadline calculation for async and native scan orchestration
- interrupt blocking native work through the existing cooperative cancellation path
- recheck elapsed time after native completion so timer scheduling cannot let a late result beat the deadline
- add deterministic controller regressions for active, expired, successful, and timer-race cases

## Why
`NativeFuzzer.start()` blocks until the native batch returns, but the synchronous controller previously checked time limits only afterward. Since the fuzzer was already finished at that point, both native time-limit options could complete successfully after their configured deadline.

A daemon watchdog now calls `NativeFuzzer.quit()` at the earliest active deadline. That method already forwards cancellation to the persistent Rust engine, so the blocking call drains before the controller raises the same `QuitInterrupt` or `SkipTargetInterrupt` used by the other backends.

This is a scoped part of #1588. Native pause and session-requeue behavior is intentionally left for a separate PR.

## Regression proof
The two active-deadline tests fail on current `master` because the native fuzzer remains blocked beyond both limits. The fixed suite also covers an already-expired deadline, normal completion without spurious cancellation, and completion after the deadline when the timer callback has not yet been scheduled.

## Validation
- Python 3.12: `python -m unittest discover -s tests -t .` (317 passed, 18 skipped)
- Python 3.12: `python testing.py` (317 passed, 18 skipped)
- Python 3.14 with the native extension: `python -m unittest discover -s tests -t .` (317 passed)
- deadline regression module repeated 25 times
- real native stalled-server scan cancelled in 0.206 seconds
- Rust: `cargo test --locked --manifest-path native/Cargo.toml` (22 passed)
- `cargo fmt --manifest-path native/Cargo.toml --all -- --check`
- `flake8 .`
- `codespell` with repository skips plus the ignored local native build directory
- `python -m compileall -q lib tests dirsearch.py testing.py`
- `git diff --check`