### PR TITLE
Use per-dictionary locks for mutable state

### DIFF
--- a/lib/core/dictionary.py
+++ b/lib/core/dictionary.py
@@ -17,9 +17,9 @@
 #  Author: Mauro Soria
 
 from __future__ import annotations
+import threading
 from typing import Any, Iterator
 
-from lib.core.decorators import locked
 from lib.core.settings import SCRIPT_PATH
 from lib.core.wordlist_backend import get_wordlist_backend, is_valid_path
 from lib.utils.file import FileUtils
@@ -50,6 +50,7 @@ def get_blacklists() -> dict[int, Dictionary]:
 
 class Dictionary:
     def __init__(self, **kwargs: Any) -> None:
+        self._lock = threading.Lock()
         self._index = 0
         self._items = self.generate(**kwargs)
         # Items in self._extra will be cleared when self.reset() is called
@@ -59,62 +60,67 @@ class Dictionary:
 
     @property
     def index(self) -> int:
-        return self._index
+        with self._lock:
+            return self._index
 
-    @locked
     def __next__(self) -> str:
-        if len(self._extra) > self._extra_index:
-            self._extra_index += 1
-            return self._extra[self._extra_index - 1]
-        elif len(self._items) > self._index:
-            self._index += 1
-            return self._items[self._index - 1]
-        else:
-            raise StopIteration
+        with self._lock:
+            if len(self._extra) > self._extra_index:
+                self._extra_index += 1
+                return self._extra[self._extra_index - 1]
+            elif len(self._items) > self._index:
+                self._index += 1
+                return self._items[self._index - 1]
+            else:
+                raise StopIteration
 
-    @locked
     def claim_next(self) -> str:
         """Return the next path and keep it recoverable until released."""
-        if len(self._extra) > self._extra_index:
-            path = self._extra[self._extra_index]
-            self._claimed.append(path)
-            self._extra_index += 1
-            return path
-        elif len(self._items) > self._index:
-            path = self._items[self._index]
-            self._claimed.append(path)
-            self._index += 1
-            return path
-        else:
-            raise StopIteration
+        with self._lock:
+            if len(self._extra) > self._extra_index:
+                path = self._extra[self._extra_index]
+                self._claimed.append(path)
+                self._extra_index += 1
+                return path
+            elif len(self._items) > self._index:
+                path = self._items[self._index]
+                self._claimed.append(path)
+                self._index += 1
+                return path
+            else:
+                raise StopIteration
 
-    @locked
     def release_claim(self, path: str) -> None:
-        self._claimed.remove(path)
+        with self._lock:
+            self._claimed.remove(path)
 
-    @locked
     def requeue_claims(self) -> None:
         """Make outstanding claims available again in their original order."""
-        if not self._claimed:
-            return
+        with self._lock:
+            if not self._claimed:
+                return
 
-        self._extra[self._extra_index:self._extra_index] = self._claimed
-        self._claimed.clear()
+            self._extra[self._extra_index:self._extra_index] = self._claimed
+            self._claimed.clear()
 
     def __contains__(self, item: str) -> bool:
         return item in self._items
 
     def __getstate__(self) -> tuple[list[str], int, list[str], int]:
-        extra = (
-            self._extra[:self._extra_index]
-            + self._claimed
-            + self._extra[self._extra_index:]
-        )
-        return list(self._items), self._index, extra, self._extra_index
+        with self._lock:
+            extra = (
+                self._extra[:self._extra_index]
+                + self._claimed
+                + self._extra[self._extra_index:]
+            )
+            return list(self._items), self._index, extra, self._extra_index
 
     def __setstate__(self, state: tuple[list[str], int, list[str], int]) -> None:
-        self._items, self._index, self._extra, self._extra_index = state
-        self._claimed = []
+        if not hasattr(self, "_lock"):
+            self._lock = threading.Lock()
+        with self._lock:
+            self._items, self._index, self._extra, self._extra_index = state
+            self._claimed = []
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._items)
@@ -150,12 +156,14 @@ class Dictionary:
         if not self.is_valid(path):
             return
 
-        if path in self._items or path in self._extra:
-            return
+        with self._lock:
+            if path in self._items or path in self._extra:
+                return
 
-        self._extra.append(path)
+            self._extra.append(path)
 
     def reset(self) -> None:
-        self._index = self._extra_index = 0
-        self._extra.clear()
-        self._claimed.clear()
+        with self._lock:
+            self._index = self._extra_index = 0
+            self._extra.clear()
+            self._claimed.clear()

--- a/tests/core/test_async_fuzzer.py
+++ b/tests/core/test_async_fuzzer.py
@@ -57,11 +57,7 @@ class BlockingAsyncRequester:
 
 def make_dictionary(paths):
     dictionary = object.__new__(Dictionary)
-    dictionary._items = list(paths)
-    dictionary._index = 0
-    dictionary._extra = []
-    dictionary._extra_index = 0
-    dictionary._claimed = []
+    dictionary.__setstate__((list(paths), 0, [], 0))
     return dictionary
 
 

--- a/tests/core/test_backup_discovery.py
+++ b/tests/core/test_backup_discovery.py
@@ -11,11 +11,7 @@ from lib.core.wordlist_template import generate_backup_paths
 
 def make_dictionary() -> Dictionary:
     dictionary = object.__new__(Dictionary)
-    dictionary._items = []
-    dictionary._index = 0
-    dictionary._extra = []
-    dictionary._extra_index = 0
-    dictionary._claimed = []
+    dictionary.__setstate__(([], 0, [], 0))
     return dictionary
 
 

--- a/tests/core/test_dictionary_concurrency.py
+++ b/tests/core/test_dictionary_concurrency.py
@@ -1,0 +1,133 @@
+import queue
+import threading
+import time
+from unittest import TestCase
+
+from lib.core.dictionary import Dictionary
+
+
+TEST_TIMEOUT = 2.0
+CONTAINS_TIMEOUT = 0.5
+
+
+def make_dictionary(items=()) -> Dictionary:
+    dictionary = object.__new__(Dictionary)
+    dictionary.__setstate__((list(items), 0, [], 0))
+    return dictionary
+
+
+def join_threads(test_case: TestCase, threads: list[threading.Thread]) -> None:
+    deadline = time.monotonic() + TEST_TIMEOUT
+    for thread in threads:
+        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    test_case.assertFalse(
+        any(thread.is_alive() for thread in threads),
+        "dictionary concurrency test leaked a worker thread",
+    )
+
+
+class BlockingItems(list):
+    def __init__(
+        self,
+        items: list[str],
+        entered: threading.Event,
+        release: threading.Event,
+    ) -> None:
+        super().__init__(items)
+        self._entered = entered
+        self._release = release
+
+    def __len__(self) -> int:
+        self._entered.set()
+        if not self._release.wait(timeout=TEST_TIMEOUT):
+            raise TimeoutError("test did not release blocked dictionary")
+        return super().__len__()
+
+
+class CoordinatedExtras(list):
+    def __init__(self, workers: int) -> None:
+        super().__init__()
+        self._contains_barrier = threading.Barrier(workers)
+
+    def __contains__(self, item: object) -> bool:
+        result = super().__contains__(item)
+        try:
+            self._contains_barrier.wait(timeout=CONTAINS_TIMEOUT)
+        except threading.BrokenBarrierError:
+            pass
+        return result
+
+
+class TestDictionaryConcurrency(TestCase):
+    def test_independent_dictionaries_do_not_share_operation_lock(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_started = threading.Event()
+        second_finished = threading.Event()
+        errors = queue.Queue()
+        first = make_dictionary()
+        first._items = BlockingItems(["first"], first_entered, release_first)
+        second = make_dictionary(["second"])
+
+        def claim(dictionary: Dictionary, started=None, finished=None) -> None:
+            if started is not None:
+                started.set()
+            try:
+                path = dictionary.claim_next()
+                dictionary.release_claim(path)
+            except Exception as error:
+                errors.put(error)
+            finally:
+                if finished is not None:
+                    finished.set()
+
+        first_thread = threading.Thread(target=claim, args=(first,))
+        second_thread = threading.Thread(
+            target=claim,
+            args=(second, second_started, second_finished),
+        )
+        first_thread.start()
+
+        try:
+            self.assertTrue(first_entered.wait(timeout=TEST_TIMEOUT))
+            second_thread.start()
+            self.assertTrue(second_started.wait(timeout=TEST_TIMEOUT))
+            completed_independently = second_finished.wait(timeout=CONTAINS_TIMEOUT)
+        finally:
+            release_first.set()
+            join_threads(self, [first_thread, second_thread])
+
+        self.assertTrue(
+            completed_independently,
+            "an unrelated dictionary was blocked by the process-wide lock",
+        )
+        self.assertTrue(errors.empty())
+
+    def test_concurrent_duplicate_extras_are_enqueued_once(self):
+        worker_count = 8
+        dictionary = make_dictionary()
+        dictionary._extra = CoordinatedExtras(worker_count)
+        start = threading.Barrier(worker_count + 1)
+        errors = queue.Queue()
+
+        def add_candidate() -> None:
+            try:
+                start.wait(timeout=TEST_TIMEOUT)
+                dictionary.add_extra("dynamic/admin.bak")
+            except Exception as error:
+                errors.put(error)
+
+        threads = [threading.Thread(target=add_candidate) for _ in range(worker_count)]
+        for thread in threads:
+            thread.start()
+
+        try:
+            start.wait(timeout=TEST_TIMEOUT)
+        except BaseException:
+            start.abort()
+            raise
+        finally:
+            join_threads(self, threads)
+
+        self.assertTrue(errors.empty())
+        self.assertEqual(dictionary._extra, ["dynamic/admin.bak"])

--- a/tests/core/test_dictionary_concurrency.py
+++ b/tests/core/test_dictionary_concurrency.py
@@ -58,6 +58,39 @@ class CoordinatedExtras(list):
         return result
 
 
+class BlockingSnapshotExtras(list):
+    def __init__(
+        self,
+        items: list[str],
+        entered: threading.Event,
+        release: threading.Event,
+    ) -> None:
+        super().__init__(items)
+        self._entered = entered
+        self._release = release
+        self._blocked = False
+
+    def __getitem__(self, item):
+        result = super().__getitem__(item)
+        if isinstance(item, slice) and not self._blocked:
+            self._blocked = True
+            self._entered.set()
+            if not self._release.wait(timeout=TEST_TIMEOUT):
+                raise TimeoutError("test did not release dictionary snapshot")
+        return result
+
+
+def remaining_paths(state: tuple[list[str], int, list[str], int]) -> list[str]:
+    dictionary = object.__new__(Dictionary)
+    dictionary.__setstate__(state)
+    paths = []
+    while True:
+        try:
+            paths.append(next(dictionary))
+        except StopIteration:
+            return paths
+
+
 class TestDictionaryConcurrency(TestCase):
     def test_independent_dictionaries_do_not_share_operation_lock(self):
         first_entered = threading.Event()
@@ -131,3 +164,50 @@ class TestDictionaryConcurrency(TestCase):
 
         self.assertTrue(errors.empty())
         self.assertEqual(dictionary._extra, ["dynamic/admin.bak"])
+
+    def test_session_snapshot_cannot_interleave_with_reset(self):
+        snapshot_entered = threading.Event()
+        release_snapshot = threading.Event()
+        reset_started = threading.Event()
+        reset_finished = threading.Event()
+        snapshot_state = []
+        errors = queue.Queue()
+        dictionary = make_dictionary(["base"])
+        dictionary._extra = BlockingSnapshotExtras(
+            ["dynamic"],
+            snapshot_entered,
+            release_snapshot,
+        )
+        self.assertEqual(next(dictionary), "dynamic")
+
+        def snapshot() -> None:
+            try:
+                snapshot_state.append(dictionary.__getstate__())
+            except Exception as error:
+                errors.put(error)
+
+        def reset() -> None:
+            reset_started.set()
+            try:
+                dictionary.reset()
+            except Exception as error:
+                errors.put(error)
+            finally:
+                reset_finished.set()
+
+        snapshot_thread = threading.Thread(target=snapshot)
+        reset_thread = threading.Thread(target=reset)
+        snapshot_thread.start()
+
+        try:
+            self.assertTrue(snapshot_entered.wait(timeout=TEST_TIMEOUT))
+            reset_thread.start()
+            self.assertTrue(reset_started.wait(timeout=TEST_TIMEOUT))
+            reset_finished.wait(timeout=CONTAINS_TIMEOUT)
+        finally:
+            release_snapshot.set()
+            join_threads(self, [snapshot_thread, reset_thread])
+
+        self.assertTrue(errors.empty())
+        self.assertEqual(len(snapshot_state), 1)
+        self.assertEqual(remaining_paths(snapshot_state[0]), ["base"])

--- a/tests/core/test_dynamic_dictionary.py
+++ b/tests/core/test_dynamic_dictionary.py
@@ -10,11 +10,7 @@ from lib.core.fuzzer import AsyncFuzzer, Fuzzer, NativeFuzzer
 
 def make_dictionary(paths: list[str]) -> Dictionary:
     dictionary = object.__new__(Dictionary)
-    dictionary._items = list(paths)
-    dictionary._index = 0
-    dictionary._extra = []
-    dictionary._extra_index = 0
-    dictionary._claimed = []
+    dictionary.__setstate__((list(paths), 0, [], 0))
     return dictionary
 
 

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -111,11 +111,7 @@ class CancelAwareNativeBackend:
 
 def make_dictionary(paths):
     dictionary = object.__new__(Dictionary)
-    dictionary._items = list(paths)
-    dictionary._index = 0
-    dictionary._extra = []
-    dictionary._extra_index = 0
-    dictionary._claimed = []
+    dictionary.__setstate__((list(paths), 0, [], 0))
     return dictionary
 
 


### PR DESCRIPTION
## Summary

- replace the process-wide dictionary operation mutex with a lock owned by each `Dictionary`
- make dynamic path deduplication and all mutable cursor/claim operations atomic
- serialize session snapshots with reset and restore a fresh lock when loading state
- add deterministic concurrency regressions for lock isolation, duplicate additions, and snapshot consistency

## User-visible effect

Independent scans no longer block one another through the shared decorator lock. Concurrent responses can no longer enqueue the same discovered backup path multiple times, and saved sessions cannot capture a mixed pre-reset/post-reset dictionary state.

## Scope

This only changes `Dictionary` synchronization. Report, terminal, and controller locks are intentionally unchanged.

## Validation

- regression harness failed on `master` before the implementation commit
- dictionary concurrency harness: 25 repeated green runs
- focused dictionary/fuzzer suite: 25 passed
- full standard suite: 345 passed, 20 optional native skips
- full suite with the native extension: 345 passed
- `flake8 lib tests`
- `codespell lib tests native/src`
- `python -m compileall -q lib tests`