### PR TITLE
Validate exclusion regexes before scanning

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -47,7 +47,7 @@ from lib.core.exceptions import (
     WordlistLimitError,
 )
 from lib.core.logger import enable_logging, logger
-from lib.core.options import validate_numeric_options
+from lib.core.options import validate_numeric_options, validate_regex_options
 from lib.core.request_backend import (
     get_native_request_backend_error,
     get_native_target_error,
@@ -228,6 +228,7 @@ class Controller:
             options.update(session_store.restore_options(payload["options"]))
             options["session_file"] = loaded_session_file
             validate_numeric_options(SimpleNamespace(**options))
+            validate_regex_options(SimpleNamespace(**options))
             if options["log_file"]:
                 try:
                     FileUtils.create_dir(FileUtils.parent(options["log_file"]))

--- a/lib/core/options.py
+++ b/lib/core/options.py
@@ -258,10 +258,7 @@ def parse_options() -> dict[str, Any]:
     opt.filter_time = _parse_advanced_times(opt.filter_time, "--filter-time")
     _validate_advanced_mode(opt.matcher_mode, "--matcher-mode")
     _validate_advanced_mode(opt.filter_mode, "--filter-mode")
-    _validate_advanced_regex(opt.match_regex, "--match-regex")
-    _validate_advanced_regex(opt.filter_regex, "--filter-regex")
-    _validate_advanced_regex(opt.match_header_regex, "--match-header-regex")
-    _validate_advanced_regex(opt.filter_header_regex, "--filter-header-regex")
+    validate_regex_options(opt)
     opt.prefixes = tuple(strip_and_uniquify(opt.prefixes.split(",")))
     opt.suffixes = tuple(strip_and_uniquify(opt.suffixes.split(",")))
     opt.subdirs = [
@@ -445,12 +442,26 @@ def _parse_size_list(value: str | None, option_name: str) -> set[int]:
         sys.exit(1)
 
 
-def _validate_advanced_regex(pattern: str | None, option_name: str) -> None:
+def _validate_regex_option(pattern: str | None, option_name: str) -> None:
     try:
         validate_regex(pattern, option_name)
     except ValueError as error:
         print(str(error))
         sys.exit(1)
+
+
+def validate_regex_options(opt: Any) -> None:
+    regex_options = (
+        ("exclude_regex", "--exclude-regex"),
+        ("exclude_redirect", "--exclude-redirect"),
+        ("match_regex", "--match-regex"),
+        ("filter_regex", "--filter-regex"),
+        ("match_header_regex", "--match-header-regex"),
+        ("filter_header_regex", "--filter-header-regex"),
+    )
+
+    for option_key, option_name in regex_options:
+        _validate_regex_option(getattr(opt, option_key), option_name)
 
 
 def _validate_advanced_mode(value: str, option_name: str) -> None:

--- a/tests/core/test_regex_option_validation.py
+++ b/tests/core/test_regex_option_validation.py
@@ -1,0 +1,91 @@
+import io
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.controller.controller import Controller
+from lib.controller.session import SessionStore
+from lib.core.data import options as runtime_options
+from lib.core.options import parse_options
+
+
+class TestRegexOptionValidation(TestCase):
+    BASE_ARGUMENTS = ["dirsearch.py", "--wordlist-status", "-e", "php"]
+    EXCLUSION_OPTIONS = (
+        ("--exclude-regex", "exclude-regex", "exclude_regex"),
+        ("--exclude-redirect", "exclude-redirect", "exclude_redirect"),
+    )
+    INVALID_PATTERNS = ("[", "(", "*", "trailing\\")
+
+    def assert_rejected(self, arguments, option_name):
+        output = io.StringIO()
+        with (
+            patch.object(sys, "argv", [*self.BASE_ARGUMENTS, *arguments]),
+            redirect_stdout(output),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            parse_options()
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertTrue(
+            output.getvalue().startswith(
+                f"Invalid --{option_name} regular expression:"
+            ),
+            output.getvalue(),
+        )
+
+    def test_invalid_cli_exclusion_regexes_are_rejected(self):
+        for cli_option, option_name, _ in self.EXCLUSION_OPTIONS:
+            for pattern in self.INVALID_PATTERNS:
+                with self.subTest(cli_option=cli_option, pattern=pattern):
+                    self.assert_rejected((cli_option, pattern), option_name)
+
+    def test_invalid_config_exclusion_regexes_are_rejected(self):
+        for _, option_name, _ in self.EXCLUSION_OPTIONS:
+            with self.subTest(option_name=option_name), tempfile.TemporaryDirectory() as directory:
+                config_path = Path(directory, "config.ini")
+                config_path.write_text(
+                    f"[general]\n{option_name} = [\n",
+                    encoding="utf-8",
+                )
+                self.assert_rejected(("--config", str(config_path)), option_name)
+
+    def test_invalid_restored_session_regexes_are_rejected(self):
+        for _, option_name, option_key in self.EXCLUSION_OPTIONS:
+            with self.subTest(option_key=option_key):
+                output = io.StringIO()
+                controller = object.__new__(Controller)
+                payload = {"options": {option_key: "["}}
+
+                with (
+                    patch.dict(runtime_options),
+                    patch.object(SessionStore, "load", return_value=payload),
+                    redirect_stdout(output),
+                    self.assertRaises(SystemExit) as raised,
+                ):
+                    controller._import("session.json")
+
+                self.assertEqual(raised.exception.code, 1)
+                self.assertTrue(
+                    output.getvalue().startswith(
+                        f"Invalid --{option_name} regular expression:"
+                    ),
+                    output.getvalue(),
+                )
+
+    def test_valid_exclusion_regexes_are_preserved(self):
+        arguments = (
+            "--exclude-regex",
+            r"not\s+found",
+            "--exclude-redirect",
+            r"/login(?:\?.*)?$",
+        )
+
+        with patch.object(sys, "argv", [*self.BASE_ARGUMENTS, *arguments]):
+            parsed = parse_options()
+
+        self.assertEqual(parsed["exclude_regex"], r"not\s+found")
+        self.assertEqual(parsed["exclude_redirect"], r"/login(?:\?.*)?$")


### PR DESCRIPTION
## Summary
- validate classic body and redirect exclusion regexes alongside advanced regex options
- apply the same validation after restoring session options
- add CLI, config, session, malformed-pattern, and valid-pattern regressions

## User-visible effect
Malformed --exclude-regex and --exclude-redirect values now fail at startup with a specific error. Previously they could survive option parsing and abort only after a response reached the fuzzer.

## Validation
- Full suite: 408 passed, 20 skipped
- Focused option/filter suite: 36 passed
- Real CLI invalid-regex smoke test: exited 1 with the expected message
- Flake8: passed
- compileall: passed
- git diff --check: passed