### PR TITLE
Redact secrets from report command metadata

### DIFF
--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -21,6 +21,7 @@ import sys
 import string
 import time
 
+from lib.utils.command import redact_command
 from lib.utils.file import FileUtils
 
 # Version format: <major version>.<minor version>.<revision>[.<month>]
@@ -31,7 +32,7 @@ BANNER = f"""
  (_||| _) (/_(_|| (_| )
 """
 
-COMMAND = " ".join(sys.argv)
+COMMAND = redact_command(sys.argv)
 
 START_TIME = time.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/lib/utils/command.py
+++ b/lib/utils/command.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#  Author: Mauro Soria
+
+from collections.abc import Sequence
+
+
+REDACTED_VALUE = "<redacted>"
+
+SENSITIVE_OPTIONS = frozenset(
+    {
+        "-d",
+        "--data",
+        "-H",
+        "--header",
+        "--auth",
+        "--cookie",
+        "-p",
+        "--proxy",
+        "--proxy-auth",
+        "--replay-proxy",
+        "--mysql-url",
+        "--postgres-url",
+    }
+)
+
+SENSITIVE_SHORT_OPTIONS = ("-d", "-H", "-p")
+
+TARGET_OPTIONS = frozenset({"-u", "--url"})
+
+SHORT_FLAG_OPTIONS = frozenset(
+    {"-a", "-C", "-f", "-F", "-h", "-L", "-q", "-r", "-U", "-v"}
+)
+
+
+def _matches_option(option: str, candidates: frozenset[str]) -> bool:
+    if option in candidates:
+        return True
+    return option.startswith("--") and any(
+        candidate.startswith(option)
+        for candidate in candidates
+        if candidate.startswith("--")
+    )
+
+
+def _redact_value(option: str, value: str) -> str:
+    if _matches_option(option, SENSITIVE_OPTIONS):
+        return REDACTED_VALUE
+    if _matches_option(option, TARGET_OPTIONS) and "@" in value:
+        return REDACTED_VALUE
+    return value
+
+
+def _find_short_value_option(argument: str) -> tuple[str, int] | None:
+    if not argument.startswith("-") or argument.startswith("--"):
+        return None
+
+    for index, character in enumerate(argument[1:], 1):
+        option = f"-{character}"
+        if option in SENSITIVE_SHORT_OPTIONS + ("-u",):
+            return option, index + 1
+        if option not in SHORT_FLAG_OPTIONS:
+            return None
+    return None
+
+
+def redact_command(arguments: Sequence[str]) -> str:
+    """Format command metadata without persisting credential-bearing values."""
+    redacted = []
+    index = 0
+
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            redacted.extend(arguments[index:])
+            break
+
+        option, separator, value = argument.partition("=")
+        if separator and option.startswith("--"):
+            redacted.append(f"{option}={_redact_value(option, value)}")
+            index += 1
+            continue
+
+        if _matches_option(argument, SENSITIVE_OPTIONS | TARGET_OPTIONS):
+            redacted.append(argument)
+            if index + 1 < len(arguments):
+                redacted.append(_redact_value(argument, arguments[index + 1]))
+                index += 2
+            else:
+                index += 1
+            continue
+
+        short_value_option = _find_short_value_option(argument)
+        if short_value_option:
+            short_option, value_index = short_value_option
+            attached_value = argument[value_index:]
+            if attached_value:
+                redacted.append(
+                    argument[:value_index]
+                    + _redact_value(short_option, attached_value)
+                )
+            else:
+                redacted.append(argument)
+                if index + 1 < len(arguments):
+                    redacted.append(
+                        _redact_value(short_option, arguments[index + 1])
+                    )
+                    index += 1
+        else:
+            redacted.append(argument)
+        index += 1
+
+    return " ".join(redacted)

--- a/tests/report/test_report_command_redaction.py
+++ b/tests/report/test_report_command_redaction.py
@@ -1,0 +1,49 @@
+import json
+import subprocess
+import sys
+from unittest import TestCase
+
+
+class TestReportCommandRedaction(TestCase):
+    def test_all_command_report_formats_use_redacted_metadata(self):
+        secret = "REPORT_ARTIFACT_SECRET"
+        script = """
+import json
+from lib.report.html_report import HTMLReport
+from lib.report.json_report import JSONReport
+from lib.report.markdown_report import MarkdownReport
+from lib.report.plain_text_report import PlainTextReport
+from lib.report.xml_report import XMLReport
+
+print(json.dumps({
+    "plain": PlainTextReport().new(),
+    "markdown": MarkdownReport().new(),
+    "json": json.dumps(JSONReport().new()),
+    "xml": XMLReport().new().attrib["args"],
+    "html": HTMLReport().new(),
+}))
+"""
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                script,
+                f"--auth={secret}",
+                "--threads",
+                "7",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payloads = json.loads(completed.stdout)
+
+        self.assertEqual(
+            set(payloads),
+            {"plain", "markdown", "json", "xml", "html"},
+        )
+        for report_format, payload in payloads.items():
+            with self.subTest(report_format=report_format):
+                self.assertNotIn(secret, payload)
+                self.assertIn("redacted", payload)
+                self.assertIn("--threads 7", payload)

--- a/tests/report/test_report_command_redaction.py
+++ b/tests/report/test_report_command_redaction.py
@@ -1,12 +1,49 @@
 import json
 import subprocess
 import sys
+from html import unescape
 from unittest import TestCase
+
+from lib.utils.command import REDACTED_VALUE
 
 
 class TestReportCommandRedaction(TestCase):
     def test_all_command_report_formats_use_redacted_metadata(self):
-        secret = "REPORT_ARTIFACT_SECRET"
+        secret_values = (
+            "test-password",
+            "test-access-token",
+            "test-session-id",
+            "test-csrf-token",
+            "test-body-password",
+            "test-proxy-password",
+            "test-proxy-auth",
+            "test-mysql-password",
+            "test-postgres-password",
+            "test-target-password",
+        )
+        expected_command = " ".join(
+            [
+                "-c",
+                f"--auth={REDACTED_VALUE}",
+                "-H",
+                REDACTED_VALUE,
+                f"--cookie={REDACTED_VALUE}",
+                "--data",
+                REDACTED_VALUE,
+                f"--proxy={REDACTED_VALUE}",
+                "--proxy-auth",
+                REDACTED_VALUE,
+                f"--mysql-url={REDACTED_VALUE}",
+                "--postgres-url",
+                REDACTED_VALUE,
+                f"--url={REDACTED_VALUE}",
+                "--auth-type",
+                "basic",
+                "--threads",
+                "7",
+                "--crawl",
+            ]
+        )
         script = """
 import json
 from lib.report.html_report import HTMLReport
@@ -18,7 +55,7 @@ from lib.report.xml_report import XMLReport
 print(json.dumps({
     "plain": PlainTextReport().new(),
     "markdown": MarkdownReport().new(),
-    "json": json.dumps(JSONReport().new()),
+    "json": JSONReport().new()["info"]["args"],
     "xml": XMLReport().new().attrib["args"],
     "html": HTMLReport().new(),
 }))
@@ -28,9 +65,28 @@ print(json.dumps({
                 sys.executable,
                 "-c",
                 script,
-                f"--auth={secret}",
+                "--auth=test-user:test-password",
+                "-H",
+                "Authorization: Bearer test-access-token",
+                "--cookie=session_id=test-session-id; csrf=test-csrf-token",
+                "--data",
+                "username=test-user&password=test-body-password",
+                "--proxy=http://proxy-user:test-proxy-password"
+                "@proxy.example.test:8080",
+                "--proxy-auth",
+                "test-proxy-user:test-proxy-auth",
+                "--mysql-url=mysql://db-user:test-mysql-password"
+                "@db.example.test/app",
+                "--postgres-url",
+                "postgresql://db-user:test-postgres-password"
+                "@db.example.test/app",
+                "--url=https://scan-user:test-target-password"
+                "@target.example.test/private",
+                "--auth-type",
+                "basic",
                 "--threads",
                 "7",
+                "--crawl",
             ],
             check=True,
             capture_output=True,
@@ -42,8 +98,12 @@ print(json.dumps({
             set(payloads),
             {"plain", "markdown", "json", "xml", "html"},
         )
+        payloads["html"] = unescape(payloads["html"])
         for report_format, payload in payloads.items():
             with self.subTest(report_format=report_format):
-                self.assertNotIn(secret, payload)
-                self.assertIn("redacted", payload)
-                self.assertIn("--threads 7", payload)
+                for secret_value in secret_values:
+                    self.assertNotIn(secret_value, payload)
+                self.assertIn(expected_command, payload)
+
+        self.assertEqual(payloads["json"], expected_command)
+        self.assertEqual(payloads["xml"], expected_command)

--- a/tests/utils/test_command.py
+++ b/tests/utils/test_command.py
@@ -1,0 +1,103 @@
+from unittest import TestCase
+
+from lib.utils.command import REDACTED_VALUE, redact_command
+
+
+class TestCommandRedaction(TestCase):
+    def test_redacts_sensitive_option_forms_and_preserves_safe_arguments(self):
+        secrets = (
+            "AUTH_EQUALS_SECRET",
+            "PROXY_SPLIT_SECRET",
+            "DATA_SHORT_SECRET",
+            "DATA_SPLIT_SECRET",
+            "HEADER_SPLIT_SECRET",
+            "HEADER_EQUALS_SECRET",
+            "COOKIE_SECRET",
+            "PROXY_URL_SECRET",
+            "REPLAY_SECRET",
+            "MYSQL_SECRET",
+            "POSTGRES_SECRET",
+            "TARGET_SPLIT_SECRET",
+            "TARGET_EQUALS_SECRET",
+            "PROXY_ABBREVIATION_SECRET",
+            "COOKIE_ABBREVIATION_SECRET",
+            "MYSQL_ABBREVIATION_SECRET",
+            "REPLAY_ABBREVIATION_SECRET",
+            "CLUSTER_DATA_SECRET",
+            "CLUSTER_HEADER_SECRET",
+            "CLUSTER_PROXY_SECRET",
+            "CLUSTER_TARGET_SECRET",
+        )
+        arguments = [
+            "dirsearch.py",
+            "--auth=AUTH_EQUALS_SECRET",
+            "--proxy-auth",
+            "PROXY_SPLIT_SECRET",
+            "-dDATA_SHORT_SECRET",
+            "--data",
+            "DATA_SPLIT_SECRET",
+            "-H",
+            "Authorization: HEADER_SPLIT_SECRET",
+            "--header=Cookie: HEADER_EQUALS_SECRET",
+            "--cookie",
+            "COOKIE_SECRET",
+            "-phttp://proxy-user:PROXY_URL_SECRET@proxy.test",
+            "--replay-proxy=http://replay-user:REPLAY_SECRET@proxy.test",
+            "--mysql-url",
+            "mysql://db-user:MYSQL_SECRET@db.test/name",
+            "--postgres-url=postgresql://db-user:POSTGRES_SECRET@db.test/name",
+            "-u",
+            "https://target-user:TARGET_SPLIT_SECRET@example.test",
+            "--url=https://target-user:TARGET_EQUALS_SECRET@example.test",
+            "--proxy-a",
+            "PROXY_ABBREVIATION_SECRET",
+            "--cook=COOKIE_ABBREVIATION_SECRET",
+            "--mys",
+            "mysql://db-user:MYSQL_ABBREVIATION_SECRET@db.test/name",
+            "--replay-p=http://replay-user:REPLAY_ABBREVIATION_SECRET@proxy.test",
+            "-qd",
+            "CLUSTER_DATA_SECRET",
+            "-qH",
+            "Authorization: CLUSTER_HEADER_SECRET",
+            "-qphttp://proxy-user:CLUSTER_PROXY_SECRET@proxy.test",
+            "-quhttps://target-user:CLUSTER_TARGET_SECRET@example.test",
+            "--threads",
+            "7",
+            "--crawl",
+        ]
+
+        command = redact_command(arguments)
+
+        for secret in secrets:
+            with self.subTest(secret=secret):
+                self.assertNotIn(secret, command)
+        self.assertIn(f"--auth={REDACTED_VALUE}", command)
+        self.assertIn(f"-d{REDACTED_VALUE}", command)
+        self.assertIn("--threads 7 --crawl", command)
+
+    def test_preserves_other_short_options_with_attached_values(self):
+        arguments = [
+            "dirsearch.py",
+            "-ephp",
+            "-t25",
+            "-Ojson,xml",
+            "-qf",
+        ]
+
+        self.assertEqual(redact_command(arguments), " ".join(arguments))
+
+    def test_preserves_target_without_embedded_credentials(self):
+        command = redact_command(
+            [
+                "dirsearch.py",
+                "-u",
+                "https://example.test/path",
+                "--threads",
+                "7",
+            ]
+        )
+
+        self.assertEqual(
+            command,
+            "dirsearch.py -u https://example.test/path --threads 7",
+        )

--- a/tests/utils/test_command.py
+++ b/tests/utils/test_command.py
@@ -4,76 +4,125 @@ from lib.utils.command import REDACTED_VALUE, redact_command
 
 
 class TestCommandRedaction(TestCase):
-    def test_redacts_sensitive_option_forms_and_preserves_safe_arguments(self):
-        secrets = (
-            "AUTH_EQUALS_SECRET",
-            "PROXY_SPLIT_SECRET",
-            "DATA_SHORT_SECRET",
-            "DATA_SPLIT_SECRET",
-            "HEADER_SPLIT_SECRET",
-            "HEADER_EQUALS_SECRET",
-            "COOKIE_SECRET",
-            "PROXY_URL_SECRET",
-            "REPLAY_SECRET",
-            "MYSQL_SECRET",
-            "POSTGRES_SECRET",
-            "TARGET_SPLIT_SECRET",
-            "TARGET_EQUALS_SECRET",
-            "PROXY_ABBREVIATION_SECRET",
-            "COOKIE_ABBREVIATION_SECRET",
-            "MYSQL_ABBREVIATION_SECRET",
-            "REPLAY_ABBREVIATION_SECRET",
-            "CLUSTER_DATA_SECRET",
-            "CLUSTER_HEADER_SECRET",
-            "CLUSTER_PROXY_SECRET",
-            "CLUSTER_TARGET_SECRET",
+    def test_replaces_realistic_secret_values_with_exact_marker(self):
+        cases = (
+            (
+                "split auth",
+                ["--auth", "alice:auth-password"],
+                ["--auth", REDACTED_VALUE],
+            ),
+            (
+                "equals auth",
+                ["--auth=alice:auth-password"],
+                [f"--auth={REDACTED_VALUE}"],
+            ),
+            (
+                "attached body",
+                ["-dusername=alice&password=body-password"],
+                [f"-d{REDACTED_VALUE}"],
+            ),
+            (
+                "split body",
+                ["--data", "username=alice&password=body-password"],
+                ["--data", REDACTED_VALUE],
+            ),
+            (
+                "authorization header",
+                ["-H", "Authorization: Bearer fake.jwt.signature"],
+                ["-H", REDACTED_VALUE],
+            ),
+            (
+                "cookie header",
+                ["--header=Cookie: session=header-cookie-value"],
+                [f"--header={REDACTED_VALUE}"],
+            ),
+            (
+                "cookie option",
+                ["--cookie", "session=cookie-value; csrftoken=csrf-value"],
+                ["--cookie", REDACTED_VALUE],
+            ),
+            (
+                "attached proxy",
+                ["-phttp://proxy-user:proxy-password@proxy.example"],
+                [f"-p{REDACTED_VALUE}"],
+            ),
+            (
+                "replay proxy",
+                ["--replay-proxy=http://replay-user:replay-password@proxy.example"],
+                [f"--replay-proxy={REDACTED_VALUE}"],
+            ),
+            (
+                "mysql URL",
+                ["--mysql-url", "mysql://reporter:mysql-password@db.example/scan"],
+                ["--mysql-url", REDACTED_VALUE],
+            ),
+            (
+                "postgres URL",
+                [
+                    "--postgres-url=postgresql://reporter:postgres-password"
+                    "@db.example/scan"
+                ],
+                [f"--postgres-url={REDACTED_VALUE}"],
+            ),
+            (
+                "split target userinfo",
+                ["-u", "https://alice:target-password@target.example"],
+                ["-u", REDACTED_VALUE],
+            ),
+            (
+                "equals target userinfo",
+                ["--url=https://alice:target-password@target.example"],
+                [f"--url={REDACTED_VALUE}"],
+            ),
+            (
+                "abbreviated proxy auth",
+                ["--proxy-a", "proxy-user:proxy-auth-password"],
+                ["--proxy-a", REDACTED_VALUE],
+            ),
+            (
+                "abbreviated cookie",
+                ["--cook=session=abbreviated-cookie-value"],
+                [f"--cook={REDACTED_VALUE}"],
+            ),
+            (
+                "abbreviated mysql URL",
+                ["--mys", "mysql://reporter:mysql-password@db.example/scan"],
+                ["--mys", REDACTED_VALUE],
+            ),
+            (
+                "abbreviated replay proxy",
+                ["--replay-p=http://user:replay-password@proxy.example"],
+                [f"--replay-p={REDACTED_VALUE}"],
+            ),
+            (
+                "clustered split body",
+                ["-qd", "username=alice&password=cluster-password"],
+                ["-qd", REDACTED_VALUE],
+            ),
+            (
+                "clustered split header",
+                ["-qH", "Authorization: Bearer clustered-token"],
+                ["-qH", REDACTED_VALUE],
+            ),
+            (
+                "clustered attached proxy",
+                ["-qphttp://user:cluster-password@proxy.example"],
+                [f"-qp{REDACTED_VALUE}"],
+            ),
+            (
+                "clustered attached target",
+                ["-quhttps://alice:cluster-password@target.example"],
+                [f"-qu{REDACTED_VALUE}"],
+            ),
         )
-        arguments = [
-            "dirsearch.py",
-            "--auth=AUTH_EQUALS_SECRET",
-            "--proxy-auth",
-            "PROXY_SPLIT_SECRET",
-            "-dDATA_SHORT_SECRET",
-            "--data",
-            "DATA_SPLIT_SECRET",
-            "-H",
-            "Authorization: HEADER_SPLIT_SECRET",
-            "--header=Cookie: HEADER_EQUALS_SECRET",
-            "--cookie",
-            "COOKIE_SECRET",
-            "-phttp://proxy-user:PROXY_URL_SECRET@proxy.test",
-            "--replay-proxy=http://replay-user:REPLAY_SECRET@proxy.test",
-            "--mysql-url",
-            "mysql://db-user:MYSQL_SECRET@db.test/name",
-            "--postgres-url=postgresql://db-user:POSTGRES_SECRET@db.test/name",
-            "-u",
-            "https://target-user:TARGET_SPLIT_SECRET@example.test",
-            "--url=https://target-user:TARGET_EQUALS_SECRET@example.test",
-            "--proxy-a",
-            "PROXY_ABBREVIATION_SECRET",
-            "--cook=COOKIE_ABBREVIATION_SECRET",
-            "--mys",
-            "mysql://db-user:MYSQL_ABBREVIATION_SECRET@db.test/name",
-            "--replay-p=http://replay-user:REPLAY_ABBREVIATION_SECRET@proxy.test",
-            "-qd",
-            "CLUSTER_DATA_SECRET",
-            "-qH",
-            "Authorization: CLUSTER_HEADER_SECRET",
-            "-qphttp://proxy-user:CLUSTER_PROXY_SECRET@proxy.test",
-            "-quhttps://target-user:CLUSTER_TARGET_SECRET@example.test",
-            "--threads",
-            "7",
-            "--crawl",
-        ]
 
-        command = redact_command(arguments)
-
-        for secret in secrets:
-            with self.subTest(secret=secret):
-                self.assertNotIn(secret, command)
-        self.assertIn(f"--auth={REDACTED_VALUE}", command)
-        self.assertIn(f"-d{REDACTED_VALUE}", command)
-        self.assertIn("--threads 7 --crawl", command)
+        for name, supplied, expected in cases:
+            with self.subTest(name=name):
+                arguments = ["dirsearch.py", *supplied, "--threads", "7"]
+                expected_command = " ".join(
+                    ["dirsearch.py", *expected, "--threads", "7"]
+                )
+                self.assertEqual(redact_command(arguments), expected_command)
 
     def test_preserves_other_short_options_with_attached_values(self):
         arguments = [


### PR DESCRIPTION
## Summary

- redact credential-bearing CLI values before constructing report command metadata
- cover split arguments, `--flag=value`, attached short values, accepted long-option abbreviations, and short-option clusters
- redact request bodies, headers, cookies, authentication, proxy/database URLs, and target URLs containing userinfo
- preserve ordinary targets and non-sensitive arguments for scan reproducibility

## User-visible effect

Plain text, Markdown, JSON, XML, and HTML reports no longer persist CLI-provided credentials or request secrets in their command metadata. Sensitive option names remain visible with a `<redacted>` marker so the report still describes how the scan was configured.

Configuration-file contents and session persistence are separate controls; this PR changes only command metadata embedded in reports.

## Tests

- `python -m unittest tests.utils.test_command tests.report.test_report_command_redaction -v` (4 passed)
- `python -m unittest discover -s tests/report -t . -v` (41 passed)
- focused options, target-credential, and session tests (24 passed)
- `python -m unittest discover -s tests -t .` (423 passed, 20 skipped)
- `python testing.py` (423 passed, 20 skipped)
- `python -m flake8 lib/core/settings.py lib/utils/command.py tests/utils/test_command.py tests/report/test_report_command_redaction.py`
- `python -m compileall -q lib/core/settings.py lib/utils/command.py tests/utils/test_command.py tests/report/test_report_command_redaction.py`
- `git diff --check`
