### PR TITLE
Use resource-owned operation locks

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -173,6 +173,7 @@ def format_session_path(path: str) -> str:
 
 class Controller:
     def __init__(self) -> None:
+        self._operation_lock = threading.Lock()
         self._handling_pause = False
         self._force_quit_handler = _create_force_quit_handler()
         self.loop = None  # Will be set if async mode is used

--- a/lib/core/decorators.py
+++ b/lib/core/decorators.py
@@ -24,7 +24,6 @@ from functools import wraps
 from time import time
 from typing import Any, Callable, TypeVar, cast
 
-_lock = threading.Lock()
 _cache: dict[int, tuple[float, Any]] = {}
 _cache_lock = threading.Lock()
 
@@ -57,8 +56,9 @@ def cached(timeout: int | float = 100) -> Callable[[F], F]:
 
 
 def locked(func: F) -> F:
-    def with_locking(*args: Any, **kwargs: Any) -> Any:
-        with _lock:
-            return func(*args, **kwargs)
+    @wraps(func)
+    def with_locking(instance: Any, *args: Any, **kwargs: Any) -> Any:
+        with instance._operation_lock:
+            return func(instance, *args, **kwargs)
 
     return cast(F, with_locking)

--- a/lib/report/factory.py
+++ b/lib/report/factory.py
@@ -17,6 +17,7 @@
 #  Author: Mauro Soria
 
 import sqlite3
+import threading
 from abc import ABC, abstractmethod
 
 from lib.core.decorators import locked
@@ -49,6 +50,9 @@ SQL_CONNECTION_ERRORS = (
 
 
 class BaseReport(ABC):
+    def __init__(self):
+        self._operation_lock = threading.Lock()
+
     @abstractmethod
     def initiate(self):
         raise NotImplementedError

--- a/lib/view/terminal.py
+++ b/lib/view/terminal.py
@@ -18,6 +18,7 @@
 
 import sys
 import shutil
+import threading
 import unicodedata
 
 from lib.core.data import options
@@ -53,6 +54,7 @@ def safe_display_text(value, max_length=MAX_DISPLAY_TEXT_LENGTH):
 
 class CLI:
     def __init__(self):
+        self._operation_lock = threading.Lock()
         self.last_in_line = False
         self.buffer = ""
 

--- a/tests/report/test_report_locking.py
+++ b/tests/report/test_report_locking.py
@@ -1,0 +1,88 @@
+import queue
+import threading
+import time
+from types import SimpleNamespace
+from unittest import TestCase
+
+from lib.report.simple_report import SimpleReport
+
+
+TEST_TIMEOUT = 2.0
+INDEPENDENT_COMPLETION_TIMEOUT = 0.5
+
+
+def join_threads(test_case, threads):
+    deadline = time.monotonic() + TEST_TIMEOUT
+    for thread in threads:
+        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    test_case.assertFalse(
+        any(thread.is_alive() for thread in threads),
+        "report locking test leaked a worker thread",
+    )
+
+
+class MemorySimpleReport(SimpleReport):
+    def __init__(self, entered=None, release=None):
+        super().__init__()
+        self._entered = entered
+        self._release = release
+        self._blocked = False
+        self.contents = ""
+
+    def parse(self, _file):
+        if self._entered is not None and not self._blocked:
+            self._blocked = True
+            self._entered.set()
+            if not self._release.wait(timeout=TEST_TIMEOUT):
+                raise TimeoutError("test did not release blocked report")
+        return self.contents
+
+    def write(self, _file, data):
+        self.contents = data
+
+
+class TestReportLocking(TestCase):
+    def test_independent_reports_do_not_share_operation_lock(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_started = threading.Event()
+        second_finished = threading.Event()
+        errors = queue.Queue()
+        first = MemorySimpleReport(first_entered, release_first)
+        second = MemorySimpleReport()
+
+        def save(report, url, started=None, finished=None):
+            if started is not None:
+                started.set()
+            try:
+                report.save("unused", SimpleNamespace(url=url))
+            except Exception as error:
+                errors.put(error)
+            finally:
+                if finished is not None:
+                    finished.set()
+
+        first_thread = threading.Thread(target=save, args=(first, "first"))
+        second_thread = threading.Thread(
+            target=save,
+            args=(second, "second", second_started, second_finished),
+        )
+        first_thread.start()
+
+        try:
+            self.assertTrue(first_entered.wait(timeout=TEST_TIMEOUT))
+            second_thread.start()
+            self.assertTrue(second_started.wait(timeout=TEST_TIMEOUT))
+            completed_independently = second_finished.wait(
+                timeout=INDEPENDENT_COMPLETION_TIMEOUT
+            )
+        finally:
+            release_first.set()
+            join_threads(self, [first_thread, second_thread])
+
+        self.assertTrue(
+            completed_independently,
+            "an unrelated report was blocked by the process-wide lock",
+        )
+        self.assertTrue(errors.empty())
+        self.assertIn("second", second.contents)

--- a/tests/report/test_report_locking.py
+++ b/tests/report/test_report_locking.py
@@ -86,3 +86,47 @@ class TestReportLocking(TestCase):
         )
         self.assertTrue(errors.empty())
         self.assertIn("second", second.contents)
+
+    def test_same_report_keeps_operation_lock(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_started = threading.Event()
+        second_finished = threading.Event()
+        errors = queue.Queue()
+        report = MemorySimpleReport(first_entered, release_first)
+
+        def save(url, started=None, finished=None):
+            if started is not None:
+                started.set()
+            try:
+                report.save("unused", SimpleNamespace(url=url))
+            except Exception as error:
+                errors.put(error)
+            finally:
+                if finished is not None:
+                    finished.set()
+
+        first_thread = threading.Thread(target=save, args=("first",))
+        second_thread = threading.Thread(
+            target=save,
+            args=("second", second_started, second_finished),
+        )
+        first_thread.start()
+
+        try:
+            self.assertTrue(first_entered.wait(timeout=TEST_TIMEOUT))
+            second_thread.start()
+            self.assertTrue(second_started.wait(timeout=TEST_TIMEOUT))
+            completed_while_first_was_blocked = second_finished.wait(
+                timeout=INDEPENDENT_COMPLETION_TIMEOUT
+            )
+        finally:
+            release_first.set()
+            join_threads(self, [first_thread, second_thread])
+
+        self.assertFalse(
+            completed_while_first_was_blocked,
+            "writes through the same report instance were not serialized",
+        )
+        self.assertTrue(errors.empty())
+        self.assertEqual(report.contents.splitlines(), ["first", "second"])


### PR DESCRIPTION
## Summary

- replace the process-wide `@locked` mutex with locks owned by each controller, terminal interface, and report instance
- keep concurrent operations on the same resource serialized
- preserve decorated method metadata with `functools.wraps`
- add deterministic concurrency coverage for independent and shared report instances

## User-visible effect

A slow report operation no longer blocks unrelated report outputs, recursion-queue updates, or terminal output through a single global mutex. Writes through the same report object remain ordered and protected.

## Test-first evidence

The first commit contains only the bounded concurrency harness. On `master`, the independent report test fails with `an unrelated report was blocked by the process-wide lock`.

## Scope

This changes only ownership of the existing operation locks. Report formats, recursion behavior, terminal formatting, and native request behavior are unchanged.

## Validation

- focused lock and consumer suite: 19 passed
- concurrency harness: 25 repeated green runs
- full standard suite: 349 passed, 20 optional native skips
- full suite with the native extension: 349 passed
- `flake8 lib tests`
- `codespell lib tests native/src`
- `python -m compileall -q lib tests`