### PR TITLE
Harden URL extraction from text responses

### DIFF
--- a/lib/utils/crawl.py
+++ b/lib/utils/crawl.py
@@ -17,6 +17,7 @@
 #  Author: Mauro Soria
 
 import re
+import string
 
 from bs4 import BeautifulSoup
 
@@ -29,8 +30,63 @@ from lib.parse.url import clean_path, parse_path
 from lib.utils.common import merge_path
 
 
+_ESCAPED_SLASH_REGEX = re.compile(r"\\(?:/|u002f|x2f)", re.IGNORECASE)
+_MEDIA_SUFFIXES = tuple(f".{extension}" for extension in MEDIA_EXTENSIONS)
+# RFC 3986 URI characters plus brackets used by common array query syntax.
+_TEXT_URL_CHARS = frozenset(
+    string.ascii_letters + string.digits + "-._~%!$&'()*+,;=:@/?#[]"
+)
+_TEXT_URL_QUOTES = frozenset("\"'`")
+
+
 def _filter(paths):
-    return {clean_path(path, keep_queries=True) for path in paths if not path.endswith(MEDIA_EXTENSIONS)}
+    results = set()
+
+    for path in paths:
+        path = clean_path(path, keep_queries=True)
+        resource_path = path.split("?", 1)[0]
+
+        if not path or resource_path.lower().endswith(_MEDIA_SUFFIXES):
+            continue
+
+        results.add(path)
+
+    return results
+
+
+def _trim_unquoted_url(path):
+    path = path.rstrip(".,")
+
+    for opening, closing in (("(", ")"), ("[", "]")):
+        excess = max(0, path.count(closing) - path.count(opening))
+        trailing = len(path) - len(path.rstrip(closing))
+        trim_count = min(excess, trailing)
+        if trim_count:
+            path = path[:-trim_count]
+
+    return path
+
+
+def _extract_scoped_paths(scope, content):
+    content = _ESCAPED_SLASH_REGEX.sub("/", content)
+    scope_regex = re.compile(re.escape(scope), re.IGNORECASE)
+
+    for match in scope_regex.finditer(content):
+        preceding = content[match.start() - 1] if match.start() else ""
+        quote = preceding if preceding in _TEXT_URL_QUOTES else None
+        path = []
+
+        for char in content[match.end():]:
+            if char == quote or char not in _TEXT_URL_CHARS:
+                break
+            path.append(char)
+
+        path = "".join(path)
+        if quote is None:
+            path = _trim_unquoted_url(path)
+
+        if path:
+            yield path
 
 
 class Crawler:
@@ -47,13 +103,7 @@ class Crawler:
 
     @staticmethod
     def text_crawl(url, scope, content):
-        results = []
-        regex = re.escape(scope) + "[a-zA-Z0-9-._~!$&*+,;=:@?%/]+"
-
-        for match in re.findall(regex, content):
-            results.append(match[len(scope):])
-
-        return _filter(results)
+        return _filter(_extract_scoped_paths(scope, content))
 
     @staticmethod
     def html_crawl(url, scope, content):

--- a/lib/utils/crawl.py
+++ b/lib/utils/crawl.py
@@ -48,7 +48,7 @@ class Crawler:
     @staticmethod
     def text_crawl(url, scope, content):
         results = []
-        regex = re.escape(scope) + "[a-zA-Z0-9-._~!$&*+,;=:@?%]+"
+        regex = re.escape(scope) + "[a-zA-Z0-9-._~!$&*+,;=:@?%/]+"
 
         for match in re.findall(regex, content):
             results.append(match[len(scope):])

--- a/tests/utils/test_crawl.py
+++ b/tests/utils/test_crawl.py
@@ -49,6 +49,17 @@ class TestCrawl(TestCase):
         html_doc = f'Link: {DUMMY_URL}foobar'
         self.assertEqual(Crawler.text_crawl(DUMMY_URL, DUMMY_URL, html_doc), {"foobar"})
 
+    def test_text_crawl_preserves_nested_paths(self):
+        text_doc = (
+            f"Links: {DUMMY_URL}api/v1/users?next=/dashboard "
+            f"{DUMMY_URL}public/scripts/"
+        )
+
+        self.assertEqual(
+            Crawler.text_crawl(DUMMY_URL, DUMMY_URL, text_doc),
+            {"api/v1/users?next=/dashboard", "public/scripts/"},
+        )
+
     def test_html_crawl(self):
         html_doc = f'<a href="{DUMMY_URL}foo">link</a><script src="/bar.js"><img src="/bar.png">'
         self.assertEqual(Crawler.html_crawl(DUMMY_URL, DUMMY_URL, html_doc), {"foo", "bar.js"})

--- a/tests/utils/test_crawl.py
+++ b/tests/utils/test_crawl.py
@@ -49,15 +49,100 @@ class TestCrawl(TestCase):
         html_doc = f'Link: {DUMMY_URL}foobar'
         self.assertEqual(Crawler.text_crawl(DUMMY_URL, DUMMY_URL, html_doc), {"foobar"})
 
-    def test_text_crawl_preserves_nested_paths(self):
+    def test_text_crawl_preserves_url_components(self):
+        paths = (
+            "api/v1/users?next=/dashboard",
+            "public/scripts/",
+            "catalog;view=full/items:latest@v2?filter[status]=active",
+            "reports/Ben's_(final)/view?format=csv",
+            "search/%E2%9C%93?q=one%20two&next=/account?tab=keys",
+            "?page=2&next=/dashboard",
+        )
+
+        for path in paths:
+            with self.subTest(path=path):
+                text_doc = f'const endpoint = "{DUMMY_URL}{path}";'
+
+                self.assertEqual(
+                    Crawler.text_crawl(DUMMY_URL, DUMMY_URL, text_doc),
+                    {path},
+                )
+
+    def test_text_crawl_handles_serialized_url_forms(self):
+        cases = (
+            (
+                'JSON escaped solidus',
+                r'const endpoint = "https:\/\/example.com\/api\/v1\/users";',
+                "api/v1/users",
+            ),
+            (
+                'JavaScript Unicode escape',
+                r'const endpoint = "https:\u002F\u002Fexample.com\u002Fgraphql\u002Fv2";',
+                "graphql/v2",
+            ),
+            (
+                'JavaScript hexadecimal escape',
+                r'const endpoint = "https:\x2f\x2fexample.com\x2fassets\x2fapp.js";',
+                "assets/app.js",
+            ),
+            (
+                "case-insensitive origin",
+                'const endpoint = "HTTPS://EXAMPLE.COM/Admin/Users";',
+                "Admin/Users",
+            ),
+        )
+
+        for name, text_doc, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    Crawler.text_crawl(DUMMY_URL, DUMMY_URL, text_doc),
+                    {expected},
+                )
+
+    def test_text_crawl_respects_context_delimiters(self):
         text_doc = (
-            f"Links: {DUMMY_URL}api/v1/users?next=/dashboard "
-            f"{DUMMY_URL}public/scripts/"
+            f'quoted = "{DUMMY_URL}api/search?q=one,two"; '
+            f"fetch('{DUMMY_URL}api/health'); "
+            f"angle = <{DUMMY_URL}docs/start>; "
+            f"See ({DUMMY_URL}docs/(draft)). "
+            f"Then visit {DUMMY_URL}account/profile, and continue."
         )
 
         self.assertEqual(
             Crawler.text_crawl(DUMMY_URL, DUMMY_URL, text_doc),
-            {"api/v1/users?next=/dashboard", "public/scripts/"},
+            {
+                "account/profile",
+                "api/health",
+                "api/search?q=one,two",
+                "docs/(draft)",
+                "docs/start",
+            },
+        )
+
+    def test_text_crawl_keeps_scope_and_fragment_boundaries(self):
+        text_doc = (
+            f"{DUMMY_URL}api/health#readiness "
+            f"{DUMMY_URL}api/health#liveness "
+            f"{DUMMY_URL}#overview "
+            "http://example.com/wrong-scheme "
+            "https://example.com.evil.test/lookalike "
+            "https://other.example/api/external"
+        )
+
+        self.assertEqual(
+            Crawler.text_crawl(DUMMY_URL, DUMMY_URL, text_doc),
+            {"api/health"},
+        )
+
+    def test_text_crawl_filters_media_paths_not_route_suffixes(self):
+        text_doc = (
+            f'route = "{DUMMY_URL}api/generatepdf"; '
+            f'image = "{DUMMY_URL}assets/LOGO.PNG?v=2#hero";'
+        )
+
+        self.assertEqual(
+            Crawler.text_crawl(DUMMY_URL, DUMMY_URL, text_doc),
+            {"api/generatepdf"},
         )
 
     def test_html_crawl(self):


### PR DESCRIPTION
## Summary

- preserve complete nested paths, RFC-style path/query characters, bracketed query keys, percent-encoding, and trailing directory slashes
- recognize target origins case-insensitively and decode common JSON/JavaScript slash encodings (`\/`, `\u002F`, and `\x2F`)
- respect quotes, angle brackets, balanced parentheses, fragments, and prose punctuation when identifying URL boundaries
- filter media using the actual case-insensitive file extension before query/fragment data, without dropping extensionless routes such as `generatepdf`
- keep extraction restricted to absolute URLs under the configured target origin

## User-visible effect

`--crawl` can now queue realistic same-origin URLs found in JavaScript, JSON, CSS, and other text responses without truncating path/query components or turning surrounding punctuation into request paths. Serialized URLs such as `https:\/\/example.com\/api\/v1` are recognized, while look-alike external origins and media assets remain excluded.

## Test-first evidence

- `3945a97` adds the original nested-path regression. On `origin/master`, `api/v1/users?next=/dashboard` became `api`.
- `04932f9` expands the harness before the broader implementation. On the prior one-character fix it produced eight independent failures: bracketed queries, valid apostrophes/parentheses, three serialized slash forms, case-insensitive origins, context punctuation, and media-extension boundaries.
- `feef1d4` and `9dce352` contain the corresponding implementation changes.

The final crawler suite covers deep REST routes, matrix parameters, array-style query keys, percent-encoded values, queries containing `/` and `?`, RFC sub-delimiters, quoted/angle/parenthesized/plain-text contexts, fragments and deduplication, origin look-alikes, serialized JavaScript/JSON URLs, and media URLs with queries.

## Research basis

- RFC 3986 path/query grammar and sub-delimiters: https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
- RFC 3986 plain-text URI boundaries: https://datatracker.ietf.org/doc/html/rfc3986#appendix-C
- Katana endpoint regexes and fixtures: https://github.com/projectdiscovery/katana/blob/e3e742739c3746f085943ce918fb4e2b8daf6fe6/pkg/utils/regex.go
- LinkFinder endpoint grammar and fixtures: https://github.com/GerbenJavado/LinkFinder/blob/1debac5dace4724fd6187c06f133578dae51c86f/linkfinder.py
- Gospider escaped-JavaScript URL fixture: https://github.com/jaeles-project/gospider/blob/f6cc9a78d709e088e55ce62e5e92ab063f1a184b/core/linkfinder_test.go
- Google Security Crawl Maze JavaScript URL cases: https://github.com/google/security-crawl-maze/tree/2a0dd0a75e39925ded887bcd25016e8b3ce0f2b3/test-cases/javascript

Relative JavaScript endpoints and framework-generated routes are intentionally not added here. Supporting those safely requires a separate extraction policy and coverage for inline HTML scripts, relative resolution, and false-positive control.

## Validation

- `python -m unittest tests.utils.test_crawl` (13 tests)
- `python -m unittest discover -s tests -t .` (361 tests, 20 expected skips)
- native-enabled `python -m unittest discover -s tests -t .` (361 tests)
- `python testing.py` (361 tests, 20 expected skips)
- `flake8 .`
- `codespell -S CONTRIBUTORS.md,./db/categories/*,./build`
- `python -m compileall -q dirsearch.py lib tests`
- local end-to-end discovery in async, sync, and native modes, including serialized URLs and media exclusion
