### PR TITLE
Make native pause recover pending paths

### DIFF
--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 from collections.abc import Iterable, Iterator
 from typing import Any
 
@@ -28,6 +30,10 @@ class NativeHTTPBackend:
         self._native = dirsearch_native
         self._engine = None
         self._engine_config = None
+        self._cancel_lock = threading.Lock()
+        # Preserve cancellation requested before lazy engine creation.
+        self._cancel_generation = 0
+        self._consumed_cancel_generation = 0
 
     def _get_engine(self):
         config = {
@@ -43,8 +49,16 @@ class NativeHTTPBackend:
         return self._engine
 
     def cancel(self) -> None:
-        if self._engine is not None:
-            self._engine.cancel()
+        with self._cancel_lock:
+            self._cancel_generation += 1
+            if self._engine is not None:
+                self._engine.cancel()
+
+    def reset_cancel(self) -> None:
+        with self._cancel_lock:
+            self._consumed_cancel_generation = self._cancel_generation
+            if self._engine is not None:
+                self._engine.reset_cancel()
 
     def scan(
         self,
@@ -55,13 +69,21 @@ class NativeHTTPBackend:
         raw_paths = list(paths)
         request_paths = [append_query_string(path, query) for path in raw_paths]
         quoted_paths = [safequote(path) for path in request_paths]
-        results = self._get_engine().scan(
+        with self._cancel_lock:
+            engine = self._get_engine()
+            cancel_generation = self._cancel_generation
+            if cancel_generation != self._consumed_cancel_generation:
+                engine.cancel()
+
+        results = engine.scan(
             base_url,
             quoted_paths,
             max_retries=options["max_retries"],
             max_body_size=MAX_RESPONSE_SIZE,
             **self._filter_options(),
         )
+        with self._cancel_lock:
+            self._consumed_cancel_generation = self._cancel_generation
 
         for path, quoted_path, result in zip(raw_paths, quoted_paths, results):
             if result.error is not None:

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -58,6 +58,8 @@ from lib.core.settings import (
     DEFAULT_SESSION_FILE,
     EXTENSION_RECOGNITION_REGEX,
     MAX_CONSECUTIVE_REQUEST_ERRORS,
+    NATIVE_WORKER_POLL_INTERVAL,
+    NATIVE_WORKER_SHUTDOWN_TIMEOUT,
     NEW_LINE,
     SIGINT_FORCE_QUIT_THRESHOLD,
     SIGINT_WINDOW_SECONDS,
@@ -488,6 +490,10 @@ class Controller:
                 pass
 
             finally:
+                native_worker = getattr(self, "_native_worker", None)
+                if native_worker is not None and native_worker.is_alive():
+                    raise QuitInterrupt("Native scan did not stop safely")
+
                 self.dictionary.reset()
                 self.directories.pop(0)
 
@@ -528,31 +534,67 @@ class Controller:
 
     def start_native_fuzzer(self, start_time: float) -> None:
         timeout, timeout_error = self.get_time_limit(start_time)
-        if timeout is None:
-            self.fuzzer.start()
-            return
-
         deadline_reached = threading.Event()
+        worker_errors = []
+
+        def run_fuzzer() -> None:
+            try:
+                self.fuzzer.start()
+            except BaseException as error:
+                worker_errors.append(error)
 
         def stop_at_deadline() -> None:
             deadline_reached.set()
             self.fuzzer.quit()
 
-        timer = threading.Timer(timeout, stop_at_deadline)
-        timer.daemon = True
-        timer.start()
+        # Keep the blocking native scan off the signal-handling thread.
+        worker = threading.Thread(target=run_fuzzer, name="dirsearch-native")
+        worker.daemon = True
+        self._native_worker = worker
+        timer = None
+        pending_error = None
         try:
-            self.fuzzer.start()
+            prepare_start = getattr(self.fuzzer, "prepare_start", None)
+            if prepare_start is not None:
+                prepare_start()
+            worker.start()
+
+            if timeout is not None:
+                timer = threading.Timer(timeout, stop_at_deadline)
+                timer.daemon = True
+                timer.start()
+
+            while worker.is_alive() and not deadline_reached.is_set():
+                worker.join(timeout=NATIVE_WORKER_POLL_INTERVAL)
+        except BaseException as error:
+            pending_error = error
+            if worker.is_alive():
+                self.fuzzer.quit()
         finally:
-            timer.cancel()
-            timer.join()
+            if timer is not None:
+                timer.cancel()
+                timer.join()
+
+        if worker.is_alive():
+            worker.join(timeout=NATIVE_WORKER_SHUTDOWN_TIMEOUT)
+        if worker.is_alive():
+            raise QuitInterrupt("Native scan did not stop safely")
+
+        self._native_worker = None
+
+        if pending_error is not None:
+            raise pending_error
+
+        if worker_errors:
+            raise worker_errors[0]
 
         if deadline_reached.is_set():
             raise timeout_error
 
-        # The scan may finish after the deadline before the timer callback
-        # gets scheduled. Recheck here so a late completion cannot win.
-        self.get_time_limit(start_time)
+        if timeout is not None:
+            # The scan may finish after the deadline before the timer callback
+            # gets scheduled. Recheck here so a late completion cannot win.
+            self.get_time_limit(start_time)
 
     async def start_coroutines(self, start_time: float) -> None:
         timeout, timeout_error = self.get_time_limit(start_time)

--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -92,6 +92,15 @@ class Dictionary:
     def release_claim(self, path: str) -> None:
         self._claimed.remove(path)
 
+    @locked
+    def requeue_claims(self) -> None:
+        """Make outstanding claims available again in their original order."""
+        if not self._claimed:
+            return
+
+        self._extra[self._extra_index:self._extra_index] = self._claimed
+        self._claimed.clear()
+
     def __contains__(self, item: str) -> bool:
         return item in self._items
 

--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -37,6 +37,7 @@ from lib.core.scanner import AsyncScanner, BaseScanner, Scanner
 from lib.core.settings import (
     DEFAULT_TEST_PREFIXES,
     DEFAULT_TEST_SUFFIXES,
+    NATIVE_PAUSE_TIMEOUT,
     WILDCARD_TEST_POINT_MARKER,
 )
 from lib.parse.url import clean_path
@@ -502,42 +503,80 @@ class NativeFuzzer(Fuzzer):
         )
         self._finished = False
         self._native_backend: NativeHTTPBackend | None = None
+        self._paused_event = threading.Event()
+        self._started_event = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+        self._prepared = False
+
+    def prepare_start(self) -> None:
+        with self._lifecycle_lock:
+            self._quit_event.clear()
+            self._finished = False
+            self._paused_event.clear()
+            self._started_event.clear()
+            self._reset_native_cancellation()
+            self._prepared = True
 
     def start(self) -> None:
-        self._native_backend = self._native_backend or NativeHTTPBackend()
-        self.setup_scanners()
-        self.play()
-        self._quit_event.clear()
-        self._finished = False
+        with self._lifecycle_lock:
+            if not self._prepared:
+                self._quit_event.clear()
+                self._finished = False
+                self._paused_event.clear()
+                self._started_event.clear()
+                self._reset_native_cancellation()
+            self._prepared = False
 
         try:
+            self._native_backend = self._native_backend or NativeHTTPBackend()
+            self.setup_scanners()
+            super().play()
+            self._started_event.set()
+
             while not self._quit_event.is_set():
+                if not self._play_event.is_set():
+                    # Acknowledge pause only after claims are recoverable.
+                    self._dictionary.requeue_claims()
+                    self._paused_event.set()
+                    self._play_event.wait()
+                    self._paused_event.clear()
+                    continue
+
                 paths = self._next_chunk()
                 if not paths:
                     break
 
-                for path, response, error in self._native_backend.scan(
-                    self._requester._url,
-                    paths,
-                    getattr(self._requester, "_query", ""),
-                ):
-                    if self._quit_event.is_set():
-                        break
-                    try:
-                        if error is not None:
-                            for callback in self.error_callbacks:
-                                callback(error)
-                            continue
-                        if response.filtered:
-                            for callback in self.not_found_callbacks:
-                                callback(response)
-                            continue
-                        self.process_response(path, response)
-                    finally:
-                        dictionary_path = lstrip_once(path, self._base_path)
-                        self._dictionary.release_claim(dictionary_path)
+                try:
+                    for path, response, error in self._native_backend.scan(
+                        self._requester._url,
+                        paths,
+                        getattr(self._requester, "_query", ""),
+                    ):
+                        if (
+                            self._quit_event.is_set()
+                            or not self._play_event.is_set()
+                        ):
+                            break
+                        try:
+                            if error is not None:
+                                for callback in self.error_callbacks:
+                                    callback(error)
+                                continue
+                            if response.filtered:
+                                for callback in self.not_found_callbacks:
+                                    callback(response)
+                                continue
+                            self.process_response(path, response)
+                        finally:
+                            dictionary_path = lstrip_once(path, self._base_path)
+                            self._dictionary.release_claim(dictionary_path)
+                finally:
+                    if not self._play_event.is_set():
+                        self._dictionary.requeue_claims()
         finally:
             self._finished = True
+            self._started_event.set()
+            self._paused_event.set()
 
     def _next_chunk(self) -> list[str]:
         chunk_size = max(1000, options["thread_count"] * 100)
@@ -552,8 +591,35 @@ class NativeFuzzer(Fuzzer):
     def is_finished(self) -> bool:
         return self._finished
 
+    def play(self) -> None:
+        self._reset_native_cancellation()
+        self._paused_event.clear()
+        super().play()
+
+    def _reset_native_cancellation(self) -> None:
+        if self._native_backend is None:
+            return
+        reset_cancel = getattr(self._native_backend, "reset_cancel", None)
+        if reset_cancel is not None:
+            reset_cancel()
+
+    def pause(self) -> bool:
+        deadline = time.monotonic() + NATIVE_PAUSE_TIMEOUT
+        if not self._started_event.wait(timeout=NATIVE_PAUSE_TIMEOUT):
+            return self._finished
+
+        self._play_event.clear()
+        if self._finished:
+            return True
+        if self._native_backend is not None:
+            self._native_backend.cancel()
+        timeout = max(0.0, deadline - time.monotonic())
+        return self._paused_event.wait(timeout=timeout)
+
     def quit(self) -> None:
-        super().quit()
+        self._quit_event.set()
+        self._paused_event.clear()
+        super().play()
         if self._native_backend is not None:
             self._native_backend.cancel()
 

--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -192,6 +192,13 @@ SIGINT_WINDOW_SECONDS = 0.8
 # Number of rapid Ctrl+C presses required to force quit
 SIGINT_FORCE_QUIT_THRESHOLD = 3
 
+# Native scanner lifecycle bounds
+NATIVE_PAUSE_TIMEOUT = 2.0
+
+NATIVE_WORKER_POLL_INTERVAL = 0.05
+
+NATIVE_WORKER_SHUTDOWN_TIMEOUT = 2.0
+
 URL_SAFE_CHARS = string.punctuation
 
 TEXT_CHARS = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F})

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -568,6 +568,10 @@ impl NativeHttpEngine {
         self.cancelled.store(true, Ordering::Release);
     }
 
+    fn reset_cancel(&self) {
+        self.cancelled.store(false, Ordering::Release);
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
         base_url,
@@ -655,7 +659,10 @@ impl NativeHttpEngine {
             .map_err(PyRuntimeError::new_err)?,
         );
 
-        self.cancelled.store(false, Ordering::Release);
+        // Pause may race ahead of the worker's first scan call.
+        if self.cancelled.swap(false, Ordering::AcqRel) {
+            return Ok(Vec::new());
+        }
         let cancelled = self.cancelled.clone();
         let clients = self.clients.clone();
         let raw_headers = self.raw_headers.clone();
@@ -665,7 +672,7 @@ impl NativeHttpEngine {
         let use_raw_http = self.use_raw_http;
         let runtime = &self.runtime;
 
-        py.allow_threads(move || {
+        let result = py.allow_threads(move || {
             runtime.block_on(async move {
                 let semaphore = Arc::new(tokio::sync::Semaphore::new(concurrency));
                 let result_count = paths.len();
@@ -756,7 +763,9 @@ impl NativeHttpEngine {
                 results.sort_by_key(|(request_index, _)| *request_index);
                 Ok(results.into_iter().map(|(_, result)| result).collect())
             })
-        })
+        });
+        self.cancelled.store(false, Ordering::Release);
+        result
     }
 }
 

--- a/tests/connection/test_native_backend.py
+++ b/tests/connection/test_native_backend.py
@@ -30,6 +30,9 @@ class FakeNativeEngine:
     def cancel(self):
         self.cancelled = True
 
+    def reset_cancel(self):
+        self.cancelled = False
+
 
 class FakeNativeModule:
     def __init__(self):
@@ -137,6 +140,31 @@ class TestNativeHTTPBackend(TestCase):
         self.assertEqual(len(fake_native.engines), 1)
         self.assertEqual(len(fake_native.engines[0].calls), 2)
         self.assertTrue(fake_native.engines[0].cancelled)
+
+    def test_cancellation_before_engine_creation_is_forwarded_to_first_scan(self):
+        fake_native = FakeNativeModule()
+
+        with patch.dict("sys.modules", {"dirsearch_native": fake_native}):
+            backend = NativeHTTPBackend()
+            backend.cancel()
+            list(backend.scan("https://example.com/", ["first"]))
+
+        self.assertEqual(len(fake_native.engines), 1)
+        self.assertTrue(fake_native.engines[0].cancelled)
+        self.assertEqual(len(fake_native.engines[0].calls), 1)
+
+    def test_reset_cancel_discards_cancellation_from_previous_lifecycle(self):
+        fake_native = FakeNativeModule()
+
+        with patch.dict("sys.modules", {"dirsearch_native": fake_native}):
+            backend = NativeHTTPBackend()
+            backend.cancel()
+            backend.reset_cancel()
+            list(backend.scan("https://example.com/", ["first"]))
+
+        self.assertEqual(len(fake_native.engines), 1)
+        self.assertFalse(fake_native.engines[0].cancelled)
+        self.assertEqual(len(fake_native.engines[0].calls), 1)
 
     def test_origin_407_remains_a_response_without_a_proxy(self):
         fake_native = FakeNativeModule()

--- a/tests/connection/test_native_engine.py
+++ b/tests/connection/test_native_engine.py
@@ -200,6 +200,35 @@ class TestNativeHttpEngine(TestCase):
         self.assertEqual(results, [])
         self.assertLess(elapsed, 2)
 
+    def test_cancellation_before_scan_is_consumed_without_sending_requests(self):
+        server = CountingHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine()
+        engine.cancel()
+
+        try:
+            cancelled = engine.scan(server.url, ["cancelled"])
+            resumed = engine.scan(server.url, ["resumed"])
+        finally:
+            server.close()
+
+        self.assertEqual(cancelled, [])
+        self.assertEqual(resumed[0].status, 200)
+        self.assertEqual(server.connection_count, 1)
+
+    def test_reset_cancel_allows_scan_after_lifecycle_shutdown(self):
+        server = CountingHTTPServer()
+        engine = dirsearch_native.NativeHttpEngine()
+        engine.cancel()
+        engine.reset_cancel()
+
+        try:
+            results = engine.scan(server.url, ["resumed"])
+        finally:
+            server.close()
+
+        self.assertEqual(results[0].status, 200)
+        self.assertEqual(server.connection_count, 1)
+
     def test_explicit_cancellation_closes_raw_fallback_socket(self):
         server = StalledHTTPServer()
         engine = dirsearch_native.NativeHttpEngine(timeout_secs=5)

--- a/tests/controller/test_native_controller.py
+++ b/tests/controller/test_native_controller.py
@@ -45,6 +45,19 @@ class SuppressedTimer:
         pass
 
 
+class UncooperativeNativeFuzzer(BlockingNativeFuzzer):
+    def __init__(self):
+        super().__init__()
+        self.release = threading.Event()
+
+    def start(self):
+        self.started.set()
+        self.release.wait(timeout=2)
+
+    def quit(self):
+        self.quit_calls += 1
+
+
 def create_controller(fuzzer):
     controller = object.__new__(Controller)
     controller.start_time = time.time()
@@ -207,3 +220,36 @@ class TestNativeControllerDeadlines(TestCase):
 
         self.assertFalse(worker.is_alive())
         self.assertEqual(errors, [])
+
+    def test_uncooperative_deadline_preserves_live_dictionary_state(self):
+        fuzzer = UncooperativeNativeFuzzer()
+        controller = create_controller(fuzzer)
+
+        try:
+            with (
+                patch.dict(
+                    options,
+                    {
+                        "async_mode": False,
+                        "request_backend": "native",
+                        "max_time": 0.1,
+                        "target_max_time": 0,
+                    },
+                ),
+                patch(
+                    "lib.controller.controller.NATIVE_WORKER_SHUTDOWN_TIMEOUT",
+                    0.05,
+                ),
+                self.assertRaisesRegex(
+                    QuitInterrupt, "Native scan did not stop safely"
+                ),
+            ):
+                controller.start()
+        finally:
+            fuzzer.release.set()
+            native_worker = getattr(controller, "_native_worker", None)
+            if native_worker is not None:
+                native_worker.join(timeout=1)
+
+        controller.dictionary.reset.assert_not_called()
+        self.assertEqual(controller.directories, [""])

--- a/tests/controller/test_native_controller.py
+++ b/tests/controller/test_native_controller.py
@@ -174,3 +174,36 @@ class TestNativeControllerDeadlines(TestCase):
             error_type=SkipTargetInterrupt,
             message="Runtime for target exceeded the maximum set by the user",
         )
+
+    def test_native_scan_does_not_occupy_controller_thread(self):
+        fuzzer = BlockingNativeFuzzer()
+        controller = create_controller(fuzzer)
+        controller_thread_ids = []
+        fuzzer_thread_ids = []
+        errors = []
+        original_start = fuzzer.start
+
+        def record_fuzzer_thread():
+            fuzzer_thread_ids.append(threading.get_ident())
+            original_start()
+
+        def run_controller():
+            controller_thread_ids.append(threading.get_ident())
+            try:
+                controller.start_native_fuzzer(start_time=time.time())
+            except BaseException as error:
+                errors.append(error)
+
+        fuzzer.start = record_fuzzer_thread
+        worker = threading.Thread(target=run_controller)
+        with patch.dict(options, {"max_time": 0, "target_max_time": 0}):
+            worker.start()
+            try:
+                self.assertTrue(fuzzer.started.wait(timeout=1))
+                self.assertNotEqual(fuzzer_thread_ids, controller_thread_ids)
+            finally:
+                fuzzer.quit()
+                worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(errors, [])

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -1,4 +1,7 @@
+import threading
+import time
 from unittest import TestCase
+from unittest.mock import patch
 from lib.connection.response import NativeResponse
 from lib.core.data import blacklists, options
 from lib.core.dictionary import Dictionary
@@ -26,6 +29,9 @@ class DummyDictionary:
     def release_claim(self, path):
         return None
 
+    def requeue_claims(self):
+        return None
+
 
 class DummyRequester:
     _url = "https://example.com/"
@@ -45,6 +51,50 @@ class FakeNativeBackend:
         self.cancelled = True
 
 
+class CoordinatedNativeBackend:
+    def __init__(self):
+        self.calls = []
+        self.cancelled = threading.Event()
+        self.waiting_for_cancel = threading.Event()
+
+    def scan(self, _base_url, paths, query=""):
+        paths = list(paths)
+        self.calls.append(paths)
+
+        if len(self.calls) == 1:
+            yield paths[0], None, RequestException(paths[0])
+            self.waiting_for_cancel.set()
+            if not self.cancelled.wait(timeout=2):
+                raise AssertionError("native scan was not cancelled while pausing")
+
+            # A cancelled backend may still deliver a result that was already
+            # ready. It must not cross the pause acknowledgement boundary.
+            yield paths[1], None, RequestException(f"late-{paths[1]}")
+            return
+
+        for path in paths:
+            yield path, None, RequestException(path)
+
+    def cancel(self):
+        self.cancelled.set()
+
+
+class UncooperativeNativeBackend:
+    def __init__(self):
+        self.started = threading.Event()
+        self.cancelled = threading.Event()
+        self.release = threading.Event()
+
+    def scan(self, _base_url, _paths, query=""):
+        self.started.set()
+        self.release.wait(timeout=2)
+        if False:
+            yield
+
+    def cancel(self):
+        self.cancelled.set()
+
+
 def make_dictionary(paths):
     dictionary = object.__new__(Dictionary)
     dictionary._items = list(paths)
@@ -53,6 +103,24 @@ def make_dictionary(paths):
     dictionary._extra_index = 0
     dictionary._claimed = []
     return dictionary
+
+
+def restored_paths(state):
+    dictionary = object.__new__(Dictionary)
+    dictionary.__setstate__(state)
+    paths = []
+    while True:
+        try:
+            paths.append(next(dictionary))
+        except StopIteration:
+            return paths
+
+
+def run_fuzzer(fuzzer, errors):
+    try:
+        fuzzer.start()
+    except BaseException as error:
+        errors.append(error)
 
 
 class TestNativeFuzzer(TestCase):
@@ -194,3 +262,76 @@ class TestNativeFuzzer(TestCase):
         fuzzer.quit()
 
         self.assertTrue(backend.cancelled)
+
+    def test_pause_retries_only_results_not_delivered_before_acknowledgement(self):
+        dictionary = make_dictionary(["admin", "login"])
+        backend = CoordinatedNativeBackend()
+        callback_errors = []
+        first_result_processed = threading.Event()
+
+        def record_error(error):
+            callback_errors.append(str(error))
+            first_result_processed.set()
+
+        fuzzer = NativeFuzzer(
+            DummyRequester(),
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(record_error,),
+        )
+        fuzzer._native_backend = backend
+        fuzzer.setup_scanners = lambda: None
+        worker_errors = []
+        worker = threading.Thread(target=run_fuzzer, args=(fuzzer, worker_errors))
+        worker.start()
+
+        try:
+            self.assertTrue(first_result_processed.wait(timeout=1))
+            self.assertTrue(backend.waiting_for_cancel.wait(timeout=1))
+            self.assertTrue(fuzzer.pause())
+            self.assertTrue(backend.cancelled.is_set())
+
+            saved_state = dictionary.__getstate__()
+            self.assertEqual(restored_paths(saved_state), ["login"])
+            self.assertEqual(callback_errors, ["admin"])
+
+            fuzzer.play()
+            worker.join(timeout=1)
+        finally:
+            fuzzer.quit()
+            backend.cancelled.set()
+            worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(worker_errors, [])
+        self.assertEqual(backend.calls, [["admin", "login"], ["login"]])
+        self.assertEqual(callback_errors, ["admin", "login"])
+        self.assertEqual(restored_paths(dictionary.__getstate__()), [])
+
+    def test_pause_reports_timeout_when_native_scan_does_not_acknowledge(self):
+        dictionary = make_dictionary(["blocked"])
+        backend = UncooperativeNativeBackend()
+        fuzzer = self.make_fuzzer(backend, dictionary, [], [], [])
+        worker_errors = []
+        worker = threading.Thread(target=run_fuzzer, args=(fuzzer, worker_errors))
+        worker.start()
+
+        try:
+            self.assertTrue(backend.started.wait(timeout=1))
+            started_at = time.monotonic()
+            with patch("lib.core.fuzzer.NATIVE_PAUSE_TIMEOUT", 0.05, create=True):
+                paused = fuzzer.pause()
+            elapsed = time.monotonic() - started_at
+
+            self.assertFalse(paused)
+            self.assertTrue(backend.cancelled.is_set())
+            self.assertLess(elapsed, 0.5)
+            self.assertTrue(worker.is_alive())
+        finally:
+            backend.release.set()
+            fuzzer.quit()
+            worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(worker_errors, [])

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -95,6 +95,20 @@ class UncooperativeNativeBackend:
         self.cancelled.set()
 
 
+class CancelAwareNativeBackend:
+    def __init__(self):
+        self.cancelled = threading.Event()
+
+    def scan(self, _base_url, _paths, query=""):
+        if not self.cancelled.wait(timeout=1):
+            raise AssertionError("native scan was not cancelled")
+        if False:
+            yield
+
+    def cancel(self):
+        self.cancelled.set()
+
+
 def make_dictionary(paths):
     dictionary = object.__new__(Dictionary)
     dictionary._items = list(paths)
@@ -333,5 +347,41 @@ class TestNativeFuzzer(TestCase):
             fuzzer.quit()
             worker.join(timeout=1)
 
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(worker_errors, [])
+
+    def test_pause_during_startup_is_not_overwritten_by_fuzzer_initialization(self):
+        dictionary = make_dictionary(["admin"])
+        backend = CancelAwareNativeBackend()
+        setup_started = threading.Event()
+        release_setup = threading.Event()
+        fuzzer = self.make_fuzzer(backend, dictionary, [], [], [])
+
+        def setup_scanners():
+            setup_started.set()
+            if not release_setup.wait(timeout=1):
+                raise AssertionError("native setup was not released")
+
+        fuzzer.setup_scanners = setup_scanners
+        worker_errors = []
+        worker = threading.Thread(target=run_fuzzer, args=(fuzzer, worker_errors))
+        pause_results = []
+        pauser = threading.Thread(target=lambda: pause_results.append(fuzzer.pause()))
+        worker.start()
+
+        try:
+            self.assertTrue(setup_started.wait(timeout=1))
+            pauser.start()
+            release_setup.set()
+            pauser.join(timeout=1)
+
+            self.assertEqual(pause_results, [True])
+            self.assertTrue(worker.is_alive())
+        finally:
+            fuzzer.quit()
+            pauser.join(timeout=1)
+            worker.join(timeout=1)
+
+        self.assertFalse(pauser.is_alive())
         self.assertFalse(worker.is_alive())
         self.assertEqual(worker_errors, [])


### PR DESCRIPTION
## Summary

- run the blocking native scan on a controller-owned worker so the signal-handling thread can pause, continue, skip, or quit it
- cancel the active native batch and acknowledge pause only after outstanding dictionary claims are requeued
- preserve cancellation across lazy engine creation and consume pre-scan cancellation without sending requests
- bound native worker shutdown and avoid resetting live dictionary state when cancellation does not complete

This advances the native scan-control parity tracked in #1588.

## Recovery semantics

A delivered result releases its dictionary claim. A claimed path without a delivered result is retried after continue or preserved in a saved session. If a request reached the server but cancellation prevented result delivery, continuing can repeat that request; this is intentional at-least-once recovery.

## Tests

- deterministic pause/cancel/requeue harness, including partial delivery, startup races, pre-engine cancellation, and uncooperative shutdown
- 25 repeated focused concurrency runs
- Python 3.12: 326 tests passed, 20 skipped because the native extension requires Python 3.14
- Python 3.14 with the rebuilt real native extension: 326 tests passed
- Rust: 22 tests passed
- flake8, codespell, compileall, and cargo fmt checks passed