### PR TITLE
Scope target URL authentication to each target

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -397,6 +397,7 @@ class BaseRequester:
         self.headers = CaseInsensitiveDict(options["headers"])
         self.agents: list[str] = []
         self.session = None
+        self._configured_auth = None
 
         self._cert = None
         if options["cert_file"] and options["key_file"]:
@@ -439,6 +440,9 @@ class BaseRequester:
     def set_header(self, key: str, value: str) -> None:
         self.headers[key] = value.lstrip()
 
+    def reset_auth(self) -> None:
+        self.session.auth = self._configured_auth
+
     def wait_for_rate_limit(self) -> None:
         self._rate_limiter.wait(options["max_rate"])
 
@@ -478,6 +482,7 @@ class Requester(BaseRequester):
 
         if options["auth"]:
             self.set_auth(options["auth_type"], options["auth"])
+        self._configured_auth = self.session.auth
 
     def set_auth(self, type: str, credential: str) -> None:
         if type in ("bearer", "jwt"):
@@ -737,6 +742,7 @@ class AsyncRequester(BaseRequester):
 
         if options["auth"]:
             self.set_auth(options["auth_type"], options["auth"])
+        self._configured_auth = self.session.auth
 
     def parse_proxy(self, proxy: str) -> str | httpx.Proxy | None:
         if not proxy:

--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -662,12 +662,13 @@ class Controller:
             )
         self.base_path = lstrip_once(parsed.path, "/")
 
-        # Credentials in URL
+        # Parse target-scoped credentials without changing requester state until
+        # the target has been validated.
+        credential = None
         if parsed.username is not None:
             credential = unquote(parsed.username)
             if parsed.password is not None:
                 credential += f":{unquote(parsed.password)}"
-            self.requester.set_auth("basic", credential)
 
         if parsed.scheme not in (UNKNOWN, "https", "http"):
             raise InvalidURLException(f"Unsupported URI scheme: {parsed.scheme}")
@@ -710,6 +711,9 @@ class Controller:
 
         self.url += "/"
 
+        self.requester.reset_auth()
+        if credential is not None:
+            self.requester.set_auth("basic", credential)
         self.requester.set_url(self.url)
         self.requester.set_query(parsed.query)
 

--- a/tests/controller/test_target_credentials.py
+++ b/tests/controller/test_target_credentials.py
@@ -1,8 +1,12 @@
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import Mock, patch
 
+import requests
+
+from lib.connection.requester import AsyncRequester, Requester
 from lib.controller.controller import Controller
 from lib.core.data import options
+from lib.core.exceptions import InvalidURLException
 
 
 class TestControllerTargetCredentials(TestCase):
@@ -40,6 +44,7 @@ class TestControllerTargetCredentials(TestCase):
 
                 self.controller.set_target(target)
 
+                self.controller.requester.reset_auth.assert_called_once_with()
                 self.controller.requester.set_auth.assert_called_once_with(
                     "basic", credential
                 )
@@ -53,6 +58,7 @@ class TestControllerTargetCredentials(TestCase):
         )
 
         self.assertEqual(self.controller.base_path, "private/")
+        self.controller.requester.reset_auth.assert_called_once_with()
         self.controller.requester.set_url.assert_called_once_with(
             "https://example.test/"
         )
@@ -68,14 +74,181 @@ class TestControllerTargetCredentials(TestCase):
         self.controller.requester.set_auth.assert_called_once_with(
             "basic", "user:p@ss"
         )
+        self.controller.requester.reset_auth.assert_called_once_with()
         self.controller.requester.set_url.assert_called_once_with(
             "https://example.test/"
         )
 
-    def test_target_without_credentials_does_not_override_authentication(self):
+    def test_target_without_credentials_restores_configured_authentication(self):
         self.controller.set_target("https://example.test/")
 
+        self.controller.requester.reset_auth.assert_called_once_with()
         self.controller.requester.set_auth.assert_not_called()
         self.controller.requester.set_url.assert_called_once_with(
             "https://example.test/"
         )
+
+    def test_rejected_target_does_not_change_authentication(self):
+        with self.assertRaisesRegex(InvalidURLException, "Unsupported URI scheme"):
+            self.controller.set_target(
+                "ftp://target-user:target-password@example.test/"
+            )
+
+        self.controller.requester.reset_auth.assert_not_called()
+        self.controller.requester.set_auth.assert_not_called()
+
+
+class TargetAuthenticationIntegrationMixin:
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "request_backend": "python",
+                "scheme": None,
+                "ip": None,
+                "proxies": [],
+                "tor": False,
+                "proxy_auth": None,
+                "headers": {},
+                "cert_file": None,
+                "key_file": None,
+                "network_interface": None,
+                "random_agents": False,
+                "data": None,
+                "auth": None,
+                "auth_type": None,
+                "thread_count": 1,
+                "timeout": 1,
+            }
+        )
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    @staticmethod
+    def controller_for(requester):
+        controller = object.__new__(Controller)
+        controller.requester = requester
+        return controller
+
+
+class TestSyncTargetAuthenticationIntegration(
+    TargetAuthenticationIntegrationMixin, TestCase
+):
+    def test_embedded_authentication_does_not_persist_to_next_target(self):
+        requester = Requester()
+        controller = self.controller_for(requester)
+        try:
+            controller.set_target("http://target-user:target-password@first.test/")
+            self.assertIsNotNone(requester.session.auth)
+
+            controller.set_target("http://second.test/")
+
+            self.assertIsNone(requester.session.auth)
+        finally:
+            requester.close()
+
+    def test_configured_authentication_is_restored_after_target_override(self):
+        options.update(
+            {
+                "auth": "global-user:global-password",
+                "auth_type": "basic",
+            }
+        )
+        requester = Requester()
+        configured_auth = requester.session.auth
+        controller = self.controller_for(requester)
+        try:
+            controller.set_target("http://target-user:target-password@first.test/")
+            self.assertIsNot(requester.session.auth, configured_auth)
+
+            controller.set_target("http://second.test/")
+
+            self.assertIs(requester.session.auth, configured_auth)
+        finally:
+            requester.close()
+
+    def test_explicit_authorization_header_survives_target_override(self):
+        options["headers"] = {"Authorization": "Bearer configured-token"}
+        requester = Requester()
+        controller = self.controller_for(requester)
+        try:
+            controller.set_target("http://target-user:target-password@first.test/")
+            target_request = requester.session.prepare_request(
+                requests.Request("GET", requester._url, headers=requester.headers)
+            )
+            self.assertEqual(
+                target_request.headers["Authorization"],
+                "Basic dGFyZ2V0LXVzZXI6dGFyZ2V0LXBhc3N3b3Jk",
+            )
+
+            controller.set_target("http://second.test/")
+            configured_request = requester.session.prepare_request(
+                requests.Request("GET", requester._url, headers=requester.headers)
+            )
+
+            self.assertEqual(
+                configured_request.headers["Authorization"],
+                "Bearer configured-token",
+            )
+        finally:
+            requester.close()
+
+
+class TestAsyncTargetAuthenticationIntegration(
+    TargetAuthenticationIntegrationMixin, IsolatedAsyncioTestCase
+):
+    async def test_embedded_authentication_does_not_persist_to_next_target(self):
+        requester = AsyncRequester()
+        controller = self.controller_for(requester)
+        try:
+            controller.set_target("http://target-user:target-password@first.test/")
+            self.assertIsNotNone(requester.session.auth)
+
+            controller.set_target("http://second.test/")
+
+            self.assertIsNone(requester.session.auth)
+        finally:
+            await requester.close()
+
+    async def test_configured_authentication_is_restored_after_target_override(self):
+        options.update(
+            {
+                "auth": "global-user:global-password",
+                "auth_type": "basic",
+            }
+        )
+        requester = AsyncRequester()
+        configured_auth = requester.session.auth
+        controller = self.controller_for(requester)
+        try:
+            controller.set_target("http://target-user:target-password@first.test/")
+            self.assertIsNot(requester.session.auth, configured_auth)
+
+            controller.set_target("http://second.test/")
+
+            self.assertIs(requester.session.auth, configured_auth)
+        finally:
+            await requester.close()
+
+    async def test_explicit_authorization_header_survives_target_override(self):
+        options["headers"] = {"Authorization": "Bearer configured-token"}
+        requester = AsyncRequester()
+        controller = self.controller_for(requester)
+        try:
+            controller.set_target("http://target-user:target-password@first.test/")
+            self.assertEqual(
+                requester.headers["Authorization"],
+                "Bearer configured-token",
+            )
+
+            controller.set_target("http://second.test/")
+
+            self.assertIsNone(requester.session.auth)
+            self.assertEqual(
+                requester.headers["Authorization"],
+                "Bearer configured-token",
+            )
+        finally:
+            await requester.close()


### PR DESCRIPTION
## Summary

- restore the requester's configured authentication at every valid target transition
- apply URL-embedded Basic credentials only to the target that supplied them
- defer authentication changes until target validation succeeds
- preserve existing sessions, explicit `Authorization` headers, and global Basic/Digest/Bearer/NTLM auth objects

`Controller.run()` reuses one requester across all targets. Previously, once a target URL supplied userinfo, that Basic auth object remained attached to the sync or async session and could be sent to every later credential-less target.

## Tests

- `python -m unittest tests.controller.test_target_credentials tests.controller.test_target_dns tests.core.test_request_backend tests.connection.test_requester` (72 tests, 5 skipped)
- `python -m unittest discover -s tests -t .` (432 tests, 20 skipped)
- `python -m compileall -q lib/connection/requester.py lib/controller/controller.py tests/controller/test_target_credentials.py`
- `python -m flake8 lib/connection/requester.py lib/controller/controller.py tests/controller/test_target_credentials.py`
- `git diff --check`

The regression coverage exercises sync and async requesters, configured-auth restoration, explicit-header preservation, encoded URL credentials, and rejected targets that must not mutate authentication state.
