### PR TITLE
Validate numeric scan options

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -84,7 +84,7 @@ Options:
     --force-recursive   Do recursive brute-force for every found path, not
                         only directories
     -R DEPTH, --max-recursion-depth=DEPTH
-                        Maximum recursion depth
+                        Maximum recursion depth (0 means unlimited)
     --recursion-status=CODES
                         Valid status codes to perform recursive scan, support
                         ranges (separated by commas)
@@ -206,8 +206,8 @@ Options:
     --cookie=COOKIE
 
   Connection Settings:
-    --timeout=TIMEOUT   Connection timeout
-    --delay=DELAY       Delay between requests
+    --timeout=TIMEOUT   Connection timeout in seconds (greater than 0)
+    --delay=DELAY       Delay between requests in seconds (0 or greater)
     -p PROXY, --proxy=PROXY
                         Proxy URL (HTTP/SOCKS), can use multiple flags
     --proxies-file=PATH
@@ -219,8 +219,8 @@ Options:
     --tor               Use Tor network as proxy
     --scheme=SCHEME     Scheme for raw request or if there is no scheme in the
                         URL (Default: auto-detect)
-    --max-rate=RATE     Max requests per second
-    --retries=RETRIES   Number of retries for failed requests
+    --max-rate=RATE     Maximum requests per second (0 means unlimited)
+    --retries=RETRIES   Number of retries for failed requests (0 or greater)
     --ip=IP             Server IP address
     --interface=NETWORK_INTERFACE
                         Network interface to use

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -47,6 +47,7 @@ from lib.core.exceptions import (
     WordlistLimitError,
 )
 from lib.core.logger import enable_logging, logger
+from lib.core.options import validate_numeric_options
 from lib.core.request_backend import (
     get_native_request_backend_error,
     get_native_target_error,
@@ -226,6 +227,7 @@ class Controller:
             loaded_session_file = session_file
             options.update(session_store.restore_options(payload["options"]))
             options["session_file"] = loaded_session_file
+            validate_numeric_options(SimpleNamespace(**options))
             if options["log_file"]:
                 try:
                     FileUtils.create_dir(FileUtils.parent(options["log_file"]))

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 import time
@@ -180,6 +181,8 @@ def parse_options() -> dict[str, Any]:
     if opt.wordlist_max_size < 1:
         print("--wordlist-max-size must be greater than zero")
         sys.exit(1)
+
+    validate_numeric_options(opt)
 
     if opt.wordlist_backend not in WORDLIST_BACKENDS:
         print("--wordlist-backend must be one of: " + ", ".join(WORDLIST_BACKENDS))
@@ -456,6 +459,25 @@ def _validate_advanced_mode(value: str, option_name: str) -> None:
 
     print(f"{option_name} must be either 'and' or 'or'")
     sys.exit(1)
+
+
+def validate_numeric_options(opt: Any) -> None:
+    if not math.isfinite(opt.timeout) or opt.timeout <= 0:
+        print("--timeout must be finite and greater than zero")
+        sys.exit(1)
+
+    if not math.isfinite(opt.delay) or opt.delay < 0:
+        print("--delay must be finite and zero or greater")
+        sys.exit(1)
+
+    for attribute, option_name in (
+        ("max_retries", "--retries"),
+        ("max_rate", "--max-rate"),
+        ("recursion_depth", "--max-recursion-depth"),
+    ):
+        if getattr(opt, attribute) < 0:
+            print(f"{option_name} must be zero or greater")
+            sys.exit(1)
 
 
 def _is_cli_flag_present(*flags: str) -> bool:
@@ -747,7 +769,11 @@ def merge_config(opt: Values) -> Values:
         if opt.delay is None
         else opt.delay
     )
-    opt.timeout = opt.timeout or config.safe_getfloat("connection", "timeout", 7.5)
+    opt.timeout = (
+        config.safe_getfloat("connection", "timeout", 7.5)
+        if opt.timeout is None
+        else opt.timeout
+    )
     opt.max_retries = (
         config.safe_getint("connection", "max-retries", 1)
         if opt.max_retries is None

--- a/lib/parse/cmdline.py
+++ b/lib/parse/cmdline.py
@@ -406,7 +406,7 @@ def parse_arguments(arguments: list[str] | None = None) -> Values:
         type="int",
         dest="recursion_depth",
         metavar="DEPTH",
-        help="Maximum recursion depth",
+        help="Maximum recursion depth (0 means unlimited)",
     )
     general.add_option(
         "--recursion-status",
@@ -774,14 +774,14 @@ def parse_arguments(arguments: list[str] | None = None) -> Values:
         action="store",
         type="float",
         dest="timeout",
-        help="Connection timeout",
+        help="Connection timeout in seconds (greater than 0)",
     )
     connection.add_option(
         "--delay",
         action="store",
         type="float",
         dest="delay",
-        help="Delay between requests",
+        help="Delay between requests in seconds (0 or greater)",
     )
     connection.add_option(
         "-p",
@@ -828,7 +828,7 @@ def parse_arguments(arguments: list[str] | None = None) -> Values:
         type="int",
         dest="max_rate",
         metavar="RATE",
-        help="Max requests per second",
+        help="Maximum requests per second (0 means unlimited)",
     )
     connection.add_option(
         "--retries",
@@ -836,7 +836,7 @@ def parse_arguments(arguments: list[str] | None = None) -> Values:
         type="int",
         dest="max_retries",
         metavar="RETRIES",
-        help="Number of retries for failed requests",
+        help="Number of retries for failed requests (0 or greater)",
     )
     connection.add_option("--ip", action="store", dest="ip", help="Server IP address")
     connection.add_option("--interface", action="store", dest="network_interface", help="Network interface to use")

--- a/tests/core/test_numeric_option_validation.py
+++ b/tests/core/test_numeric_option_validation.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+import io
+import sys
+import tempfile
+
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.controller.controller import Controller
+from lib.controller.session import SessionStore
+from lib.core.data import options as runtime_options
+from lib.core.options import parse_options
+
+
+class TestNumericOptionValidation(TestCase):
+    BASE_ARGUMENTS = ["dirsearch.py", "--wordlist-status", "-e", "php"]
+
+    def parse(self, *arguments):
+        with patch.object(sys, "argv", [*self.BASE_ARGUMENTS, *arguments]):
+            return parse_options()
+
+    def assert_rejected(self, arguments, message):
+        output = io.StringIO()
+        with redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            self.parse(*arguments)
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(output.getvalue(), message + "\n")
+
+    def test_invalid_cli_values_are_rejected(self):
+        cases = (
+            (("--timeout", "0"), "--timeout must be finite and greater than zero"),
+            (("--timeout", "-1"), "--timeout must be finite and greater than zero"),
+            (("--timeout", "nan"), "--timeout must be finite and greater than zero"),
+            (("--timeout", "inf"), "--timeout must be finite and greater than zero"),
+            (("--delay", "-1"), "--delay must be finite and zero or greater"),
+            (("--delay", "nan"), "--delay must be finite and zero or greater"),
+            (("--delay", "inf"), "--delay must be finite and zero or greater"),
+            (("--retries", "-1"), "--retries must be zero or greater"),
+            (("--max-rate", "-1"), "--max-rate must be zero or greater"),
+            (
+                ("--max-recursion-depth", "-1"),
+                "--max-recursion-depth must be zero or greater",
+            ),
+        )
+
+        for arguments, message in cases:
+            with self.subTest(arguments=arguments):
+                self.assert_rejected(arguments, message)
+
+    def test_invalid_config_values_are_rejected(self):
+        cases = (
+            (
+                "[connection]\ntimeout = 0\n",
+                "--timeout must be finite and greater than zero",
+            ),
+            (
+                "[connection]\ntimeout = nan\n",
+                "--timeout must be finite and greater than zero",
+            ),
+            (
+                "[connection]\ndelay = -1\n",
+                "--delay must be finite and zero or greater",
+            ),
+            (
+                "[connection]\ndelay = inf\n",
+                "--delay must be finite and zero or greater",
+            ),
+            (
+                "[connection]\nmax-retries = -1\n",
+                "--retries must be zero or greater",
+            ),
+            (
+                "[connection]\nmax-rate = -1\n",
+                "--max-rate must be zero or greater",
+            ),
+            (
+                "[general]\nmax-recursion-depth = -1\n",
+                "--max-recursion-depth must be zero or greater",
+            ),
+        )
+
+        for config_text, message in cases:
+            with self.subTest(config_text=config_text), tempfile.TemporaryDirectory() as directory:
+                config_path = Path(directory) / "config.ini"
+                config_path.write_text(config_text, encoding="utf-8")
+                self.assert_rejected(("--config", str(config_path)), message)
+
+    def test_valid_boundaries_remain_accepted(self):
+        options = self.parse(
+            "--timeout",
+            "0.001",
+            "--delay",
+            "0",
+            "--retries",
+            "0",
+            "--max-rate",
+            "0",
+            "--max-recursion-depth",
+            "0",
+        )
+
+        self.assertEqual(options["timeout"], 0.001)
+        self.assertEqual(options["delay"], 0.0)
+        self.assertEqual(options["max_retries"], 0)
+        self.assertEqual(options["max_rate"], 0)
+        self.assertEqual(options["recursion_depth"], 0)
+
+    def test_invalid_restored_session_value_is_rejected(self):
+        payload = {"options": {"delay": -1}}
+        output = io.StringIO()
+        controller = object.__new__(Controller)
+
+        with (
+            patch.dict(runtime_options),
+            patch.object(SessionStore, "load", return_value=payload),
+            redirect_stdout(output),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            controller._import("session.json")
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(
+            output.getvalue(),
+            "--delay must be finite and zero or greater\n",
+        )

--- a/tests/parse/test_cmdline.py
+++ b/tests/parse/test_cmdline.py
@@ -43,6 +43,24 @@ class TestCommandLineHelp(TestCase):
             "Read request body from file without encoding or newline conversion",
             short_output.replace("\n                        ", " "),
         )
+        normalized_output = short_output.replace("\n                        ", " ")
+        self.assertIn("Maximum recursion depth (0 means unlimited)", normalized_output)
+        self.assertIn(
+            "Connection timeout in seconds (greater than 0)",
+            normalized_output,
+        )
+        self.assertIn(
+            "Delay between requests in seconds (0 or greater)",
+            normalized_output,
+        )
+        self.assertIn(
+            "Maximum requests per second (0 means unlimited)",
+            normalized_output,
+        )
+        self.assertIn(
+            "Number of retries for failed requests (0 or greater)",
+            normalized_output,
+        )
 
     def test_help_change_does_not_affect_normal_parsing(self):
         parsed = parse_arguments(


### PR DESCRIPTION
Description
---------------

Numeric scan controls accepted values that their runtime consumers cannot handle consistently. In synchronous mode, a negative --delay reaches time.sleep() after the first wildcard request and raises ValueError. Negative retries suppress every request attempt, while negative rate and recursion limits silently behave as unlimited. Zero, negative, NaN, and infinite timeout values also diverge across Requests, HTTPX, and the native Rust duration boundary.

This change validates merged options before controller/requester startup:

- timeout must be finite and greater than zero;
- delay must be finite and zero or greater;
- retries, maximum rate, and maximum recursion depth must be zero or greater.

Validation applies equally to command-line and config-file values. Restored sessions pass through the same guard before requester setup, preventing old or edited session data from bypassing it. Explicit --timeout 0 is now preserved through config merging and rejected clearly instead of silently falling back to the configured timeout.

Existing valid zero semantics remain unchanged: zero delay, zero retries, unlimited rate, and unlimited recursion depth. Complete CLI help and docs now state the boundaries and zero meanings.

Regression coverage includes negative CLI and config inputs, zero timeout, NaN and infinity for float controls, restored session values, valid zero boundaries, help text, and the prior zero-over-config behavior.

Testing
---------------

- Focused options, config, session, and CLI-help suites: 30 passed
- python -m unittest discover -s tests -t .: 383 passed, 20 skipped
- flake8 on changed Python files
- codespell on changed files
- git diff --check
- python -m compileall -q on changed runtime/test paths
- Wheel build and isolated package install
- python tests/check_packaged_install.py
- Real CLI invalid-delay smoke: exited 1 before controller startup

Requirements
---------------

- [x] No new feature or changelog entry required
- [x] No private infrastructure details are included
