### PR TITLE
Parse embedded target credentials safely

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -29,7 +29,7 @@ import time
 from types import SimpleNamespace
 from typing import Any
 
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from lib.connection.response import BaseResponse
 from lib.core.data import blacklists, options
@@ -655,9 +655,11 @@ class Controller:
         self.base_path = lstrip_once(parsed.path, "/")
 
         # Credentials in URL
-        if "@" in parsed.netloc:
-            cred, parsed.netloc = parsed.netloc.split("@")
-            self.requester.set_auth("basic", cred)
+        if parsed.username is not None:
+            credential = unquote(parsed.username)
+            if parsed.password is not None:
+                credential += f":{unquote(parsed.password)}"
+            self.requester.set_auth("basic", credential)
 
         if parsed.scheme not in (UNKNOWN, "https", "http"):
             raise InvalidURLException(f"Unsupported URI scheme: {parsed.scheme}")

--- a/tests/controller/test_target_credentials.py
+++ b/tests/controller/test_target_credentials.py
@@ -1,0 +1,81 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+
+
+class TestControllerTargetCredentials(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "request_backend": "python",
+                "scheme": None,
+                "ip": None,
+            }
+        )
+        self.controller = object.__new__(Controller)
+        self.controller.requester = Mock()
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_embedded_basic_credentials_are_parsed_and_decoded(self):
+        cases = (
+            ("http://user:pass@example.test/", "user:pass"),
+            (
+                "http://user%40name:p%40ss%3Aword@example.test/",
+                "user@name:p@ss:word",
+            ),
+            ("http://user:p@ss@example.test/", "user:p@ss"),
+            ("http://user@example.test/", "user"),
+            ("http://:pass@example.test/", ":pass"),
+        )
+
+        for target, credential in cases:
+            with self.subTest(target=target):
+                self.controller.requester.reset_mock()
+
+                self.controller.set_target(target)
+
+                self.controller.requester.set_auth.assert_called_once_with(
+                    "basic", credential
+                )
+                self.controller.requester.set_url.assert_called_once_with(
+                    "http://example.test/"
+                )
+
+    def test_target_path_and_query_survive_credential_removal(self):
+        self.controller.set_target(
+            "https://user:pass@example.test/private?debug=true"
+        )
+
+        self.assertEqual(self.controller.base_path, "private/")
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://example.test/"
+        )
+        self.controller.requester.set_query.assert_called_once_with("debug=true")
+
+    def test_scheme_less_target_supports_embedded_credentials(self):
+        with patch(
+            "lib.controller.controller.detect_scheme",
+            side_effect=(ValueError, "https"),
+        ):
+            self.controller.set_target("user:p%40ss@example.test")
+
+        self.controller.requester.set_auth.assert_called_once_with(
+            "basic", "user:p@ss"
+        )
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://example.test/"
+        )
+
+    def test_target_without_credentials_does_not_override_authentication(self):
+        self.controller.set_target("https://example.test/")
+
+        self.controller.requester.set_auth.assert_not_called()
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://example.test/"
+        )


### PR DESCRIPTION
Description
---------------

Python request backends crash while preparing targets that contain embedded Basic authentication credentials. The controller tries to assign to the immutable ParseResult.netloc field, and credentials containing another literal at-sign also fail because the netloc is split without a limit.

This change reads username and password through urllib's parsed userinfo fields, percent-decodes them, and passes the resulting credential to the requester without retaining it in the sanitized target URL.

The existing behavior remains otherwise unchanged:

- URL credentials still select Basic authentication for Python sync and async requesters;
- username-only and empty-username credentials remain supported;
- target paths and queries survive credential removal;
- native mode retains its explicit preflight rejection for embedded credentials.

Regression coverage includes ordinary credentials, percent-encoded delimiters, literal at-signs in passwords, username-only credentials, empty usernames, scheme-less targets, path/query preservation, and targets without credentials.

Testing
---------------

- python -m unittest -v tests.controller.test_target_credentials tests.controller.test_target_dns tests.core.test_request_backend
- python -m unittest discover -s tests -t . (368 passed, 20 skipped)
- Local HTTP integration harness for sync and async Authorization headers (19 authenticated requests in each mode)
- flake8 .
- codespell -S CONTRIBUTORS.md,./db/categories/*,./build
- python -m pip install --force-reinstall --no-deps .
- dirsearch --version
- python tests/check_packaged_install.py

Requirements
---------------

- [x] No new feature or changelog entry required
- [x] No private infrastructure details are included
