### PR TITLE
Restore report destinations when resuming sessions

### DIFF
--- a/lib/report/manager.py
+++ b/lib/report/manager.py
@@ -29,24 +29,25 @@ from lib.report.simple_report import SimpleReport
 from lib.report.sqlite_report import SQLiteReport
 from lib.report.xml_report import XMLReport
 
+# Store option keys so restored session destinations are resolved at manager creation.
 output_handlers = {
-    "simple": (SimpleReport, [options["output_file"]]),
-    "plain": (PlainTextReport, [options["output_file"]]),
-    "json": (JSONReport, [options["output_file"]]),
-    "xml": (XMLReport, [options["output_file"]]),
-    "md": (MarkdownReport, [options["output_file"]]),
-    "csv": (CSVReport, [options["output_file"]]),
-    "html": (HTMLReport, [options["output_file"]]),
-    "sqlite": (SQLiteReport, [options["output_file"], options["output_table"]]),
+    "simple": (SimpleReport, ("output_file",)),
+    "plain": (PlainTextReport, ("output_file",)),
+    "json": (JSONReport, ("output_file",)),
+    "xml": (XMLReport, ("output_file",)),
+    "md": (MarkdownReport, ("output_file",)),
+    "csv": (CSVReport, ("output_file",)),
+    "html": (HTMLReport, ("output_file",)),
+    "sqlite": (SQLiteReport, ("output_file", "output_table")),
     "mysql": (
         "lib.report.mysql_report",
         "MySQLReport",
-        [options["mysql_url"], options["output_table"]],
+        ("mysql_url", "output_table"),
     ),
     "postgresql": (
         "lib.report.postgresql_report",
         "PostgreSQLReport",
-        [options["postgres_url"], options["output_table"]],
+        ("postgres_url", "output_table"),
     ),
 }
 
@@ -58,7 +59,7 @@ class ReportManager:
         for format in formats:
             # No output location provided
             handler = output_handlers[format]
-            sources = handler[-1]
+            sources = [options[key] for key in handler[-1]]
             if any(not _ for _ in sources):
                 continue
             self.reports.append((self._load_report(handler)(), sources))

--- a/tests/report/test_report_manager.py
+++ b/tests/report/test_report_manager.py
@@ -1,0 +1,130 @@
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.controller.session import SessionStore
+from lib.core.data import options
+from lib.report.manager import ReportManager
+
+
+class DummyReport:
+    __format__ = "dummy"
+    __extension__ = "txt"
+
+
+def make_result(url):
+    return SimpleNamespace(
+        datetime="2026-09-05 23:45:00",
+        url=url,
+        status=200,
+        length=42,
+        type="text/plain",
+        redirect="",
+        elapsed=0.25,
+    )
+
+
+class TestReportManagerDestinations(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_uses_destinations_restored_after_report_module_import(self):
+        output_file = "/tmp/restored-{format}.{extension}"
+        output_table = "restored_results"
+        mysql_url = "mysql://user:pass@example.test/db"
+        postgres_url = "postgresql://user:pass@example.test/db"
+        restored = SessionStore({}).restore_options(
+            {
+                "output_file": output_file,
+                "output_table": output_table,
+                "mysql_url": mysql_url,
+                "postgres_url": postgres_url,
+            }
+        )
+        options.update(restored)
+        expected_sources = {
+            "simple": [output_file],
+            "plain": [output_file],
+            "json": [output_file],
+            "xml": [output_file],
+            "md": [output_file],
+            "csv": [output_file],
+            "html": [output_file],
+            "sqlite": [output_file, output_table],
+            "mysql": [mysql_url, output_table],
+            "postgresql": [postgres_url, output_table],
+        }
+
+        with patch.object(ReportManager, "_load_report", return_value=DummyReport):
+            for report_format, sources in expected_sources.items():
+                with self.subTest(report_format=report_format):
+                    manager = ReportManager([report_format])
+                    self.assertEqual(len(manager.reports), 1)
+                    self.assertEqual(manager.reports[0][1], sources)
+
+    def test_restored_file_and_sqlite_reports_persist_results(self):
+        with TemporaryDirectory() as directory:
+            output_file = str(Path(directory, "report-{format}.{extension}"))
+            options.update(
+                SessionStore({}).restore_options(
+                    {
+                        "output_file": output_file,
+                        "output_table": "results",
+                    }
+                )
+            )
+            manager = ReportManager(["json", "sqlite"])
+
+            self.assertEqual(len(manager.reports), 2)
+            manager.prepare("https://example.test/")
+            manager.save(make_result("https://example.test/admin"))
+            manager.finish()
+
+            json_path = Path(directory, "report-json.json")
+            sqlite_path = Path(directory, "report-sql.sqlite")
+            json_results = json.loads(json_path.read_text(encoding="utf-8"))[
+                "results"
+            ]
+            with closing(sqlite3.connect(sqlite_path)) as connection:
+                sqlite_rows = connection.execute(
+                    'SELECT url, status_code FROM "results"'
+                ).fetchall()
+
+        self.assertEqual(
+            json_results,
+            [
+                {
+                    "contentLength": 42,
+                    "contentType": "text/plain",
+                    "elapsed": 0.25,
+                    "redirect": "",
+                    "status": 200,
+                    "url": "https://example.test/admin",
+                }
+            ],
+        )
+        self.assertEqual(sqlite_rows, [("https://example.test/admin", 200)])
+
+    def test_formats_without_a_current_destination_are_skipped(self):
+        options.update(
+            {
+                "output_file": None,
+                "output_table": "results",
+                "mysql_url": None,
+            }
+        )
+
+        with patch.object(ReportManager, "_load_report") as load_report:
+            manager = ReportManager(["json", "mysql"])
+
+        self.assertEqual(manager.reports, [])
+        load_report.assert_not_called()


### PR DESCRIPTION
## Summary
- resolve report destinations from the current runtime options when a report manager is created
- preserve lazy loading for optional MySQL and PostgreSQL reporters
- add coverage for every report format and artifact-level JSON/SQLite persistence after session option restoration

## User-visible effect
Resuming a session now keeps writing newly discovered results to the output file or database saved in that session. Previously, importing the report manager before restoring the session captured empty destinations and silently disabled those handlers.

## Validation
- Full suite: 399 passed, 20 skipped
- Focused report/session suite: 22 passed
- Flake8: passed
- compileall: passed
- git diff --check: passed