### PR TITLE
Preserve unrelated files during session cleanup

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import asyncio
 import gc
 import os
-import shutil
 import signal
 import sys
 import re
@@ -455,10 +454,7 @@ class Controller:
 
         if options["session_file"]:
             try:
-                if os.path.isdir(options["session_file"]):
-                    shutil.rmtree(options["session_file"])
-                else:
-                    os.remove(options["session_file"])
+                SessionStore(options).delete(options["session_file"])
             except OSError:
                 interface.error("Failed to delete old session file, remove it to free some space")
 

--- a/lib/controller/session.py
+++ b/lib/controller/session.py
@@ -156,6 +156,21 @@ class SessionStore:
             payload["options"],
         )
 
+    def delete(self, session_path: str) -> None:
+        """Delete session-owned files without removing unrelated entries."""
+        if os.path.islink(session_path) or not os.path.isdir(session_path):
+            os.remove(session_path)
+            return
+
+        for file_name in self.FILES.values():
+            try:
+                os.remove(FileUtils.build_path(session_path, file_name))
+            except FileNotFoundError:
+                pass
+
+        if not os.listdir(session_path):
+            os.rmdir(session_path)
+
     def apply_to_controller(self, controller: Any, payload: dict[str, Any]) -> None:
         controller_state = payload["controller"]
         controller.start_time = controller_state["start_time"]

--- a/tests/controller/test_session_cleanup.py
+++ b/tests/controller/test_session_cleanup.py
@@ -1,0 +1,92 @@
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from lib.controller.controller import Controller
+from lib.controller.session import SessionStore
+from lib.core.data import options
+
+
+class DummyFuzzer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class TestSessionCleanup(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def _complete_scan(self, session_path):
+        controller = object.__new__(Controller)
+        controller.response_stores = ()
+        controller.reporter = Mock()
+        controller.dictionary = Mock()
+        controller.directories = []
+        controller.base_path = ""
+        controller.old_session = True
+        controller.url = "https://example.test/"
+        controller.set_target = Mock()
+        controller.crawl_target = Mock()
+        controller.start = Mock()
+
+        options.update(
+            {
+                "urls": ["https://example.test/"],
+                "request_backend": "python",
+                "async_mode": False,
+                "subdirs": [],
+                "session_file": session_path,
+            }
+        )
+
+        with (
+            patch("lib.connection.requester.Requester", return_value=Mock()),
+            patch("lib.core.fuzzer.Fuzzer", DummyFuzzer),
+            patch("lib.controller.controller.signal.signal"),
+            patch("lib.controller.controller.interface"),
+        ):
+            controller.run()
+
+    def test_completed_session_preserves_unrelated_directory_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_dir = os.path.join(tmpdir, "session")
+            os.makedirs(session_dir)
+            for file_name in SessionStore.FILES.values():
+                with open(os.path.join(session_dir, file_name), "w", encoding="utf-8"):
+                    pass
+            unrelated_path = os.path.join(session_dir, "keep.txt")
+            with open(unrelated_path, "w", encoding="utf-8") as file_handle:
+                file_handle.write("unrelated")
+
+            self._complete_scan(session_dir)
+
+            self.assertTrue(os.path.isfile(unrelated_path))
+            for file_name in SessionStore.FILES.values():
+                self.assertFalse(os.path.exists(os.path.join(session_dir, file_name)))
+
+    def test_completed_session_removes_empty_owned_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_dir = os.path.join(tmpdir, "session")
+            os.makedirs(session_dir)
+            for file_name in SessionStore.FILES.values():
+                with open(os.path.join(session_dir, file_name), "w", encoding="utf-8"):
+                    pass
+
+            self._complete_scan(session_dir)
+
+            self.assertFalse(os.path.exists(session_dir))
+
+    def test_completed_legacy_session_removes_single_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_file = os.path.join(tmpdir, "session.json")
+            with open(session_file, "w", encoding="utf-8"):
+                pass
+
+            self._complete_scan(session_file)
+
+            self.assertFalse(os.path.exists(session_file))


### PR DESCRIPTION
Description
---------------

Completing a directory-backed session currently removes the entire session directory recursively. If the session was saved in a pre-existing directory, that also deletes files that dirsearch did not create.

This change moves cleanup into SessionStore so it owns the deletion boundary. Directory-backed sessions now remove only meta.json, controller.json, dictionary.json, and options.json, then remove the directory only when it is empty. Legacy single-file sessions keep their existing cleanup behavior, and directory symlinks are unlinked without following them.

Regression coverage exercises the completed-scan lifecycle and verifies that:

- unrelated directory entries survive;
- an otherwise empty session directory is still removed;
- legacy single-file sessions are still removed.

Testing
---------------

- python -m unittest -v tests.controller.test_session_cleanup tests.controller.test_session_store
- python -m unittest discover -s tests -t . (364 passed, 20 skipped)
- flake8 .
- codespell -S CONTRIBUTORS.md,./db/categories/*,./build
- python -m pip install --force-reinstall --no-deps .
- dirsearch --version
- python tests/check_packaged_install.py

Requirements
---------------

- [x] No new feature or changelog entry required
- [x] No private infrastructure details are included
