### PR TITLE
Make scheme detection proxy-safe

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -654,6 +654,11 @@ class Controller:
         url = ensure_trailing_path_slash(url)
 
         parsed = urlparse(url)
+        if parsed.scheme == UNKNOWN and (options["proxies"] or options["tor"]):
+            raise InvalidURLException(
+                "Cannot auto-detect the scheme when using a proxy or Tor. "
+                "Specify http:// or https:// in the target, or use --scheme"
+            )
         self.base_path = lstrip_once(parsed.path, "/")
 
         # Credentials in URL

--- a/lib/utils/schemedet.py
+++ b/lib/utils/schemedet.py
@@ -33,6 +33,8 @@ def detect_scheme(host, port, connect_host=None):
     try:
         conn.connect((connect_host or host, port))
         return "https"
+    except ssl.SSLCertVerificationError:
+        return "https"
     except OSError:
         return "http"
     finally:

--- a/tests/controller/test_target_dns.py
+++ b/tests/controller/test_target_dns.py
@@ -21,6 +21,7 @@ from unittest.mock import Mock, call, patch
 
 from lib.controller.controller import Controller
 from lib.core.data import options
+from lib.core.exceptions import InvalidURLException
 
 
 class TestControllerTargetDNS(TestCase):
@@ -31,6 +32,8 @@ class TestControllerTargetDNS(TestCase):
                 "request_backend": "python",
                 "scheme": None,
                 "ip": "192.0.2.10",
+                "proxies": [],
+                "tor": False,
             }
         )
         self.controller = object.__new__(Controller)
@@ -69,4 +72,62 @@ class TestControllerTargetDNS(TestCase):
         )
         self.controller.requester.set_url.assert_called_once_with(
             "https://forced-origin.invalid/"
+        )
+
+    def test_proxy_or_tor_rejects_scheme_less_target_without_direct_probe(self):
+        routing_options = (
+            {"proxies": ["socks5h://127.0.0.1:9050"], "tor": False},
+            {"proxies": [], "tor": True},
+        )
+
+        for routing in routing_options:
+            with self.subTest(routing=routing):
+                options.update({"ip": None, "proxies": [], "tor": False})
+                options.update(routing)
+                self.controller.requester.reset_mock()
+
+                with patch(
+                    "lib.controller.controller.detect_scheme",
+                    return_value="https",
+                ) as detect_scheme, self.assertRaisesRegex(
+                    InvalidURLException,
+                    "Cannot auto-detect the scheme when using a proxy or Tor",
+                ):
+                    self.controller.set_target("user:secret@private.example")
+
+                detect_scheme.assert_not_called()
+                self.controller.requester.set_auth.assert_not_called()
+                self.controller.requester.set_url.assert_not_called()
+
+    def test_proxy_accepts_an_explicit_url_scheme(self):
+        options.update(
+            {
+                "ip": None,
+                "proxies": ["http://127.0.0.1:8080"],
+            }
+        )
+
+        with patch("lib.controller.controller.detect_scheme") as detect_scheme:
+            self.controller.set_target("https://example.test")
+
+        detect_scheme.assert_not_called()
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://example.test/"
+        )
+
+    def test_proxy_accepts_scheme_option(self):
+        options.update(
+            {
+                "ip": None,
+                "proxies": ["http://127.0.0.1:8080"],
+                "scheme": "https",
+            }
+        )
+
+        with patch("lib.controller.controller.detect_scheme") as detect_scheme:
+            self.controller.set_target("example.test")
+
+        detect_scheme.assert_not_called()
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://example.test/"
         )

--- a/tests/utils/test_schemedet.py
+++ b/tests/utils/test_schemedet.py
@@ -15,11 +15,13 @@
 #
 #  Author: Mauro Soria
 
+import ssl
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from lib.core.settings import SOCKET_TIMEOUT
 from lib.utils.schemedet import detect_scheme
+from tests.connection.proxy_server import ProxyTestStack
 
 
 class TestSchemedet(TestCase):
@@ -56,5 +58,22 @@ class TestSchemedet(TestCase):
     def test_falls_back_to_http_when_tls_connection_fails(self):
         self.assertEqual(self.run_probe(OSError("network unavailable")), "http")
 
+    def test_certificate_verification_failure_still_identifies_https(self):
+        error = ssl.SSLCertVerificationError(1, "certificate verify failed")
+
+        self.assertEqual(self.run_probe(error), "https")
+
     def test_connects_to_explicit_address_without_changing_tls_hostname(self):
         self.assertEqual(self.run_probe(connect_host="192.0.2.10"), "https")
+
+    def test_detects_self_signed_https_endpoint(self):
+        with ProxyTestStack() as stack:
+            port = stack.https_target.server.server_port
+
+            scheme = detect_scheme(
+                "localhost",
+                port,
+                connect_host="127.0.0.1",
+            )
+
+        self.assertEqual(scheme, "https")


### PR DESCRIPTION
## Summary
- prevent scheme auto-detection from opening a direct target connection when proxy or Tor routing is configured
- keep scheme-less proxy scans usable through an explicit URL scheme or --scheme
- classify certificate-verification failures as HTTPS because they prove TLS is present
- add regression coverage for proxy, Tor, explicit-scheme, IP override, and a real self-signed TLS endpoint

## User-visible effect
Scheme-less targets used with a proxy or Tor now fail with an actionable message instead of silently probing the target directly. Direct scans retain automatic scheme detection, including self-signed HTTPS endpoints.

## Validation
- Full suite: 404 passed, 20 skipped
- Focused scheme/target/proxy suite: 28 passed, 4 optional-native tests skipped
- CLI proxy smoke test: passed with the expected actionable error
- Flake8: passed
- compileall: passed
- git diff --check: passed