### PR TITLE
Preserve data-file request bodies

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -187,7 +187,7 @@ Options:
                         Request backend: python, native (default: python)
     -d DATA, --data=DATA
                         HTTP request data
-    --data-file=PATH    File contains HTTP request data
+    --data-file=PATH    File containing raw HTTP request body bytes
     -H HEADERS, --header=HEADERS
                         HTTP request header, can use multiple flags
     --headers-file=PATH

--- a/docs/options.md
+++ b/docs/options.md
@@ -187,7 +187,8 @@ Options:
                         Request backend: python, native (default: python)
     -d DATA, --data=DATA
                         HTTP request data
-    --data-file=PATH    File containing raw HTTP request body bytes
+    --data-file=PATH    Read request body from file without encoding or newline
+                        conversion
     -H HEADERS, --header=HEADERS
                         HTTP request header, can use multiple flags
     --headers-file=PATH

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,6 +139,33 @@ python3 dirsearch.py -u https://target --filter-header "x-cache: fallback"
 python3 dirsearch.py -u https://target --match-header-regex "etag: W/.+"
 ```
 
+## Request Bodies
+
+For a short request body, pass it directly:
+
+```sh
+python3 dirsearch.py -u https://target -m POST -d "username=admin&active=true"
+```
+
+For a saved or multiline body, use `--data-file`:
+
+```sh
+python3 dirsearch.py -u https://target -m POST --data-file body.txt
+```
+
+dirsearch sends the file exactly as saved. ASCII, UTF-8, Windows-encoded files,
+CRLF, LF, mixed line endings, and a final newline require no dirsearch-specific
+conversion option. If the server requires an explicit character set, declare it
+in the content type:
+
+```sh
+python3 dirsearch.py -u https://target -m POST --data-file body.txt \
+  -H "Content-Type: application/x-www-form-urlencoded; charset=windows-1252"
+```
+
+Use `--data-file` for a body only. Use `--raw request.txt` when the file contains
+the complete HTTP request line, headers, and body.
+
 ## Raw Requests
 
 dirsearch can import a raw request from a file:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -728,7 +728,7 @@ class AsyncRequester(BaseRequester):
                     options["http_method"],
                     url,
                     headers=self.headers,
-                    data=options["data"],
+                    content=options["data"],
                     extensions={
                         "target": (
                             url

--- a/lib/controller/session.py
+++ b/lib/controller/session.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import os
 from typing import Any
@@ -31,6 +33,7 @@ from lib.view.terminal import interface
 
 class SessionStore:
     SESSION_VERSION = 1
+    SESSION_BYTES_MARKER = "__dirsearch_bytes_b64__"
     SESSION_OPTION_SET_KEYS = {
         "recursion_status_codes",
         "include_status_codes",
@@ -211,6 +214,20 @@ class SessionStore:
                 restored[key] = set(value)
             elif key in self.SESSION_OPTION_TUPLE_KEYS and value is not None:
                 restored[key] = tuple(value)
+            elif (
+                key == "data"
+                and isinstance(value, dict)
+                and set(value) == {self.SESSION_BYTES_MARKER}
+            ):
+                try:
+                    restored[key] = base64.b64decode(
+                        value[self.SESSION_BYTES_MARKER],
+                        validate=True,
+                    )
+                except (binascii.Error, TypeError, ValueError) as error:
+                    raise UnpicklingError(
+                        f"Invalid binary session option: {key}"
+                    ) from error
             else:
                 restored[key] = value
         return restored
@@ -240,7 +257,11 @@ class SessionStore:
     def _serialize_options(self) -> dict[str, Any]:
         serialized: dict[str, Any] = {}
         for key, value in self.options.items():
-            if isinstance(value, (set, tuple)):
+            if key == "data" and isinstance(value, bytes):
+                serialized[key] = {
+                    self.SESSION_BYTES_MARKER: base64.b64encode(value).decode("ascii")
+                }
+            elif isinstance(value, (set, tuple)):
                 serialized[key] = list(value)
             else:
                 serialized[key] = value

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -206,10 +206,7 @@ def parse_options() -> dict[str, Any]:
 
     if opt.data_file:
         fd = _access_file(opt.data_file)
-        with open(
-            fd.path, "r", encoding="utf-8", errors="replace", newline=""
-        ) as data_file:
-            opt.data = data_file.read()
+        opt.data = FileUtils.read_bytes(fd.path)
 
     if opt.cert_file:
         _access_file(opt.cert_file)

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -206,7 +206,10 @@ def parse_options() -> dict[str, Any]:
 
     if opt.data_file:
         fd = _access_file(opt.data_file)
-        opt.data = fd.get_lines()
+        with open(
+            fd.path, "r", encoding="utf-8", errors="replace", newline=""
+        ) as data_file:
+            opt.data = data_file.read()
 
     if opt.cert_file:
         _access_file(opt.cert_file)

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -708,7 +708,7 @@ def parse_arguments(arguments: list[str] | None = None) -> Values:
         action="store",
         dest="data_file",
         metavar="PATH",
-        help="File contains HTTP request data"
+        help="File containing raw HTTP request body bytes"
     )
     request.add_option(
         "-H",

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -708,7 +708,7 @@ def parse_arguments(arguments: list[str] | None = None) -> Values:
         action="store",
         dest="data_file",
         metavar="PATH",
-        help="File containing raw HTTP request body bytes"
+        help="Read request body from file without encoding or newline conversion"
     )
     request.add_option(
         "-H",

--- a/lib/utils/mimetype.py
+++ b/lib/utils/mimetype.py
@@ -36,7 +36,7 @@ class MimeTypeUtils:
         try:
             json.loads(content)
             return True
-        except json.decoder.JSONDecodeError:
+        except (json.decoder.JSONDecodeError, UnicodeDecodeError):
             return False
 
     @staticmethod

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -98,6 +98,11 @@ ENCODED_RESPONSES_BY_TARGET = {
     f"/{path}".encode(): (charset, body, gzip.compress(body, mtime=0))
     for path, charset, body in ENCODED_RESPONSE_CASES
 }
+REQUEST_BODY_CASES = (
+    ("ascii", b"name=plain&line=two\r\n"),
+    ("utf-8", "value=\u00e9&city=\u6771\u4eac\r\n".encode("utf-8")),
+    ("windows-1252", "value=\u00e9&currency=\u20ac\r\n".encode("cp1252")),
+)
 
 
 class RequestTargetTCPServer(socketserver.TCPServer):
@@ -105,6 +110,11 @@ class RequestTargetTCPServer(socketserver.TCPServer):
 
 
 class RequestTargetHandler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers.get("content-length", "0"))
+        self.server.request_bodies.append(self.rfile.read(content_length))
+        self.do_GET()
+
     def do_GET(self):
         target = self.raw_requestline.split(b" ")[1]
         self.server.targets.append(target)
@@ -147,6 +157,7 @@ class RequestTargetServer:
         self.server = RequestTargetTCPServer(("127.0.0.1", 0), RequestTargetHandler)
         self.server.targets = []
         self.server.proxy_authorizations = []
+        self.server.request_bodies = []
         self.thread = threading.Thread(
             target=lambda: self.server.serve_forever(poll_interval=0.05),
             daemon=True,
@@ -171,6 +182,10 @@ class RequestTargetServer:
     @property
     def proxy_authorizations(self):
         return self.server.proxy_authorizations
+
+    @property
+    def request_bodies(self):
+        return self.server.request_bodies
 
 
 def normalize_percent_hex(target: bytes) -> bytes:
@@ -578,6 +593,27 @@ class TestRequesterPathPreservation(BaseRequesterTestCase):
             self.assertEqual(server.targets, [b"/admin?debug=true"])
 
 
+class TestRequesterBodyPreservation(BaseRequesterTestCase):
+    def test_sync_requester_preserves_data_file_encodings(self):
+        options["http_method"] = "POST"
+
+        with RequestTargetServer() as server:
+            for name, body in REQUEST_BODY_CASES:
+                with self.subTest(encoding=name):
+                    options["data"] = body
+                    requester = Requester()
+                    requester.set_url(server.url)
+                    try:
+                        requester.request(name)
+                    finally:
+                        requester.close()
+
+        self.assertEqual(
+            server.request_bodies,
+            [body for _, body in REQUEST_BODY_CASES],
+        )
+
+
 class TestRequesterProxyRouting(BaseRequesterTestCase):
     def test_proxy_scheme_never_bypasses_target_scheme(self):
         for proxy_scheme in ("http", "https"):
@@ -796,6 +832,39 @@ class TestAsyncRequesterPathPreservation(BaseRequesterTestCase, IsolatedAsyncioT
                 await requester.session.aclose()
 
             self.assertEqual(server.targets, [b"/admin?debug=true"])
+
+    async def test_async_requester_preserves_data_file_encodings(self):
+        options["http_method"] = "POST"
+
+        with RequestTargetServer() as server:
+            for name, body in REQUEST_BODY_CASES:
+                with self.subTest(encoding=name):
+                    options["data"] = body
+                    requester = AsyncRequester()
+                    requester.set_url(server.url)
+                    try:
+                        await requester.request(name)
+                    finally:
+                        await requester.close()
+
+        self.assertEqual(
+            server.request_bodies,
+            [body for _, body in REQUEST_BODY_CASES],
+        )
+
+    async def test_async_requester_preserves_inline_unicode_text(self):
+        options["http_method"] = "POST"
+        options["data"] = "value=\u00e9"
+
+        with RequestTargetServer() as server:
+            requester = AsyncRequester()
+            requester.set_url(server.url)
+            try:
+                await requester.request("inline")
+            finally:
+                await requester.close()
+
+        self.assertEqual(server.request_bodies, [options["data"].encode("utf-8")])
 
 
 class TestNativeRequesterPathPreservation(BaseRequesterTestCase):

--- a/tests/controller/test_session_store.py
+++ b/tests/controller/test_session_store.py
@@ -21,9 +21,12 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest import TestCase
 
 from lib.controller.session import SessionStore
+from lib.core.dictionary import Dictionary
+from lib.core.exceptions import UnpicklingError
 
 
 class TestSessionStore(TestCase):
@@ -70,3 +73,47 @@ class TestSessionStore(TestCase):
                 [session["path"] for session in sessions],
                 sorted([nested_dir, root_file]),
             )
+
+    def test_request_body_bytes_round_trip_through_json_session(self):
+        body = "value=\u00e9&currency=\u20ac\r\n".encode("cp1252")
+        session_options = {"data": body, "output_formats": []}
+        controller = SimpleNamespace(
+            start_time="2026-01-01T00:00:00Z",
+            passed_urls=set(),
+            directories=[],
+            jobs_processed=0,
+            errors=0,
+            consecutive_errors=0,
+            base_path="",
+            url="https://example.com/",
+            old_session=False,
+            dictionary=Dictionary(),
+            output_history=[],
+        )
+
+        with tempfile.TemporaryDirectory() as session_dir:
+            store = SessionStore(session_options)
+            store.save(controller, session_dir, "")
+            payload = store.load(session_dir)
+            restored = store.restore_options(payload["options"])
+
+        self.assertEqual(restored["data"], body)
+
+    def test_bytes_marker_in_headers_remains_a_header_mapping(self):
+        marker = SessionStore.SESSION_BYTES_MARKER
+        headers = {marker: "header-value"}
+
+        restored = SessionStore({}).restore_options({"headers": headers})
+
+        self.assertEqual(restored["headers"], headers)
+
+    def test_invalid_request_body_encoding_is_rejected(self):
+        serialized = {
+            "data": {SessionStore.SESSION_BYTES_MARKER: "not base64!"}
+        }
+
+        with self.assertRaisesRegex(
+            UnpicklingError,
+            "Invalid binary session option: data",
+        ):
+            SessionStore({}).restore_options(serialized)

--- a/tests/core/test_options.py
+++ b/tests/core/test_options.py
@@ -10,23 +10,45 @@ from lib.core.options import parse_options
 
 
 class TestOptions(TestCase):
-    def test_data_file_preserves_request_body_text(self):
-        with tempfile.TemporaryDirectory() as directory:
-            data_path = os.path.join(directory, "request-body.txt")
-            body = "alpha=1&beta=2\r\nline=two\n"
-            with open(data_path, "wb") as data_file:
-                data_file.write(body.encode())
-            args = [
-                "dirsearch.py",
-                "--wordlist-status",
-                "-e",
-                "php",
-                "--data-file",
-                data_path,
-            ]
+    def test_data_file_preserves_request_body_bytes(self):
+        bodies = {
+            "ascii": b"alpha=1&beta=2\r\nline=two\n",
+            "utf-8": "value=\u00e9&city=\u6771\u4eac\r\n".encode("utf-8"),
+            "windows-1252": "value=\u00e9&currency=\u20ac\r\n".encode("cp1252"),
+        }
 
-            with patch("sys.argv", args):
-                parsed = parse_options()
+        for encoding, body in bodies.items():
+            with self.subTest(encoding=encoding), tempfile.TemporaryDirectory() as directory:
+                data_path = os.path.join(directory, "request-body.bin")
+                with open(data_path, "wb") as data_file:
+                    data_file.write(body)
+                args = [
+                    "dirsearch.py",
+                    "--wordlist-status",
+                    "-e",
+                    "php",
+                    "--data-file",
+                    data_path,
+                ]
+
+                with patch("sys.argv", args):
+                    parsed = parse_options()
+
+            self.assertEqual(parsed["data"], body)
+
+    def test_inline_data_remains_text(self):
+        body = "value=\u00e9"
+        args = [
+            "dirsearch.py",
+            "--wordlist-status",
+            "-e",
+            "php",
+            "--data",
+            body,
+        ]
+
+        with patch("sys.argv", args):
+            parsed = parse_options()
 
         self.assertEqual(parsed["data"], body)
 

--- a/tests/core/test_options.py
+++ b/tests/core/test_options.py
@@ -10,6 +10,26 @@ from lib.core.options import parse_options
 
 
 class TestOptions(TestCase):
+    def test_data_file_preserves_request_body_text(self):
+        with tempfile.TemporaryDirectory() as directory:
+            data_path = os.path.join(directory, "request-body.txt")
+            body = "alpha=1&beta=2\r\nline=two\n"
+            with open(data_path, "wb") as data_file:
+                data_file.write(body.encode())
+            args = [
+                "dirsearch.py",
+                "--wordlist-status",
+                "-e",
+                "php",
+                "--data-file",
+                data_path,
+            ]
+
+            with patch("sys.argv", args):
+                parsed = parse_options()
+
+        self.assertEqual(parsed["data"], body)
+
     def test_aggressive_wordlist_category_is_opt_in(self):
         args = [
             "dirsearch.py",

--- a/tests/parse/test_cmdline.py
+++ b/tests/parse/test_cmdline.py
@@ -39,6 +39,10 @@ class TestCommandLineHelp(TestCase):
         self.assertIn("--match-header-regex", short_output)
         self.assertIn("--mysql-url", short_output)
         self.assertIn("--find-backup", short_output)
+        self.assertIn(
+            "Read request body from file without encoding or newline conversion",
+            short_output.replace("\n                        ", " "),
+        )
 
     def test_help_change_does_not_affect_normal_parsing(self):
         parsed = parse_arguments(

--- a/tests/utils/test_mimetype.py
+++ b/tests/utils/test_mimetype.py
@@ -17,7 +17,7 @@
 
 from unittest import TestCase
 
-from lib.utils.mimetype import MimeTypeUtils
+from lib.utils.mimetype import MimeTypeUtils, guess_mimetype
 
 
 class TestMimeTypeUtils(TestCase):
@@ -46,3 +46,11 @@ class TestMimeTypeUtils(TestCase):
 
     def test_is_query_string(self):
         self.assertTrue(MimeTypeUtils.is_query_string("foo=1&bar=&foobar=2"), "Failed to detect query string")
+
+    def test_guess_mimetype_accepts_windows_encoded_query_string(self):
+        content = "value=\u00e9&currency=\u20ac".encode("cp1252")
+
+        self.assertEqual(
+            guess_mimetype(content),
+            "application/x-www-form-urlencoded",
+        )


### PR DESCRIPTION
Description
---------------

The --data-file option reads request data with get_lines(), producing a list of strings instead of one request body. Ordinary form and multiline payloads then fail during request preparation, and line endings are discarded before any request is sent.

This change reads the file as raw bytes. It does not detect, decode, or transcode the body: ASCII, UTF-8, Windows-1252, CRLF, trailing newlines, and arbitrary byte values are passed to the Python request backends exactly as stored in the file.

Binary request data is stored in JSON sessions through a validated Base64 envelope scoped to the data option. Existing text-valued --data sessions remain compatible, malformed binary session values fail closed, and unrelated option dictionaries cannot collide with the envelope.

HTTPX now receives raw request bodies through its supported content parameter. Inline --data remains text and its async UTF-8 wire representation is covered by a compatibility test. Native mode retains its existing request-body preflight rejection.

The CLI help and usage guide expose one simple workflow: use --data for short inline text, --data-file for a body sent exactly as saved on any OS, and --raw for a complete request. Users only need a charset header when the target server explicitly requires one.

Regression coverage includes:

- ASCII, UTF-8, and Windows-1252 parsing without conversion;
- byte-for-byte POST bodies through local sync and async transport fixtures;
- CP1252 request-body JSON session save/load;
- malformed Base64 rejection and marker-collision protection;
- CP1252 MIME guessing without a UnicodeDecodeError;
- unchanged inline --data behavior;
- the complete-help wording for the no-conversion contract.

Testing
---------------

- Focused option, session, requester, MIME, backend, raw-request, public-API, and CLI-help suites: passed
- python -m unittest discover -s tests -t .: 377 passed, 20 skipped
- flake8 .
- codespell -S CONTRIBUTORS.md,./db/categories/*,./build
- git diff --check
- python -m pip install --force-reinstall --no-deps .
- dirsearch --version
- dirsearch --help-all
- python tests/check_packaged_install.py

Requirements
---------------

- [x] No new feature or changelog entry required
- [x] No private infrastructure details are included
