### PR TITLE
Redact secrets from log output

### DIFF
--- a/lib/core/logger.py
+++ b/lib/core/logger.py
@@ -17,9 +17,27 @@
 #  Author: Mauro Soria
 
 import logging
+import re
 from logging.handlers import RotatingFileHandler
 
 from lib.core.data import options
+from lib.utils.command import REDACTED_VALUE
+
+
+URL_USERINFO_PATTERN = re.compile(
+    r"(?P<scheme>\b[a-zA-Z][a-zA-Z0-9+.-]*://)"
+    r"(?P<userinfo>[^/\s?#\"'<>]+)@"
+)
+QUERY_VALUE_PATTERN = re.compile(
+    r"(?P<prefix>[?&;])"
+    r"(?P<key>[^=&;#\s\"'<>]*)="
+    r"(?P<value>[^&;#\s\"'<>]*)"
+)
+BARE_QUERY_COMPONENT_PATTERN = re.compile(
+    r"(?P<prefix>[?&;])"
+    r"(?P<component>[^=&;#\s\"'<>]+)"
+    r"(?=[&;#\s\"'<>]|$)"
+)
 
 
 logger = logging.getLogger(__name__)
@@ -27,9 +45,41 @@ logger.setLevel(logging.DEBUG)
 logger.disabled = True
 
 
+def redact_log_text(text: str) -> str:
+    """Remove credentials and query values from rendered log output."""
+    proxy_auth = options.get("proxy_auth")
+    if proxy_auth:
+        text = re.sub(
+            rf"(?P<scheme>\b[a-zA-Z][a-zA-Z0-9+.-]*://)?"
+            rf"{re.escape(str(proxy_auth))}(?=@)",
+            lambda match: f'{match.group("scheme") or ""}{REDACTED_VALUE}',
+            text,
+        )
+
+    text = URL_USERINFO_PATTERN.sub(
+        lambda match: f'{match.group("scheme")}{REDACTED_VALUE}@',
+        text,
+    )
+    text = QUERY_VALUE_PATTERN.sub(
+        lambda match: (
+            f'{match.group("prefix")}{match.group("key")}={REDACTED_VALUE}'
+        ),
+        text,
+    )
+    return BARE_QUERY_COMPONENT_PATTERN.sub(
+        lambda match: f'{match.group("prefix")}{REDACTED_VALUE}',
+        text,
+    )
+
+
+class RedactingFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return redact_log_text(super().format(record))
+
+
 def enable_logging() -> None:
     logger.disabled = False
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+    formatter = RedactingFormatter('%(asctime)s [%(levelname)s] %(message)s')
     handler = RotatingFileHandler(options["log_file"], maxBytes=options["log_file_size"])
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(formatter)

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -1,0 +1,92 @@
+import os
+import tempfile
+from unittest import TestCase
+
+from lib.core.data import options
+from lib.core.logger import enable_logging, logger, redact_log_text
+
+
+class TestLogRedaction(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        self.original_handlers = tuple(logger.handlers)
+        self.original_disabled = logger.disabled
+        for handler in self.original_handlers:
+            logger.removeHandler(handler)
+
+    def tearDown(self):
+        for handler in tuple(logger.handlers):
+            handler.close()
+            logger.removeHandler(handler)
+        for handler in self.original_handlers:
+            logger.addHandler(handler)
+        logger.disabled = self.original_disabled
+        options.clear()
+        options.update(self.original_options)
+
+    def test_redacts_url_secrets_without_hiding_request_metadata(self):
+        options["proxy_auth"] = "proxy-user:scheme-less-password"
+        message = (
+            '"GET https://alice:target-password@example.test/admin'
+            '?=empty-key-secret&token=query-secret&mode=debug&bare-secret" '
+            "200 - 42B - "
+            "LOCATION: /login?code=redirect-secret&empty= - "
+            "PROXIES: socks5://encoded-user:p%3Ass@[2001:db8::1]:1080/ "
+            "proxy-user:scheme-less-password@proxy.example.test"
+        )
+
+        self.assertEqual(
+            redact_log_text(message),
+            '"GET https://<redacted>@example.test/admin'
+            '?=<redacted>&token=<redacted>&mode=<redacted>&<redacted>" '
+            "200 - 42B - "
+            "LOCATION: /login?code=<redacted>&empty=<redacted> - "
+            "PROXIES: socks5://<redacted>@[2001:db8::1]:1080/ "
+            "<redacted>@proxy.example.test",
+        )
+
+    def test_file_formatter_redacts_traceback_and_configured_proxy_auth(self):
+        proxy_auth = "proxy-user:proxy-password/segment"
+        with tempfile.TemporaryDirectory() as root:
+            log_path = os.path.join(root, "dirsearch.log")
+            options["log_file"] = log_path
+            options["log_file_size"] = 0
+            options["proxy_auth"] = proxy_auth
+            enable_logging()
+
+            logger.info(
+                '"GET https://target-user:target-password@target.example.test/path'
+                '?token=query-secret&debug=true" 200 - 42B'
+            )
+            try:
+                raise ValueError(
+                    f"Invalid proxy URL: http://{proxy_auth}"
+                    "@proxy.example.test:8080"
+                )
+            except ValueError as error:
+                logger.exception(error)
+            logger.info('THREAD-7 started')
+
+            for handler in logger.handlers:
+                handler.flush()
+            with open(log_path, encoding="utf-8") as log_file:
+                contents = log_file.read()
+
+        for secret in (
+            "target-password",
+            "query-secret",
+            "true",
+            "proxy-password",
+        ):
+            with self.subTest(secret=secret):
+                self.assertNotIn(secret, contents)
+
+        self.assertIn(
+            "GET https://<redacted>@target.example.test/path",
+            contents,
+        )
+        self.assertIn("?token=<redacted>&debug=<redacted>", contents)
+        self.assertIn("proxy.example.test:8080", contents)
+        self.assertIn("Traceback (most recent call last)", contents)
+        self.assertIn("ValueError: Invalid proxy URL", contents)
+        self.assertIn("THREAD-7 started", contents)

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -67,8 +67,10 @@ class TestLogRedaction(TestCase):
                 logger.exception(error)
             logger.info('THREAD-7 started')
 
-            for handler in logger.handlers:
+            for handler in tuple(logger.handlers):
                 handler.flush()
+                handler.close()
+                logger.removeHandler(handler)
             with open(log_path, encoding="utf-8") as log_file:
                 contents = log_file.read()
 


### PR DESCRIPTION
## Summary

- redact URL userinfo and query values at the file-log formatting boundary
- sanitize fully rendered exception tracebacks, including malformed proxy URLs
- preserve request method, scheme, host, port, path, query names, status, sizes, redirect structure, and traceback diagnostics
- cover keyed, empty-name, and bare query components plus split proxy credentials

## User-visible effect

Opt-in logs no longer persist target query values or credentials embedded in target/proxy URLs. Query parameter names remain visible with <redacted> values so logs still explain request shape without retaining secrets.

This change affects only file logging. Requests, report artifacts, sessions, terminal errors, and proxy parsing retain their existing behavior.

## Validation

- Original P2.2 harness: query_secret_logged=false and reserved_proxy_secret_logged_in_parse_failure=false; traceback remains present
- python -m unittest tests.core.test_logger tests.connection.test_requester tests.connection.test_proxy_integration: 61 tests, 9 native skips
- python -m unittest discover -s tests -t .: 425 passed, 20 skipped
- python testing.py: 425 passed, 20 skipped
- python -m flake8 lib/core/logger.py tests/core/test_logger.py
- python -m compileall -q lib/core/logger.py tests/core/test_logger.py
- git diff --check

The first CI run exposed a Windows-only test cleanup error because the temporary log remained open. Commit 411a19d closes and detaches the handler before cleanup; the rerun passes on Windows Python 3.11 and 3.14.
