### PR TITLE
Fix binary response fingerprint matching

### DIFF
--- a/lib/connection/response.py
+++ b/lib/connection/response.py
@@ -18,9 +18,10 @@
 
 from __future__ import annotations
 
+import hashlib
+import time
 from typing import Any
 
-import time
 import httpx
 import requests
 
@@ -32,6 +33,71 @@ from lib.core.settings import (
 )
 from lib.parse.url import clean_path, parse_path
 from lib.utils.common import get_readable_size, is_binary, replace_path
+
+
+def _decoded_content_length(headers) -> int | None:
+    if headers.get("transfer-encoding"):
+        return None
+
+    content_encoding = headers.get("content-encoding", "").strip().lower()
+    if content_encoding and content_encoding != "identity":
+        return None
+
+    try:
+        length = int(headers.get("content-length"))
+    except (TypeError, ValueError):
+        return None
+
+    return length if length >= 0 else None
+
+
+class _BodyCapture:
+    """Keep response bodies bounded while retaining a complete binary digest."""
+
+    def __init__(self, headers, capture_full_body: bool) -> None:
+        self.body = bytearray()
+        self.complete = False
+        self.digest = None
+        self._capture_full_body = capture_full_body
+        self._headers = headers
+        self._read_length = 0
+
+    def add(self, chunk: bytes) -> bool:
+        remaining = MAX_RESPONSE_SIZE - self._read_length
+        captured = chunk[:remaining]
+        self._read_length += len(captured)
+
+        if self.digest is not None:
+            self.digest.update(captured)
+        else:
+            self.body.extend(captured)
+            if (
+                not self._capture_full_body
+                and self._headers.get("content-length") is not None
+                and is_binary(self.body)
+            ):
+                # Keep only the captured binary prefix, but digest later chunks
+                # so wildcard checks never treat that prefix as the whole body.
+                self.digest = hashlib.sha256(self.body)
+
+        if len(captured) < len(chunk) or self._read_length >= MAX_RESPONSE_SIZE:
+            self.complete = (
+                len(captured) == len(chunk)
+                and _decoded_content_length(self._headers) == self._read_length
+            )
+            return False
+
+        return True
+
+    def finish(self) -> None:
+        self.complete = True
+
+    @property
+    def body_digest(self) -> bytes | None:
+        if self.digest is None:
+            return None
+
+        return self.digest.digest()
 
 
 class BaseResponse:
@@ -47,6 +113,8 @@ class BaseResponse:
         self.elapsed = elapsed
         self.content = ""
         self.body = b""
+        self._body_complete = True
+        self._body_digest = None
 
     @property
     def type(self) -> str:
@@ -93,14 +161,43 @@ class BaseResponse:
     def __hash__(self) -> int:
         # Hash the static parts of the response only.
         # See https://github.com/maurosoria/dirsearch/pull/1436#issuecomment-2476390956
-        body = replace_path(self.content, self.full_path.split("#")[0], "") if self.content else self.body
+        body = (
+            replace_path(self.content, self.full_path.split("#")[0], "")
+            if self.content
+            else self._body_fingerprint
+        )
         return hash((self.status, body))
 
+    @property
+    def _body_fingerprint(self) -> bytes:
+        if self._body_digest is not None:
+            return self._body_digest
+
+        return hashlib.sha256(self.body).digest()
+
+    def has_same_body(self, other: BaseResponse) -> bool:
+        """Return whether both responses contain the same complete body."""
+        if self is other:
+            return True
+
+        return (
+            self._body_complete
+            and other._body_complete
+            and (
+                self.body == other.body
+                if self._body_digest is None and other._body_digest is None
+                else self._body_fingerprint == other._body_fingerprint
+            )
+        )
+
     def __eq__(self, other: Any) -> bool:
-        return (self.status, self.body, self.redirect) == (
-            other.status,
-            other.body,
-            other.redirect,
+        if not isinstance(other, BaseResponse):
+            return NotImplemented
+
+        return (
+            self.status == other.status
+            and self.redirect == other.redirect
+            and self.has_same_body(other)
         )
 
 
@@ -113,20 +210,17 @@ class Response(BaseResponse):
         capture_full_body: bool = False,
     ) -> None:
         super().__init__(url, response, elapsed)
-        body = bytearray()
+        capture = _BodyCapture(self.headers, capture_full_body)
 
         for chunk in response.iter_content(chunk_size=ITER_CHUNK_SIZE):
-            remaining = MAX_RESPONSE_SIZE - len(body)
-            body.extend(chunk[:remaining])
-
-            if len(body) >= MAX_RESPONSE_SIZE or (
-                not capture_full_body
-                and "content-length" in self.headers
-                and is_binary(body)
-            ):
+            if not capture.add(chunk):
                 break
+        else:
+            capture.finish()
 
-        self.body = bytes(body)
+        self.body = bytes(capture.body)
+        self._body_complete = capture.complete
+        self._body_digest = capture.body_digest
         if not is_binary(self.body):
             try:
                 self.content = self.body.decode(
@@ -146,19 +240,16 @@ class AsyncResponse(BaseResponse):
         capture_full_body: bool = False,
     ) -> AsyncResponse:
         self = cls(url, response, elapsed)
-        body = bytearray()
+        capture = _BodyCapture(self.headers, capture_full_body)
         async for chunk in response.aiter_bytes(chunk_size=ITER_CHUNK_SIZE):
-            remaining = MAX_RESPONSE_SIZE - len(body)
-            body.extend(chunk[:remaining])
-
-            if len(body) >= MAX_RESPONSE_SIZE or (
-                not capture_full_body
-                and "content-length" in self.headers
-                and is_binary(body)
-            ):
+            if not capture.add(chunk):
                 break
+        else:
+            capture.finish()
 
-        self.body = bytes(body)
+        self.body = bytes(capture.body)
+        self._body_complete = capture.complete
+        self._body_digest = capture.body_digest
         if not is_binary(self.body):
             try:
                 self.content = self.body.decode(
@@ -198,6 +289,8 @@ class NativeResponse(BaseResponse):
         self.filtered = filtered
         self.filter_reason = filter_reason
         self.body = bytes(body)
+        if self._length is not None:
+            self._body_complete = self._length == len(self.body)
         if not is_binary(self.body):
             self.content = self.body.decode(DEFAULT_ENCODING, errors="replace")
 

--- a/lib/core/scanner.py
+++ b/lib/core/scanner.py
@@ -126,7 +126,7 @@ class BaseScanner:
 
         # Compare 2 binary responses (Response.content is empty if the body is binary)
         if not self.response.content and not response.content:
-            return self.response.body == response.body
+            return self.response.has_same_body(response)
 
         return self.content_parser.compare_to(response.content)
 

--- a/tests/connection/test_native_response.py
+++ b/tests/connection/test_native_response.py
@@ -96,3 +96,22 @@ class TestNativeResponse(TestCase):
         self.assertEqual(response.filter_reason, "advanced_filter")
         self.assertEqual(response.body, b"")
         self.assertEqual(response.length, 123)
+
+    def test_truncated_native_responses_do_not_compare_as_complete_bodies(self):
+        prefix = b"\x00" + b"a" * 15
+        left = NativeResponse(
+            "https://example.com/left.bin",
+            200,
+            [("Content-Length", str(len(prefix) + 4))],
+            prefix,
+            length=len(prefix) + 4,
+        )
+        right = NativeResponse(
+            "https://example.com/right.bin",
+            200,
+            [("Content-Length", str(len(prefix) + 4))],
+            prefix,
+            length=len(prefix) + 4,
+        )
+
+        self.assertNotEqual(left, right)

--- a/tests/connection/test_response.py
+++ b/tests/connection/test_response.py
@@ -121,6 +121,8 @@ class TestResponse(TestCase):
 
         self.assertEqual(default.body, chunks[0])
         self.assertEqual(captured.body, b"".join(chunks))
+        self.assertEqual(default, captured)
+        self.assertEqual(hash(default), hash(captured))
 
     def test_full_capture_never_exceeds_response_limit(self):
         with patch("lib.connection.response.MAX_RESPONSE_SIZE", 5):
@@ -131,6 +133,22 @@ class TestResponse(TestCase):
             )
 
         self.assertEqual(response.body, b"abcde")
+
+    def test_binary_responses_with_matching_prefixes_are_not_equal(self):
+        prefix = b"\x00" + b"a" * 15
+        headers = {"content-length": str(len(prefix) + 4)}
+        left = Response(
+            "http://example.com/left.bin",
+            DummyResponse(headers=headers, body=[prefix, b"LEFT"]),
+        )
+        right = Response(
+            "http://example.com/right.bin",
+            DummyResponse(headers=headers, body=[prefix, b"RGHT"]),
+        )
+
+        self.assertEqual(left.body, prefix)
+        self.assertEqual(right.body, prefix)
+        self.assertNotEqual(left, right)
 
 
 class TestAsyncResponse(IsolatedAsyncioTestCase):
@@ -195,6 +213,8 @@ class TestAsyncResponse(IsolatedAsyncioTestCase):
 
         self.assertEqual(default.body, chunks[0])
         self.assertEqual(captured.body, b"".join(chunks))
+        self.assertEqual(default, captured)
+        self.assertEqual(hash(default), hash(captured))
 
     async def test_full_capture_never_exceeds_response_limit(self):
         with patch("lib.connection.response.MAX_RESPONSE_SIZE", 5):
@@ -205,3 +225,19 @@ class TestAsyncResponse(IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(response.body, b"abcde")
+
+    async def test_binary_responses_with_matching_prefixes_are_not_equal(self):
+        prefix = b"\x00" + b"a" * 15
+        headers = {"content-length": str(len(prefix) + 4)}
+        left = await AsyncResponse.create(
+            "http://example.com/left.bin",
+            DummyAsyncResponse(headers=headers, body=[prefix, b"LEFT"]),
+        )
+        right = await AsyncResponse.create(
+            "http://example.com/right.bin",
+            DummyAsyncResponse(headers=headers, body=[prefix, b"RGHT"]),
+        )
+
+        self.assertEqual(left.body, prefix)
+        self.assertEqual(right.body, prefix)
+        self.assertNotEqual(left, right)

--- a/tests/core/test_scanner.py
+++ b/tests/core/test_scanner.py
@@ -19,7 +19,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from lib.connection.response import NativeResponse
+from lib.connection.response import NativeResponse, Response
 from lib.core.data import options
 from lib.core.scanner import BaseScanner
 from lib.core.settings import REFLECTED_PATH_MARKER, WILDCARD_TEST_POINT_MARKER
@@ -42,6 +42,23 @@ class DynamicSoft404Requester:
             [("content-type", "text/html")],
             body,
         )
+
+
+class ChunkedResponse:
+    status_code = 200
+    history = []
+    encoding = None
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+        self.headers = {
+            "content-type": "application/octet-stream",
+            "content-length": str(sum(map(len, chunks))),
+        }
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        yield from self._chunks
 
 
 class TestScanner(TestCase):
@@ -90,6 +107,37 @@ class TestScanner(TestCase):
         )
 
         self.assertTrue(scanner.check("admin", response))
+
+    def test_binary_prefix_match_does_not_hide_distinct_response(self):
+        prefix = b"\x00" + b"a" * 15
+        scanner = BaseScanner(None)
+        scanner.response = Response(
+            "https://example.com/wildcard.bin",
+            ChunkedResponse([prefix, b"LEFT"]),
+        )
+        response = Response(
+            "https://example.com/admin.bin",
+            ChunkedResponse([prefix, b"RGHT"]),
+        )
+
+        self.assertEqual(scanner.response.body, response.body)
+        self.assertEqual(scanner.classify("admin.bin", response), "unique")
+        self.assertEqual(scanner.reason, "response is unique enough")
+
+    def test_binary_fingerprint_still_matches_identical_responses(self):
+        prefix = b"\x00" + b"a" * 15
+        scanner = BaseScanner(None)
+        scanner.response = Response(
+            "https://example.com/wildcard.bin",
+            ChunkedResponse([prefix, b"SAME"]),
+        )
+        response = Response(
+            "https://example.com/admin.bin",
+            ChunkedResponse([prefix, b"SAME"]),
+        )
+
+        self.assertEqual(scanner.classify("admin.bin", response), "wildcard")
+        self.assertEqual(scanner.reason, "matches wildcard profile")
 
     def test_probable_wildcard_skips_expensive_similarity_for_large_bodies(self):
         class DummyParser:


### PR DESCRIPTION
Description
---------------

Binary responses with the same captured prefix could compare equal even when later chunks differed. That could make wildcard calibration or duplicate detection hide a real path.

This change keeps the stored binary body bounded, streams a SHA-256 fingerprint through later chunks up to the existing response-size limit, and only compares fingerprints known to represent a complete body. It also marks size-capped native bodies as incomplete. Sync, async, and native response comparisons now use the same complete-body contract.

Oversized bodies that cannot be fingerprinted completely are treated conservatively as distinct instead of being filtered from a prefix match.

Validation
---------------

- `python -m unittest discover -s tests -t .` (388 passed, 20 skipped)
- `python testing.py` (388 passed, 20 skipped)
- focused response, requester, scanner, and native-response tests (72 passed, 5 skipped)
- local HTTP harness covering real requests/httpx streams, matching 1 MiB prefixes, distinct tails, identical tails, and bounded retained bodies
- randomized chunk-boundary and full-capture hash/equality invariants
- flake8 and codespell on changed files
- package build/install and import smoke test

Requirements
---------------

- [x] Contributor-list update is not needed for this bug fix
- [x] Changelog update is not needed for this bug fix
- [x] PR text and committed files contain no private infrastructure details