### PR TITLE
Protect session files with private permissions

### DIFF
--- a/lib/controller/session.py
+++ b/lib/controller/session.py
@@ -22,6 +22,7 @@ import base64
 import binascii
 import json
 import os
+import tempfile
 from typing import Any
 
 from lib.core.exceptions import InvalidURLException, UnpicklingError
@@ -135,7 +136,7 @@ class SessionStore:
             "options": self._serialize_options(),
             "last_output": last_output,
         }
-        FileUtils.create_dir(session_dir)
+        os.makedirs(session_dir, mode=0o700, exist_ok=True)
 
         meta_path = FileUtils.build_path(session_dir, self.FILES["meta"])
         self._write_json(
@@ -283,8 +284,25 @@ class SessionStore:
             raise UnpicklingError(str(error)) from error
 
     def _write_json(self, path: str, payload: dict[str, Any]) -> None:
-        with open(path, "w", encoding="utf-8") as file_handle:
-            json.dump(payload, file_handle, indent=2, ensure_ascii=False)
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{os.path.basename(path)}.",
+            suffix=".tmp",
+            dir=FileUtils.parent(path),
+        )
+        try:
+            if os.name != "nt":
+                os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as file_handle:
+                descriptor = -1
+                json.dump(payload, file_handle, indent=2, ensure_ascii=False)
+            os.replace(temporary_path, path)
+        finally:
+            if descriptor != -1:
+                os.close(descriptor)
+            try:
+                os.remove(temporary_path)
+            except FileNotFoundError:
+                pass
 
     def _validate_payload(self, payload: dict[str, Any]) -> None:
         if payload.get("version") != self.SESSION_VERSION:

--- a/lib/controller/session.py
+++ b/lib/controller/session.py
@@ -22,7 +22,6 @@ import base64
 import binascii
 import json
 import os
-import tempfile
 from typing import Any
 
 from lib.core.exceptions import InvalidURLException, UnpicklingError
@@ -136,7 +135,7 @@ class SessionStore:
             "options": self._serialize_options(),
             "last_output": last_output,
         }
-        os.makedirs(session_dir, mode=0o700, exist_ok=True)
+        FileUtils.create_private_dir(session_dir)
 
         meta_path = FileUtils.build_path(session_dir, self.FILES["meta"])
         self._write_json(
@@ -284,25 +283,8 @@ class SessionStore:
             raise UnpicklingError(str(error)) from error
 
     def _write_json(self, path: str, payload: dict[str, Any]) -> None:
-        descriptor, temporary_path = tempfile.mkstemp(
-            prefix=f".{os.path.basename(path)}.",
-            suffix=".tmp",
-            dir=FileUtils.parent(path),
-        )
-        try:
-            if os.name != "nt":
-                os.fchmod(descriptor, 0o600)
-            with os.fdopen(descriptor, "w", encoding="utf-8") as file_handle:
-                descriptor = -1
-                json.dump(payload, file_handle, indent=2, ensure_ascii=False)
-            os.replace(temporary_path, path)
-        finally:
-            if descriptor != -1:
-                os.close(descriptor)
-            try:
-                os.remove(temporary_path)
-            except FileNotFoundError:
-                pass
+        with FileUtils.atomic_write_private_text(path) as file_handle:
+            json.dump(payload, file_handle, indent=2, ensure_ascii=False)
 
     def _validate_payload(self, payload: dict[str, Any]) -> None:
         if payload.get("version") != self.SESSION_VERSION:

--- a/lib/utils/file.py
+++ b/lib/utils/file.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import os
 import os.path
 import tempfile
@@ -150,6 +151,15 @@ class FileUtils:
         if not cls.exists(directory):
             os.makedirs(directory, exist_ok=True)
 
+    @staticmethod
+    def create_private_dir(directory: str) -> None:
+        """Create a private leaf directory without following a leaf link."""
+        if os.path.islink(directory):
+            raise OSError(f"Refusing symbolic link: {directory}")
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+        if os.path.islink(directory):
+            raise OSError(f"Refusing symbolic link: {directory}")
+
     @classmethod
     def create_writable_dir(cls, directory: str) -> None:
         """Create a directory and prove that files can be created inside it."""
@@ -183,6 +193,30 @@ class FileUtils:
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         return os.open(file_name, flags, 0o600)
+
+    @staticmethod
+    @contextmanager
+    def atomic_write_private_text(file_name: str, encoding: str = "utf-8"):
+        """Write text through a private same-directory replacement file."""
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{os.path.basename(file_name)}.",
+            suffix=".tmp",
+            dir=FileUtils.parent(file_name),
+        )
+        try:
+            if os.name != "nt":
+                os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding=encoding) as file_handle:
+                descriptor = -1
+                yield file_handle
+            os.replace(temporary_path, file_name)
+        finally:
+            if descriptor != -1:
+                os.close(descriptor)
+            try:
+                os.remove(temporary_path)
+            except FileNotFoundError:
+                pass
 
     @staticmethod
     def _open_exclusive_windows(file_name: str) -> int:

--- a/tests/controller/test_session_store.py
+++ b/tests/controller/test_session_store.py
@@ -23,8 +23,7 @@ import os
 import stat
 import tempfile
 from types import SimpleNamespace
-from unittest import TestCase, skipIf, skipUnless
-from unittest.mock import patch
+from unittest import TestCase, skipIf
 
 from lib.controller.session import SessionStore
 from lib.core.dictionary import Dictionary
@@ -104,21 +103,6 @@ class TestSessionStore(TestCase):
 
         self.assertEqual(restored["data"], body)
 
-    def test_new_session_requests_private_directory_permissions(self):
-        with tempfile.TemporaryDirectory() as root:
-            session_dir = os.path.join(root, "session")
-            with patch(
-                "lib.controller.session.os.makedirs",
-                wraps=os.makedirs,
-            ) as makedirs:
-                SessionStore({}).save(self._controller(), session_dir, "")
-
-        makedirs.assert_called_once_with(
-            session_dir,
-            mode=0o700,
-            exist_ok=True,
-        )
-
     @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
     def test_new_session_directory_and_files_are_private(self):
         with tempfile.TemporaryDirectory() as root:
@@ -168,44 +152,6 @@ class TestSessionStore(TestCase):
                         stat.S_IMODE(os.stat(file_path).st_mode),
                         0o600,
                     )
-
-    @skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
-    def test_json_write_replaces_symlink_without_following_it(self):
-        with tempfile.TemporaryDirectory() as root:
-            outside_path = os.path.join(root, "outside.json")
-            session_path = os.path.join(root, "options.json")
-            self._write_json(outside_path, {"outside": "preserved"})
-            try:
-                os.symlink(outside_path, session_path)
-            except (NotImplementedError, OSError) as error:
-                self.skipTest(f"symbolic links are unavailable: {error}")
-
-            SessionStore({})._write_json(session_path, {"session": "private"})
-
-            with open(outside_path, encoding="utf-8") as file_handle:
-                self.assertEqual(json.load(file_handle), {"outside": "preserved"})
-            self.assertFalse(os.path.islink(session_path))
-            with open(session_path, encoding="utf-8") as file_handle:
-                self.assertEqual(json.load(file_handle), {"session": "private"})
-
-    def test_failed_json_write_preserves_existing_file(self):
-        with tempfile.TemporaryDirectory() as root:
-            session_path = os.path.join(root, "options.json")
-            self._write_json(session_path, {"session": "preserved"})
-
-            with patch(
-                "lib.controller.session.json.dump",
-                side_effect=OSError("write failed"),
-            ):
-                with self.assertRaisesRegex(OSError, "write failed"):
-                    SessionStore({})._write_json(
-                        session_path,
-                        {"session": "replacement"},
-                    )
-
-            with open(session_path, encoding="utf-8") as file_handle:
-                self.assertEqual(json.load(file_handle), {"session": "preserved"})
-            self.assertEqual(os.listdir(root), ["options.json"])
 
     def test_bytes_marker_in_headers_remains_a_header_mapping(self):
         marker = SessionStore.SESSION_BYTES_MARKER

--- a/tests/controller/test_session_store.py
+++ b/tests/controller/test_session_store.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import tempfile
 from types import SimpleNamespace
-from unittest import TestCase
+from unittest import TestCase, skipIf, skipUnless
+from unittest.mock import patch
 
 from lib.controller.session import SessionStore
 from lib.core.dictionary import Dictionary
@@ -58,6 +60,21 @@ class TestSessionStore(TestCase):
         }
         self._write_json(session_file, payload)
 
+    def _controller(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            start_time="2026-01-01T00:00:00Z",
+            passed_urls=set(),
+            directories=[],
+            jobs_processed=0,
+            errors=0,
+            consecutive_errors=0,
+            base_path="",
+            url="https://example.com/",
+            old_session=False,
+            dictionary=Dictionary(),
+            output_history=[],
+        )
+
     def test_list_sessions_recurses_and_includes_root_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             nested_dir = os.path.join(tmpdir, "2024-01-01", "session_01")
@@ -77,19 +94,7 @@ class TestSessionStore(TestCase):
     def test_request_body_bytes_round_trip_through_json_session(self):
         body = "value=\u00e9&currency=\u20ac\r\n".encode("cp1252")
         session_options = {"data": body, "output_formats": []}
-        controller = SimpleNamespace(
-            start_time="2026-01-01T00:00:00Z",
-            passed_urls=set(),
-            directories=[],
-            jobs_processed=0,
-            errors=0,
-            consecutive_errors=0,
-            base_path="",
-            url="https://example.com/",
-            old_session=False,
-            dictionary=Dictionary(),
-            output_history=[],
-        )
+        controller = self._controller()
 
         with tempfile.TemporaryDirectory() as session_dir:
             store = SessionStore(session_options)
@@ -98,6 +103,109 @@ class TestSessionStore(TestCase):
             restored = store.restore_options(payload["options"])
 
         self.assertEqual(restored["data"], body)
+
+    def test_new_session_requests_private_directory_permissions(self):
+        with tempfile.TemporaryDirectory() as root:
+            session_dir = os.path.join(root, "session")
+            with patch(
+                "lib.controller.session.os.makedirs",
+                wraps=os.makedirs,
+            ) as makedirs:
+                SessionStore({}).save(self._controller(), session_dir, "")
+
+        makedirs.assert_called_once_with(
+            session_dir,
+            mode=0o700,
+            exist_ok=True,
+        )
+
+    @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
+    def test_new_session_directory_and_files_are_private(self):
+        with tempfile.TemporaryDirectory() as root:
+            for umask in (0o000, 0o022):
+                with self.subTest(umask=oct(umask)):
+                    session_dir = os.path.join(root, f"session-{umask:o}")
+                    previous_umask = os.umask(umask)
+                    try:
+                        SessionStore({"auth": "alice:secret"}).save(
+                            self._controller(), session_dir, ""
+                        )
+                    finally:
+                        os.umask(previous_umask)
+
+                    self.assertEqual(
+                        stat.S_IMODE(os.stat(session_dir).st_mode),
+                        0o700,
+                    )
+                    for file_name in SessionStore.FILES.values():
+                        with self.subTest(file_name=file_name):
+                            file_path = os.path.join(session_dir, file_name)
+                            self.assertEqual(
+                                stat.S_IMODE(os.stat(file_path).st_mode),
+                                0o600,
+                            )
+
+    @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
+    def test_resaving_legacy_session_tightens_file_permissions(self):
+        with tempfile.TemporaryDirectory() as root:
+            session_dir = os.path.join(root, "session")
+            store = SessionStore({"auth": "alice:secret"})
+            store.save(self._controller(), session_dir, "")
+            os.chmod(session_dir, 0o755)
+            for file_name in SessionStore.FILES.values():
+                os.chmod(os.path.join(session_dir, file_name), 0o644)
+
+            store.save(self._controller(), session_dir, "")
+
+            self.assertEqual(
+                stat.S_IMODE(os.stat(session_dir).st_mode),
+                0o755,
+            )
+            for file_name in SessionStore.FILES.values():
+                with self.subTest(file_name=file_name):
+                    file_path = os.path.join(session_dir, file_name)
+                    self.assertEqual(
+                        stat.S_IMODE(os.stat(file_path).st_mode),
+                        0o600,
+                    )
+
+    @skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
+    def test_json_write_replaces_symlink_without_following_it(self):
+        with tempfile.TemporaryDirectory() as root:
+            outside_path = os.path.join(root, "outside.json")
+            session_path = os.path.join(root, "options.json")
+            self._write_json(outside_path, {"outside": "preserved"})
+            try:
+                os.symlink(outside_path, session_path)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"symbolic links are unavailable: {error}")
+
+            SessionStore({})._write_json(session_path, {"session": "private"})
+
+            with open(outside_path, encoding="utf-8") as file_handle:
+                self.assertEqual(json.load(file_handle), {"outside": "preserved"})
+            self.assertFalse(os.path.islink(session_path))
+            with open(session_path, encoding="utf-8") as file_handle:
+                self.assertEqual(json.load(file_handle), {"session": "private"})
+
+    def test_failed_json_write_preserves_existing_file(self):
+        with tempfile.TemporaryDirectory() as root:
+            session_path = os.path.join(root, "options.json")
+            self._write_json(session_path, {"session": "preserved"})
+
+            with patch(
+                "lib.controller.session.json.dump",
+                side_effect=OSError("write failed"),
+            ):
+                with self.assertRaisesRegex(OSError, "write failed"):
+                    SessionStore({})._write_json(
+                        session_path,
+                        {"session": "replacement"},
+                    )
+
+            with open(session_path, encoding="utf-8") as file_handle:
+                self.assertEqual(json.load(file_handle), {"session": "preserved"})
+            self.assertEqual(os.listdir(root), ["options.json"])
 
     def test_bytes_marker_in_headers_remains_a_header_mapping(self):
         marker = SessionStore.SESSION_BYTES_MARKER

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -1,14 +1,125 @@
 # -*- coding: utf-8 -*-
 
 import os
+import stat
 import tempfile
-from unittest import TestCase, skipUnless
+from unittest import TestCase, skipIf, skipUnless
 from unittest.mock import patch
 
 from lib.utils.file import FileUtils
 
 
 class TestFileUtils(TestCase):
+    def test_create_private_dir_requests_private_mode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            destination = FileUtils.build_path(directory, "session")
+            with patch(
+                "lib.utils.file.os.makedirs",
+                wraps=os.makedirs,
+            ) as makedirs:
+                FileUtils.create_private_dir(destination)
+
+        makedirs.assert_called_once_with(
+            destination,
+            mode=0o700,
+            exist_ok=True,
+        )
+
+    @skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
+    def test_create_private_dir_rejects_directory_symlink(self):
+        with tempfile.TemporaryDirectory() as directory:
+            outside = FileUtils.build_path(directory, "outside")
+            destination = FileUtils.build_path(directory, "session")
+            os.mkdir(outside)
+            try:
+                os.symlink(outside, destination, target_is_directory=True)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"symbolic links are unavailable: {error}")
+
+            with self.assertRaisesRegex(OSError, "Refusing symbolic link"):
+                FileUtils.create_private_dir(destination)
+
+            self.assertEqual(os.listdir(outside), [])
+
+    @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
+    def test_private_writes_set_modes_without_changing_existing_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            destination = FileUtils.build_path(directory, "session")
+            previous_umask = os.umask(0o000)
+            try:
+                FileUtils.create_private_dir(destination)
+                file_name = FileUtils.build_path(destination, "options.json")
+                with FileUtils.atomic_write_private_text(file_name) as file_handle:
+                    file_handle.write("first")
+            finally:
+                os.umask(previous_umask)
+
+            self.assertEqual(stat.S_IMODE(os.stat(destination).st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(os.stat(file_name).st_mode), 0o600)
+
+            os.chmod(destination, 0o755)
+            os.chmod(file_name, 0o644)
+            FileUtils.create_private_dir(destination)
+            with FileUtils.atomic_write_private_text(file_name) as file_handle:
+                file_handle.write("second")
+
+            self.assertEqual(stat.S_IMODE(os.stat(destination).st_mode), 0o755)
+            self.assertEqual(stat.S_IMODE(os.stat(file_name).st_mode), 0o600)
+
+    def test_atomic_private_write_preserves_existing_file_on_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_name = FileUtils.build_path(directory, "options.json")
+            with open(file_name, "w", encoding="utf-8") as file_handle:
+                file_handle.write("preserved")
+
+            with self.assertRaisesRegex(OSError, "write failed"):
+                with FileUtils.atomic_write_private_text(file_name) as file_handle:
+                    file_handle.write("replacement")
+                    raise OSError("write failed")
+
+            with open(file_name, encoding="utf-8") as file_handle:
+                self.assertEqual(file_handle.read(), "preserved")
+            self.assertEqual(os.listdir(directory), ["options.json"])
+
+    def test_atomic_private_write_cleans_up_after_replace_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_name = FileUtils.build_path(directory, "options.json")
+            with open(file_name, "w", encoding="utf-8") as file_handle:
+                file_handle.write("preserved")
+
+            with patch(
+                "lib.utils.file.os.replace",
+                side_effect=OSError("replace failed"),
+            ):
+                with self.assertRaisesRegex(OSError, "replace failed"):
+                    with FileUtils.atomic_write_private_text(file_name) as file_handle:
+                        file_handle.write("replacement")
+
+            with open(file_name, encoding="utf-8") as file_handle:
+                self.assertEqual(file_handle.read(), "preserved")
+            self.assertEqual(os.listdir(directory), ["options.json"])
+
+    @skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
+    def test_atomic_private_write_replaces_symlink_without_following_it(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_name = FileUtils.build_path(directory, "options.json")
+            outside = FileUtils.build_path(directory, "outside.json")
+            with open(outside, "w", encoding="utf-8") as file_handle:
+                file_handle.write("preserved")
+            try:
+                os.symlink(outside, file_name)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"symbolic links are unavailable: {error}")
+
+            with FileUtils.atomic_write_private_text(file_name) as file_handle:
+                file_handle.write("replacement")
+
+            with open(outside, encoding="utf-8") as file_handle:
+                self.assertEqual(file_handle.read(), "preserved")
+            self.assertFalse(FileUtils.is_link(file_name))
+            with open(file_name, encoding="utf-8") as file_handle:
+                self.assertEqual(file_handle.read(), "replacement")
+
     def test_create_writable_dir_creates_and_validates_directory(self):
         with tempfile.TemporaryDirectory() as directory:
             destination = FileUtils.build_path(directory, "responses")


### PR DESCRIPTION
## Summary

- move private directory creation and atomic private text replacement into `FileUtils`
- keep `SessionStore` responsible only for JSON serialization
- create new POSIX session directories with `0700` permissions and write all four JSON files through `0600` same-directory temporary files
- tighten permissive files when an older session is saved again without changing the mode of an existing user-supplied directory
- reject a session-directory leaf symlink and replace destination-file symlinks instead of following them
- preserve the prior destination and clean up the temporary file when serialization or replacement fails

## User-visible effect

Session state can contain authentication values, cookies, headers, request bodies, targets, and scan progress. New POSIX session directories/files are no longer created as `0755`/`0644` under a common `022` umask. Windows retains the same atomic replacement path without POSIX-only `fchmod`; existing user-supplied directory ACLs are left untouched.

Each JSON replacement is failure-safe, but cross-file transaction/manifest consistency remains a separate issue and is intentionally outside this PR.

## Tests

- `python -m unittest tests.utils.test_file tests.controller.test_session_store tests.controller.test_session_cleanup -v` (21 passed)
- `python -m unittest tests.controller.test_session_store tests.controller.test_session_cleanup tests.core.test_options tests.core.test_options_config_merge tests.report.test_report_manager tests.utils.test_file -v` (36 passed before the two final helper edge-case tests were added)
- `python -m unittest discover -s tests -t .` (419 passed, 20 skipped)
- `python testing.py` (419 passed, 20 skipped)
- `python -m flake8 lib/controller/session.py lib/utils/file.py tests/controller/test_session_store.py tests/utils/test_file.py`
- `python -m compileall -q lib/controller/session.py lib/utils/file.py tests/controller/test_session_store.py tests/utils/test_file.py`
- `git diff --check`
