### PR TITLE
Preserve zero-valued CLI overrides

### DIFF
--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -575,7 +575,11 @@ def merge_config(opt: Values) -> Values:
         if opt.async_mode is None
         else opt.async_mode
     )
-    opt.filter_threshold = opt.filter_threshold or config.safe_getint("general", "filter-threshold", 0)
+    opt.filter_threshold = (
+        config.safe_getint("general", "filter-threshold", 0)
+        if opt.filter_threshold is None
+        else opt.filter_threshold
+    )
     opt.include_status_codes = opt.include_status_codes or config.safe_get(
         "general", "include-status"
     )
@@ -602,8 +606,10 @@ def merge_config(opt: Values) -> Values:
     opt.force_recursive = opt.force_recursive or config.safe_getboolean(
         "general", "force-recursive"
     )
-    opt.recursion_depth = opt.recursion_depth or config.safe_getint(
-        "general", "max-recursion-depth"
+    opt.recursion_depth = (
+        config.safe_getint("general", "max-recursion-depth")
+        if opt.recursion_depth is None
+        else opt.recursion_depth
     )
     opt.recursion_status_codes = opt.recursion_status_codes or config.safe_get(
         "general", "recursion-status", "100-999"
@@ -672,9 +678,15 @@ def merge_config(opt: Values) -> Values:
     opt.filter_time = opt.filter_time or config.safe_get(
         "advanced-filtering", "filter-time", ""
     )
-    opt.max_time = opt.max_time or config.safe_getint("general", "max-time")
-    opt.target_max_time = opt.target_max_time or config.safe_getint(
-        "general", "target-max-time"
+    opt.max_time = (
+        config.safe_getint("general", "max-time")
+        if opt.max_time is None
+        else opt.max_time
+    )
+    opt.target_max_time = (
+        config.safe_getint("general", "target-max-time")
+        if opt.target_max_time is None
+        else opt.target_max_time
     )
     opt.exit_on_error = opt.exit_on_error or config.safe_getboolean(
         "general", "exit-on-error"
@@ -730,12 +742,22 @@ def merge_config(opt: Values) -> Values:
     opt.cookie = opt.cookie or config.safe_get("request", "cookie")
 
     # Connection
-    opt.delay = opt.delay or config.safe_getfloat("connection", "delay")
-    opt.timeout = opt.timeout or config.safe_getfloat("connection", "timeout", 7.5)
-    opt.max_retries = opt.max_retries or config.safe_getint(
-        "connection", "max-retries", 1
+    opt.delay = (
+        config.safe_getfloat("connection", "delay")
+        if opt.delay is None
+        else opt.delay
     )
-    opt.max_rate = opt.max_rate or config.safe_getint("connection", "max-rate")
+    opt.timeout = opt.timeout or config.safe_getfloat("connection", "timeout", 7.5)
+    opt.max_retries = (
+        config.safe_getint("connection", "max-retries", 1)
+        if opt.max_retries is None
+        else opt.max_retries
+    )
+    opt.max_rate = (
+        config.safe_getint("connection", "max-rate")
+        if opt.max_rate is None
+        else opt.max_rate
+    )
     opt.proxies = opt.proxies or config.safe_getlist("connection", "proxies")
     opt.proxies_file = opt.proxies_file or config.safe_get("connection", "proxies-file")
     opt.scheme = opt.scheme or config.safe_get(

--- a/tests/core/test_options_config_merge.py
+++ b/tests/core/test_options_config_merge.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import tempfile
+
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.core.options import merge_config
+from lib.parse.cmdline import parse_arguments
+
+
+CONFIG = """
+[general]
+filter-threshold = 17
+max-recursion-depth = 4
+max-time = 60
+target-max-time = 30
+
+[connection]
+delay = 0.5
+max-retries = 3
+max-rate = 9
+"""
+
+
+class TestOptionsConfigMerge(TestCase):
+    def merge(self, *arguments):
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory) / "config.ini"
+            config_path.write_text(CONFIG, encoding="utf-8")
+            argv = ["dirsearch.py", "--config", str(config_path), *arguments]
+            with patch.object(sys, "argv", argv):
+                return merge_config(parse_arguments())
+
+    def test_explicit_zero_values_override_nonzero_config_values(self):
+        options = self.merge(
+            "--filter-threshold",
+            "0",
+            "--max-recursion-depth",
+            "0",
+            "--max-time",
+            "0",
+            "--target-max-time",
+            "0",
+            "--delay",
+            "0",
+            "--retries",
+            "0",
+            "--max-rate",
+            "0",
+        )
+
+        self.assertEqual(options.filter_threshold, 0)
+        self.assertEqual(options.recursion_depth, 0)
+        self.assertEqual(options.max_time, 0)
+        self.assertEqual(options.target_max_time, 0)
+        self.assertEqual(options.delay, 0.0)
+        self.assertEqual(options.max_retries, 0)
+        self.assertEqual(options.max_rate, 0)
+
+    def test_unset_values_still_use_config_values(self):
+        options = self.merge()
+
+        self.assertEqual(options.filter_threshold, 17)
+        self.assertEqual(options.recursion_depth, 4)
+        self.assertEqual(options.max_time, 60)
+        self.assertEqual(options.target_max_time, 30)
+        self.assertEqual(options.delay, 0.5)
+        self.assertEqual(options.max_retries, 3)
+        self.assertEqual(options.max_rate, 9)


### PR DESCRIPTION
Description
---------------

Several numeric options used truthiness to choose between the command line and config file. As a result, an explicit CLI value of 0 was treated as unset and silently replaced by a nonzero config value.

This change distinguishes None from 0 for options where zero has an existing valid meaning:

- filter threshold disabled;
- unlimited recursion depth;
- unlimited scan and target runtime;
- no request delay;
- no request retries;
- unlimited request rate.

Omitted CLI flags still inherit their configured values. Timeout and positive-only settings are intentionally outside this change because they require separate range validation rather than zero-as-disabled semantics.

Regression coverage parses real CLI arguments against a temporary config and verifies both sides of the precedence contract: explicit zeros win, while omitted flags use config values.

Testing
---------------

- Focused options suites: 14 passed
- python -m unittest discover -s tests -t .: 379 passed, 20 skipped
- flake8 on changed Python files
- codespell on changed Python files
- git diff --check
- python -m compileall -q lib tests/core/test_options_config_merge.py
- Wheel build and isolated package install
- python tests/check_packaged_install.py

Requirements
---------------

- [x] No new feature or changelog entry required
- [x] No private infrastructure details are included
