### PR TITLE
Preserve raw paths through Python proxies

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -30,11 +30,13 @@ from urllib.parse import urlparse
 
 import httpx
 import requests
+from httpx._transports.default import AsyncResponseStream, map_httpcore_exceptions
 from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth
 from requests.packages import urllib3
 from urllib3 import connection as urllib3_connection
 from urllib3 import connectionpool as urllib3_connectionpool
 from urllib3 import poolmanager as urllib3_poolmanager
+from urllib3.contrib import socks as urllib3_socks
 from requests_ntlm import HttpNtlmAuth
 from httpx_ntlm import HttpNtlmAuth as HttpxNtlmAuth
 from requests_toolbelt.adapters.socket_options import SocketOptionsAdapter
@@ -83,11 +85,14 @@ def _join_request_target(base_url: str, quoted_path: str) -> str:
 # the already-quoted dirsearch target for direct requests so fuzzed characters
 # such as malformed percent escapes and backslashes reach the server unchanged.
 class _ScopedDNSConnection:
-    def __init__(self, *args, dns_resolver: DNSResolver, **kwargs):
+    def __init__(self, *args, dns_resolver: DNSResolver | None = None, **kwargs):
         self._dns_resolver = dns_resolver
         super().__init__(*args, **kwargs)
 
     def _new_conn(self):
+        if self._dns_resolver is None:
+            return super()._new_conn()
+
         original_host = self._dns_host
         self._dns_host = self._dns_resolver.resolve(original_host, self.port)
         try:
@@ -96,26 +101,43 @@ class _ScopedDNSConnection:
             self._dns_host = original_host
 
 
-class PathPreservingHTTPConnection(
-    _ScopedDNSConnection, urllib3_connection.HTTPConnection
-):
+class _PathPreservingRequestMixin:
     def request(self, method, url, body=None, headers=None, *args, **kwargs):
         target = getattr(_request_target_state, "target", None)
         if target:
             url = target
 
         return super().request(method, url, body, headers, *args, **kwargs)
+
+
+class PathPreservingHTTPConnection(
+    _PathPreservingRequestMixin,
+    _ScopedDNSConnection,
+    urllib3_connection.HTTPConnection,
+):
+    pass
 
 
 class PathPreservingHTTPSConnection(
-    _ScopedDNSConnection, urllib3_connection.HTTPSConnection
+    _PathPreservingRequestMixin,
+    _ScopedDNSConnection,
+    urllib3_connection.HTTPSConnection,
 ):
-    def request(self, method, url, body=None, headers=None, *args, **kwargs):
-        target = getattr(_request_target_state, "target", None)
-        if target:
-            url = target
+    pass
 
-        return super().request(method, url, body, headers, *args, **kwargs)
+
+class PathPreservingSOCKSConnection(
+    _PathPreservingRequestMixin,
+    urllib3_socks.SOCKSConnection,
+):
+    pass
+
+
+class PathPreservingSOCKSHTTPSConnection(
+    _PathPreservingRequestMixin,
+    urllib3_socks.SOCKSHTTPSConnection,
+):
+    pass
 
 
 class PathPreservingHTTPConnectionPool(urllib3_connectionpool.HTTPConnectionPool):
@@ -124,6 +146,16 @@ class PathPreservingHTTPConnectionPool(urllib3_connectionpool.HTTPConnectionPool
 
 class PathPreservingHTTPSConnectionPool(urllib3_connectionpool.HTTPSConnectionPool):
     ConnectionCls = PathPreservingHTTPSConnection
+
+
+class PathPreservingSOCKSConnectionPool(urllib3_socks.SOCKSHTTPConnectionPool):
+    ConnectionCls = PathPreservingSOCKSConnection
+
+
+class PathPreservingSOCKSHTTPSConnectionPool(
+    urllib3_socks.SOCKSHTTPSConnectionPool
+):
+    ConnectionCls = PathPreservingSOCKSHTTPSConnection
 
 
 class PathPreservingPoolManager(urllib3_poolmanager.PoolManager):
@@ -157,18 +189,37 @@ class PathPreservingSocketOptionsAdapter(SocketOptionsAdapter):
 
     def request_url(self, request: requests.PreparedRequest, proxies: dict[str, str]) -> str:
         target = getattr(request, "_dirsearch_request_target", None)
-        if target and not proxies:
+        if not target:
+            return super().request_url(request, proxies)
+
+        request_url = super().request_url(request, proxies)
+        if request_url.startswith("/"):
             return target
 
-        return super().request_url(request, proxies)
+        parsed_url = urlparse(request_url)
+        return f"{parsed_url.scheme}://{parsed_url.netloc}{target}"
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        manager = super().proxy_manager_for(proxy, **proxy_kwargs)
+        if proxy.lower().startswith("socks"):
+            manager.pool_classes_by_scheme = {
+                "http": PathPreservingSOCKSConnectionPool,
+                "https": PathPreservingSOCKSHTTPSConnectionPool,
+            }
+        else:
+            manager.pool_classes_by_scheme = {
+                "http": PathPreservingHTTPConnectionPool,
+                "https": PathPreservingHTTPSConnectionPool,
+            }
+        return manager
 
     def send(self, request, **kwargs):
         target = getattr(request, "_dirsearch_request_target", None)
         proxies = kwargs.get("proxies") or {}
-        if not target or proxies:
+        if not target:
             return super().send(request, **kwargs)
 
-        _request_target_state.target = target
+        _request_target_state.target = self.request_url(request, proxies)
         try:
             return super().send(request, **kwargs)
         finally:
@@ -603,16 +654,51 @@ class ScopedDNSAsyncTransport(httpx.AsyncBaseTransport):
         await self._transport.aclose()
 
 
+class PathPreservingAsyncHTTPTransport(httpx.AsyncHTTPTransport):
+    """Pass a raw target into httpcore without leaking it into proxy subrequests."""
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        target = request.extensions.get("target")
+        if target is None:
+            return await super().handle_async_request(request)
+
+        import httpcore
+
+        # httpcore constructs its own absolute-form or CONNECT request. Leaving
+        # the override in extensions would replace those generated targets too.
+        extensions = dict(request.extensions)
+        extensions.pop("target")
+        core_request = httpcore.Request(
+            method=request.method,
+            url=httpcore.URL(
+                scheme=request.url.raw_scheme,
+                host=request.url.raw_host,
+                port=request.url.port,
+                target=target,
+            ),
+            headers=request.headers.raw,
+            content=request.stream,
+            extensions=extensions,
+        )
+        with map_httpcore_exceptions():
+            core_response = await self._pool.handle_async_request(core_request)
+
+        return httpx.Response(
+            status_code=core_response.status,
+            headers=core_response.headers,
+            stream=AsyncResponseStream(core_response.stream),
+            extensions=core_response.extensions,
+        )
+
+
 class ProxyRoatingTransport(httpx.AsyncBaseTransport):
     def __init__(self, proxies: list[str], **kwargs: Any) -> None:
         self._transports = [
-            httpx.AsyncHTTPTransport(proxy=proxy, **kwargs) for proxy in proxies
+            PathPreservingAsyncHTTPTransport(proxy=proxy, **kwargs)
+            for proxy in proxies
         ]
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        # Let httpcore choose absolute-form for forwarding and authority/origin-form
-        # for CONNECT tunnels. A custom target overrides all three request forms.
-        request.extensions.pop("target", None)
         transport = random.choice(self._transports)
         return await transport.handle_async_request(request)
 
@@ -692,7 +778,7 @@ class AsyncRequester(BaseRequester):
 
     async def replay_request(self, path: str, proxy: str) -> AsyncResponse:
         if self.replay_session is None:
-            transport = httpx.AsyncHTTPTransport(
+            transport = PathPreservingAsyncHTTPTransport(
                 verify=False,
                 cert=self._cert,
                 limits=httpx.Limits(max_connections=options["thread_count"]),
@@ -730,10 +816,8 @@ class AsyncRequester(BaseRequester):
                     headers=self.headers,
                     content=options["data"],
                     extensions={
-                        "target": (
-                            url
-                            if replay
-                            else _join_request_target(self._url, quoted_request_path)
+                        "target": _join_request_target(
+                            self._url, quoted_request_path
                         ).encode()
                     },
                 )

--- a/tests/connection/test_proxy_integration.py
+++ b/tests/connection/test_proxy_integration.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import re
 import time
 import warnings
 from unittest import TestCase, skipUnless
@@ -26,6 +27,23 @@ PROXY_AUTHORIZATION = "Basic " + base64.b64encode(
 ).decode()
 PROXY_FAILURE_TIMEOUT = 0.2
 PROXY_CASE_DEADLINE = 2
+RAW_REQUEST_TARGET_CASES = (
+    ("malformed escape", "admin%3d..%1\\*", "/admin%3D..%1\\*"),
+    ("encoded backslash", "admin/%83%5c/..", "/admin/%83%5C/.."),
+    (
+        "query and unicode",
+        "admin?x=1 y=ñ&raw=%1\\*",
+        "/admin?x=1%20y=%C3%B1&raw=%1\\*",
+    ),
+)
+
+
+def normalize_percent_hex(target: str) -> str:
+    return re.sub(
+        r"%[0-9a-fA-F]{2}",
+        lambda match: match.group(0).upper(),
+        target,
+    )
 
 
 class TestProxyIntegration(TestCase):
@@ -87,6 +105,58 @@ class TestProxyIntegration(TestCase):
 
                 self.assertIsNone(error)
                 self._assert_case(proxy, target, path, response)
+
+    def test_sync_engine_preserves_raw_targets_through_proxies(self):
+        for name, path, expected in RAW_REQUEST_TARGET_CASES:
+            for proxy, target in self._cases():
+                with self.subTest(
+                    case=name,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    self._prepare_case(proxy, target)
+                    response, error, _ = self._sync_request(proxy, target, path)
+
+                    self.assertIsNone(error)
+                    self._assert_raw_target(target, expected, response)
+
+    def test_async_engine_preserves_raw_targets_through_proxies(self):
+        asyncio.run(self._test_async_engine_raw_targets())
+
+    async def _test_async_engine_raw_targets(self):
+        for name, path, expected in RAW_REQUEST_TARGET_CASES:
+            for proxy, target in self._cases():
+                with self.subTest(
+                    case=name,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    self._prepare_case(proxy, target)
+                    response, error, _ = await self._async_request(
+                        proxy, target, path
+                    )
+
+                    self.assertIsNone(error)
+                    self._assert_raw_target(target, expected, response)
+
+    def test_async_replay_preserves_raw_targets_through_proxies(self):
+        asyncio.run(self._test_async_replay_raw_targets())
+
+    async def _test_async_replay_raw_targets(self):
+        for name, path, expected in RAW_REQUEST_TARGET_CASES:
+            for proxy, target in self._cases():
+                with self.subTest(
+                    case=name,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    self._prepare_case(proxy, target)
+                    response, error = await self._async_replay_request(
+                        proxy, target, path
+                    )
+
+                    self.assertIsNone(error)
+                    self._assert_raw_target(target, expected, response)
 
     @skipUnless(
         dirsearch_native is not None
@@ -355,6 +425,19 @@ class TestProxyIntegration(TestCase):
             await requester.session.aclose()
 
     @staticmethod
+    async def _async_replay_request(proxy, target, path):
+        options["proxies"] = []
+        requester = AsyncRequester()
+        requester.set_url(target.url)
+        try:
+            try:
+                return await requester.replay_request(path, proxy.url), None
+            except RequestException as error:
+                return None, error
+        finally:
+            await requester.close()
+
+    @staticmethod
     def _native_request(proxy, target, path):
         options["proxies"] = [proxy.url]
         backend = NativeHTTPBackend()
@@ -375,6 +458,14 @@ class TestProxyIntegration(TestCase):
         self.assertEqual(target.proxy_authorizations, [None])
 
         self.assertEqual(proxy.events, [self._expected_proxy_event(target, path)])
+
+    def _assert_raw_target(self, target, expected, response):
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(
+            [normalize_percent_hex(path) for _, path in target.events],
+            [expected],
+        )
 
     def _assert_authentication_rejected(
         self,

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -39,6 +39,10 @@ from lib.connection.native import NativeHTTPBackend
 from lib.connection.rate_limiter import RequestRateLimiter
 from lib.connection.requester import (
     AsyncRequester,
+    PathPreservingHTTPConnectionPool,
+    PathPreservingHTTPSConnectionPool,
+    PathPreservingSOCKSConnectionPool,
+    PathPreservingSOCKSHTTPSConnectionPool,
     Requester,
     _find_ssl_error,
     _format_ssl_error,
@@ -615,6 +619,32 @@ class TestRequesterBodyPreservation(BaseRequesterTestCase):
 
 
 class TestRequesterProxyRouting(BaseRequesterTestCase):
+    def test_proxy_managers_keep_path_preserving_connection_pools(self):
+        requester = Requester()
+        adapter = requester.session.get_adapter("http://")
+        try:
+            cases = (
+                (
+                    "http://proxy.invalid:8080",
+                    PathPreservingHTTPConnectionPool,
+                    PathPreservingHTTPSConnectionPool,
+                ),
+                (
+                    "socks5h://proxy.invalid:1080",
+                    PathPreservingSOCKSConnectionPool,
+                    PathPreservingSOCKSHTTPSConnectionPool,
+                ),
+            )
+            for proxy, http_pool, https_pool in cases:
+                with self.subTest(proxy=proxy):
+                    manager = adapter.proxy_manager_for(proxy)
+                    self.assertIs(manager.pool_classes_by_scheme["http"], http_pool)
+                    self.assertIs(
+                        manager.pool_classes_by_scheme["https"], https_pool
+                    )
+        finally:
+            requester.close()
+
     def test_proxy_scheme_never_bypasses_target_scheme(self):
         for proxy_scheme in ("http", "https"):
             proxy_url = f"{proxy_scheme}://proxy.invalid:8080"


### PR DESCRIPTION
Description
---------------

Proxy-backed Python requests could rewrite fuzzing targets before they reached the origin. The sync backend double-encoded percent sequences and encoded literal backslashes, while the async proxy path normalized dot segments in some encoded paths. Async replay also replaced the HTTPS CONNECT authority with the request URL.

This change preserves the already-quoted dirsearch target at the transport boundary:

- Requests uses path-preserving connection pools for HTTP, HTTPS, and SOCKS proxy managers while retaining the correct absolute-form or origin-form request target.
- HTTPX applies the raw target to the outer httpcore request, then removes the override before httpcore generates forwarding and CONNECT subrequests.
- Async replay uses the same origin-form target contract as normal requests.

Regression coverage exercises malformed percent escapes, literal and encoded backslashes, dot segments, queries, spaces, and Unicode through every HTTP/HTTPS proxy-target combination. It also covers normal and replayed async requests and verifies SOCKS/Tor managers select path-preserving pools.

Scope: this PR fixes the Python sync and async proxy backends. The native backend requires a separate Rust raw proxy/CONNECT transport and is intentionally unchanged here.

Validation
---------------

- `python -m unittest discover -s tests -t .` (392 passed, 20 skipped)
- requester and proxy integration suites on Python 3.12 (56 passed, 9 optional-native skips)
- requester and proxy integration suites on Python 3.14 with the native extension installed (56 passed)
- focused raw-target proxy and replay regressions (5 passed)
- flake8 and codespell on changed files
- package build/install and transport import smoke test

Requirements
---------------

- [x] Contributor-list update is not needed for this bug fix
- [x] Changelog update is not needed for this bug fix
- [x] PR text and committed files contain no private infrastructure details