### PR TITLE
Stop retaining crawled response bodies

### DIFF
--- a/lib/utils/crawl.py
+++ b/lib/utils/crawl.py
@@ -19,7 +19,6 @@
 import re
 
 from bs4 import BeautifulSoup
-from functools import lru_cache
 
 from lib.core.settings import (
     CRAWL_ATTRIBUTES, CRAWL_TAGS,
@@ -47,7 +46,6 @@ class Crawler:
             return cls.text_crawl(response.url, scope, response.content)
 
     @staticmethod
-    @lru_cache(maxsize=None)
     def text_crawl(url, scope, content):
         results = []
         regex = re.escape(scope) + "[a-zA-Z0-9-._~!$&*+,;=:@?%]+"
@@ -58,7 +56,6 @@ class Crawler:
         return _filter(results)
 
     @staticmethod
-    @lru_cache(maxsize=None)
     def html_crawl(url, scope, content):
         results = []
         soup = BeautifulSoup(content, 'html.parser')
@@ -82,6 +79,5 @@ class Crawler:
         return _filter(results)
 
     @staticmethod
-    @lru_cache(maxsize=None)
     def robots_crawl(url, scope, content):
         return _filter(re.findall(ROBOTS_TXT_REGEX, content))

--- a/tests/utils/test_crawl.py
+++ b/tests/utils/test_crawl.py
@@ -16,13 +16,35 @@
 #
 #  Author: Mauro Soria
 
+import gc
+import weakref
 from unittest import TestCase
 
 from lib.core.settings import DUMMY_URL
 from lib.utils.crawl import Crawler
 
 
+class WeakText(str):
+    pass
+
+
 class TestCrawl(TestCase):
+    def assert_body_is_released(self, parser, body):
+        clear_cache = getattr(parser, "cache_clear", None)
+        if clear_cache:
+            clear_cache()
+
+        content = WeakText(body)
+        reference = weakref.ref(content)
+        try:
+            parser(DUMMY_URL, DUMMY_URL, content)
+            del content
+            gc.collect()
+            self.assertIsNone(reference())
+        finally:
+            if clear_cache:
+                clear_cache()
+
     def test_text_crawl(self):
         html_doc = f'Link: {DUMMY_URL}foobar'
         self.assertEqual(Crawler.text_crawl(DUMMY_URL, DUMMY_URL, html_doc), {"foobar"})
@@ -56,3 +78,21 @@ Disallow: /path1
 User-agent: *
         Allow: /path2"""
         self.assertEqual(Crawler.robots_crawl(DUMMY_URL, DUMMY_URL, robots_txt), {"path1", "path2"})
+
+    def test_text_crawl_releases_response_body(self):
+        self.assert_body_is_released(
+            Crawler.text_crawl,
+            f"Link: {DUMMY_URL}text-retention-check",
+        )
+
+    def test_html_crawl_releases_response_body(self):
+        self.assert_body_is_released(
+            Crawler.html_crawl,
+            '<a href="/html-retention-check">link</a>',
+        )
+
+    def test_robots_crawl_releases_response_body(self):
+        self.assert_body_is_released(
+            Crawler.robots_crawl,
+            "Allow: /robots-retention-check",
+        )


### PR DESCRIPTION
## Summary

- remove unlimited memoization from the HTML, text, and robots crawl parsers
- allow response bodies to be reclaimed after each parser call
- preserve existing path extraction and media filtering behavior

## User-visible effect

Long `--crawl` scans no longer keep every unique crawled response body alive for the lifetime of the process. The removed cache was keyed by URL, scope, and full content, while scan responses are normally unique, so it grew continuously without useful reuse.

## Test-first evidence

Commit `522b26d` adds weak-reference regression coverage first. On `origin/master`, all three cases fail because each parser's unlimited cache retains the supplied response body. Commit `abaf251` removes only those cache decorators and the unused import.

## Validation

- `python -m unittest tests.utils.test_crawl` (8 tests)
- `python -m unittest discover -s tests -t .` (356 tests, 20 expected skips)
- native-enabled `python -m unittest discover -s tests -t .` (356 tests)
- `python testing.py` (356 tests, 20 expected skips)
- `flake8 .`
- `codespell -S CONTRIBUTORS.md,./db/categories/*,./build`
- `python -m compileall -q dirsearch.py lib tests`
