### PR TITLE
Stop HTML report parsing at EOF

### DIFF
--- a/lib/report/html_report.py
+++ b/lib/report/html_report.py
@@ -35,9 +35,10 @@ class HTMLReport(FileReportMixin, BaseReport):
 
     def parse(self, file):
         with open(file) as fh:
-            while 1:
+            while True:
                 line = fh.readline()
-                # Gotta be the worst way to parse it but I don't know a better way:P
+                if not line:
+                    raise ValueError("HTML report does not contain resources data")
                 if line.startswith("        resources: "):
                     return json.loads(line[19:-2])
 

--- a/tests/test_report_exception_handling.py
+++ b/tests/test_report_exception_handling.py
@@ -1,4 +1,5 @@
 import sqlite3
+from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -7,7 +8,22 @@ from unittest.mock import Mock, patch
 from lib.core.exceptions import FileExistsException, InvalidRawRequest
 from lib.parse.rawrequest import parse_raw
 from lib.report.csv_report import CSVReport
+from lib.report.html_report import HTMLReport
 from lib.report.sqlite_report import SQLiteReport
+
+
+class EOFGuard(StringIO):
+    def __init__(self, value):
+        super().__init__(value)
+        self.eof_reads = 0
+
+    def readline(self, *args, **kwargs):
+        line = super().readline(*args, **kwargs)
+        if not line:
+            self.eof_reads += 1
+            if self.eof_reads > 1:
+                raise AssertionError("HTML report parser read past EOF")
+        return line
 
 
 class TestReportExceptionHandling(TestCase):
@@ -28,6 +44,19 @@ class TestReportExceptionHandling(TestCase):
                 CSVReport().initiate(str(report))
 
         self.assertIsInstance(context.exception.__cause__, ValueError)
+
+    def test_html_report_validation_stops_at_end_of_malformed_file(self):
+        with TemporaryDirectory() as directory:
+            report = Path(directory, "report.html")
+            report.write_text("<html>not a dirsearch report</html>\n")
+            guarded_file = EOFGuard(report.read_text())
+
+            with patch("lib.report.html_report.open", return_value=guarded_file):
+                with self.assertRaises(FileExistsException) as context:
+                    HTMLReport().initiate(str(report))
+
+        self.assertIsInstance(context.exception.__cause__, ValueError)
+        self.assertEqual(guarded_file.eof_reads, 1)
 
     def test_sqlite_report_rejects_non_sqlite_file(self):
         with TemporaryDirectory() as directory:

--- a/tests/test_report_exception_handling.py
+++ b/tests/test_report_exception_handling.py
@@ -58,6 +58,16 @@ class TestReportExceptionHandling(TestCase):
         self.assertIsInstance(context.exception.__cause__, ValueError)
         self.assertEqual(guarded_file.eof_reads, 1)
 
+    def test_html_report_parser_preserves_generated_resources(self):
+        resources = [{"status": 200, "url": "https://example.com/admin"}]
+        html_report = HTMLReport()
+
+        with TemporaryDirectory() as directory:
+            report = Path(directory, "report.html")
+            report.write_text(html_report.generate(resources))
+
+            self.assertEqual(html_report.parse(str(report)), resources)
+
     def test_sqlite_report_rejects_non_sqlite_file(self):
         with TemporaryDirectory() as directory:
             database = Path(directory, "report.sqlite")


### PR DESCRIPTION
## Summary

- stop HTML report parsing at the first end-of-file when the embedded resources payload is missing
- preserve the existing invalid-output-file contract by raising a parse `ValueError`, which validation wraps as `FileExistsException`
- add a bounded EOF regression harness plus a valid generated-report round-trip test

## User-visible effect

Reusing a non-empty malformed HTML output file no longer hangs dirsearch indefinitely. The scan now rejects the file through the same output-file validation path used by other report formats.

## Test-first evidence

The first commit contains only the regression harness. On `master`, it fails immediately with `HTML report parser read past EOF`, proving that the parser repeatedly reads EOF without allowing the test suite to hang.

## Validation

- report exception suite: 7 passed
- full standard suite: 347 passed, 20 optional native skips
- full suite with the native extension: 347 passed
- `flake8 lib tests`
- `codespell lib tests native/src`
- `python -m compileall -q lib tests`