### PR TITLE
Add Related Projects section (Agentic Bug Bounty Hunter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ mutate CLI globals.
 See [Python API](docs/python-api.md) for examples covering templates, custom
 wordlists, callbacks, authenticated sessions, and agent-oriented scan recipes.
 
+## Related Projects
+
+- [Agentic Bug Bounty Hunter](https://github.com/Awarexone/Agentic-Bug-Hunter) - AI-powered bug bounty toolkit (Claude Code plugin) that orchestrates content-discovery tools like dirsearch alongside recon, vulnerability testing and report writing. Works with or without a subscription.
+
 ## Contributing
 
 Pull requests and feature requests are welcome. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the people who have helped improve dirsearch.


### PR DESCRIPTION
Adds a small **Related Projects** section linking **Agentic Bug Bounty Hunter**.

- Repo: https://github.com/Awarexone/Agentic-Bug-Hunter (open-source, 4.6k+ stars)
- Why here: it is an AI-driven bug bounty toolkit (Claude Code plugin) whose content-discovery workflow orchestrates dirsearch alongside recon, vuln testing and reporting. The README already notes dirsearch is used from MCP servers and agent-controlled scans, and this project is one such consumer.

Docs-only change; single section added just above Contributing. Happy to drop or reword if you would rather not link out.