### PR TITLE
Crawl the target root before scanning

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -425,6 +425,7 @@ class Controller:
                     interface.target(self.url)
 
                 self.reporter.prepare(self.url)
+                self.crawl_target()
                 self.start()
 
             except (
@@ -706,6 +707,28 @@ class Controller:
         self.requester.set_url(self.url)
         self.requester.set_query(parsed.query)
 
+    def crawl_target(self) -> None:
+        if not options["crawl"]:
+            return
+
+        try:
+            if options["async_mode"]:
+                response = self.loop.run_until_complete(
+                    self.requester.request(self.base_path)
+                )
+            else:
+                response = self.requester.request(self.base_path)
+        except RequestException as error:
+            self.raise_error(error)
+            self.append_error_log(error)
+            return
+
+        self.add_crawled_paths(response)
+
+    def add_crawled_paths(self, response: BaseResponse) -> None:
+        for path in Crawler.crawl(response):
+            self.dictionary.add_extra(lstrip_once(path, self.base_path))
+
     def reset_consecutive_errors(self, response: BaseResponse) -> None:
         self.consecutive_errors = 0
 
@@ -808,9 +831,7 @@ class Controller:
                 self.requester.request(response.full_path, proxy=options["replay_proxy"])
 
         if options["crawl"]:
-            for path in Crawler.crawl(response):
-                path = lstrip_once(path, self.base_path)
-                self.dictionary.add_extra(path)
+            self.add_crawled_paths(response)
 
         if options["find_backup"]:
             path = lstrip_once(response.path, self.base_path)

--- a/tests/controller/test_root_crawl.py
+++ b/tests/controller/test_root_crawl.py
@@ -1,0 +1,135 @@
+import asyncio
+from unittest import TestCase
+from unittest.mock import AsyncMock, Mock, patch
+
+from lib.connection.response import NativeResponse
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.exceptions import RequestException
+
+
+class RecordingDictionary:
+    def __init__(self):
+        self.extra = []
+
+    def is_valid(self, path):
+        return path != "ignored"
+
+    def add_extra(self, path):
+        if not self.is_valid(path):
+            return
+
+        if path not in self.extra:
+            self.extra.append(path)
+
+
+class DummyFuzzer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def root_response():
+    return NativeResponse(
+        "https://example.test/base/",
+        200,
+        [("Content-Type", "text/html")],
+        (
+            b'<a href="/base/root-only">root-only</a>'
+            b'<a href="/base/ignored">ignored</a>'
+        ),
+    )
+
+
+def create_controller(requester):
+    controller = object.__new__(Controller)
+    controller.requester = requester
+    controller.dictionary = RecordingDictionary()
+    controller.base_path = "base/"
+    controller.raise_error = Mock()
+    controller.append_error_log = Mock()
+    return controller
+
+
+class TestRootCrawl(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_run_seeds_paths_from_target_root_before_scan(self):
+        requester = Mock()
+        requester.request.return_value = root_response()
+        controller = create_controller(requester)
+        controller.response_stores = ()
+        controller.reporter = Mock()
+        controller.directories = []
+        controller.passed_urls = set()
+        controller.old_session = True
+        controller.start = Mock()
+
+        options.update(
+            {
+                "urls": ["https://example.test/base/"],
+                "request_backend": "python",
+                "async_mode": False,
+                "subdirs": [""],
+                "exclude_subdirs": [],
+                "recursion_depth": 0,
+                "session_file": None,
+                "scheme": None,
+                "ip": None,
+                "crawl": True,
+            }
+        )
+
+        with (
+            patch("lib.connection.requester.Requester", return_value=requester),
+            patch("lib.core.fuzzer.Fuzzer", DummyFuzzer),
+            patch("lib.controller.controller.signal.signal"),
+            patch("lib.controller.controller.interface"),
+        ):
+            controller.run()
+
+        requester.request.assert_called_once_with("base/")
+        self.assertEqual(controller.dictionary.extra, ["root-only"])
+        controller.start.assert_called_once_with()
+
+    def test_async_root_request_is_awaited(self):
+        requester = Mock()
+        requester.request = AsyncMock(return_value=root_response())
+        controller = create_controller(requester)
+        controller.loop = asyncio.new_event_loop()
+
+        try:
+            with patch.dict(options, {"async_mode": True, "crawl": True}):
+                controller.crawl_target()
+        finally:
+            controller.loop.close()
+
+        requester.request.assert_awaited_once_with("base/")
+        self.assertEqual(controller.dictionary.extra, ["root-only"])
+
+    def test_disabled_crawl_does_not_request_target_root(self):
+        requester = Mock()
+        controller = create_controller(requester)
+
+        with patch.dict(options, {"async_mode": False, "crawl": False}):
+            controller.crawl_target()
+
+        requester.request.assert_not_called()
+        self.assertEqual(controller.dictionary.extra, [])
+
+    def test_root_request_failure_uses_scan_error_callbacks(self):
+        error = RequestException("root request failed")
+        requester = Mock()
+        requester.request.side_effect = error
+        controller = create_controller(requester)
+
+        with patch.dict(options, {"async_mode": False, "crawl": True}):
+            controller.crawl_target()
+
+        controller.raise_error.assert_called_once_with(error)
+        controller.append_error_log.assert_called_once_with(error)
+        self.assertEqual(controller.dictionary.extra, [])


### PR DESCRIPTION
## Summary

- fetch the configured target base path once before fuzzing when `--crawl` is enabled
- feed root-page discoveries through the same normalization and dynamic dictionary validation used for matched responses
- await the async requester while retaining the synchronous path used by threaded and native scans

Fixes #1219

## User-visible effect

Paths linked only from the target root are now scanned. This also lets crawling seed work when the supplied wordlist contains no useful match, without reporting the root response as a discovered result or bypassing wildcard filtering.

## Test-first evidence

Commit `4936550` adds the regression harness first. On `origin/master`, it fails because the root requester is never called and the controller has no root-crawl operation. Commit `9c970c3` implements the fix.

## Validation

- `python -m unittest tests.controller.test_root_crawl`
- `python -m unittest discover -s tests -t .` (353 tests, 20 expected skips)
- native-enabled `python -m unittest discover -s tests -t .` (353 tests)
- `python testing.py` (353 tests, 20 expected skips)
- `flake8 .`
- `codespell -S CONTRIBUTORS.md,./db/categories/*,./build`
- `python -m compileall -q dirsearch.py lib tests`
- local end-to-end root-only discovery in async, sync, and native modes
