### PR TITLE
Preserve existing SQL report results

### DIFF
--- a/lib/report/factory.py
+++ b/lib/report/factory.py
@@ -101,11 +101,8 @@ class SQLReportMixin:
 
         return self._conn
 
-    def get_drop_table_query(self, table):
-        return (f'''DROP TABLE IF EXISTS "{table}";''',)
-
     def get_create_table_query(self, table):
-        return (f'''CREATE TABLE "{table}" (
+        return (f'''CREATE TABLE IF NOT EXISTS "{table}" (
             time TIMESTAMP,
             url TEXT,
             status_code INTEGER,
@@ -127,7 +124,6 @@ class SQLReportMixin:
 
         cursor = conn.cursor()
 
-        cursor.execute(*self.get_drop_table_query(table))
         cursor.execute(*self.get_create_table_query(table))
         conn.commit()
 

--- a/lib/report/sqlite_report.py
+++ b/lib/report/sqlite_report.py
@@ -28,7 +28,7 @@ class SQLiteReport(SQLReportMixin, BaseReport):
     _reuse = False
 
     def get_create_table_query(self, table):
-        return (f'''CREATE TABLE "{table}" (
+        return (f'''CREATE TABLE IF NOT EXISTS "{table}" (
             time DATETIME,
             url TEXT,
             status_code INTEGER,

--- a/tests/report/test_sql_report.py
+++ b/tests/report/test_sql_report.py
@@ -1,0 +1,97 @@
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+
+from lib.report.factory import SQLReportMixin
+from lib.report.sqlite_report import SQLiteReport
+
+
+def make_result(url):
+    return SimpleNamespace(
+        datetime="2026-09-05 23:30:00",
+        url=url,
+        status=200,
+        length=42,
+        type="text/plain",
+        redirect="",
+    )
+
+
+class TestSQLReportPersistence(TestCase):
+    def test_reinitializing_sqlite_table_preserves_existing_results(self):
+        with TemporaryDirectory() as directory:
+            database = str(Path(directory, "report.sqlite"))
+            report = SQLiteReport()
+            report.initiate(database, "results")
+            report.save(database, "results", make_result("https://one.example/"))
+
+            report.initiate(database, "results")
+            SQLiteReport().initiate(database, "results")
+
+            with closing(sqlite3.connect(database)) as connection:
+                rows = connection.execute(
+                    'SELECT url FROM "results" ORDER BY rowid'
+                ).fetchall()
+
+        self.assertEqual(rows, [("https://one.example/",)])
+
+    def test_new_sqlite_table_keeps_existing_schema_and_accepts_results(self):
+        with TemporaryDirectory() as directory:
+            database = str(Path(directory, "report.sqlite"))
+            report = SQLiteReport()
+            report.initiate(database, "results")
+            report.save(database, "results", make_result("https://example.test/"))
+
+            with closing(sqlite3.connect(database)) as connection:
+                columns = [
+                    row[1]
+                    for row in connection.execute('PRAGMA table_info("results")')
+                ]
+                row = connection.execute(
+                    'SELECT url, status_code, content_length FROM "results"'
+                ).fetchone()
+
+        self.assertEqual(
+            columns,
+            [
+                "time",
+                "url",
+                "status_code",
+                "content_length",
+                "content_type",
+                "redirect",
+            ],
+        )
+        self.assertEqual(row, ("https://example.test/", 200, 42))
+
+    def test_incompatible_existing_sqlite_table_is_not_modified(self):
+        with TemporaryDirectory() as directory:
+            database = str(Path(directory, "report.sqlite"))
+            with closing(sqlite3.connect(database)) as connection:
+                connection.execute('CREATE TABLE "results" (sentinel TEXT)')
+                connection.execute('INSERT INTO "results" VALUES (?)', ("keep-me",))
+                connection.commit()
+
+            SQLiteReport().initiate(database, "results")
+
+            with closing(sqlite3.connect(database)) as connection:
+                columns = [
+                    row[1]
+                    for row in connection.execute('PRAGMA table_info("results")')
+                ]
+                rows = connection.execute('SELECT sentinel FROM "results"').fetchall()
+
+        self.assertEqual(columns, ["sentinel"])
+        self.assertEqual(rows, [("keep-me",)])
+
+    def test_all_sql_create_queries_are_idempotent(self):
+        shared_query = SQLReportMixin.get_create_table_query(None, "results")[0]
+        sqlite_query = SQLiteReport().get_create_table_query("results")[0]
+
+        for query in (shared_query, sqlite_query):
+            with self.subTest(query=query):
+                self.assertIn("CREATE TABLE IF NOT EXISTS", query)
+                self.assertNotIn("DROP TABLE", query)


### PR DESCRIPTION
## Summary

- stop dropping SQL report tables every time a target is prepared
- create SQLite, MySQL, and PostgreSQL report tables idempotently
- preserve compatible prior results across multiple targets, resumed sessions, and new reporter instances
- leave an incompatible existing table and its data untouched instead of replacing it

This deliberately does not add a `run_id` column. That would require a schema migration and consumer contract beyond the data-loss fix; existing timestamps and result URLs remain unchanged.

## User-visible effect

Reusing the same SQL database and table no longer silently deletes results collected for an earlier target or before a resumed scan.

## Validation

- regression proof before the fix: 3 failures, including an empty table after reinitialization
- `python -m unittest tests.report.test_sql_report tests.test_report_exception_handling tests.test_optional_db_dependencies`: 15 passed
- `python -m unittest discover -s tests -t .`: 396 passed, 20 skipped
- `python -m flake8 lib/report/factory.py lib/report/sqlite_report.py tests/report/test_sql_report.py`
- `codespell lib/report/factory.py lib/report/sqlite_report.py tests/report/test_sql_report.py`
- `python -m compileall -q lib/report/factory.py lib/report/sqlite_report.py tests/report/test_sql_report.py`
- clean wheel build/install and import smoke test
