### PR TITLE
Preserve threaded in-flight paths in sessions

### DIFF
--- a/lib/core/fuzzer.py
+++ b/lib/core/fuzzer.py
@@ -474,8 +474,11 @@ class Fuzzer(BaseFuzzer):
         while True:
             should_quit = False
             try:
-                path = next(self._dictionary)
-                self.scan(self._base_path + path)
+                path = self._dictionary.claim_next()
+                try:
+                    self.scan(self._base_path + path)
+                finally:
+                    self._dictionary.release_claim(path)
 
             except StopIteration:
                 break

--- a/tests/controller/test_session_resume_queue.py
+++ b/tests/controller/test_session_resume_queue.py
@@ -1,0 +1,135 @@
+import asyncio
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.dictionary import Dictionary
+
+
+class RecordingFuzzer:
+    def __init__(self, _requester, dictionary, records, *args, **kwargs):
+        self.dictionary = dictionary
+        self.records = records
+        self.base_path = ""
+
+    def set_base_path(self, path):
+        self.base_path = path
+
+    def _record_job(self):
+        paths = []
+        while True:
+            try:
+                paths.append(next(self.dictionary))
+            except StopIteration:
+                break
+        self.records.append((self.base_path, paths))
+
+    def start(self):
+        self._record_job()
+
+    def is_finished(self):
+        return True
+
+    def stop(self, _timeout):
+        return True
+
+
+class RecordingAsyncFuzzer(RecordingFuzzer):
+    async def start(self):
+        self._record_job()
+
+
+class TestSessionResumeQueue(TestCase):
+    def _controller(self):
+        controller = object.__new__(Controller)
+        controller.start_time = 0
+        controller.passed_urls = set()
+        controller.directories = ["current/", "next/"]
+        controller.jobs_processed = 3
+        controller.errors = 0
+        controller.consecutive_errors = 0
+        controller.base_path = "first/"
+        controller.url = "https://first.example/"
+        controller.old_session = True
+        controller.dictionary = object.__new__(Dictionary)
+        controller.dictionary.__setstate__(
+            (["done", "in-flight", "later"], 2, ["in-flight"], 0)
+        )
+        controller.output_history = []
+        controller.response_stores = ()
+        controller.reporter = Mock()
+        controller.crawl_target = Mock()
+
+        def set_target(url):
+            controller.url = url
+            controller.base_path = (
+                "first/" if url == "https://first.example/" else "second/"
+            )
+
+        controller.set_target = set_target
+        return controller
+
+    def test_current_job_resumes_and_later_work_uses_full_wordlist(self):
+        stack_cases = (
+            ("threaded", False, "python", RecordingFuzzer),
+            ("async", True, "python", RecordingAsyncFuzzer),
+            ("native", False, "native", RecordingFuzzer),
+        )
+
+        for stack, async_mode, request_backend, fuzzer_class in stack_cases:
+            with self.subTest(stack=stack):
+                controller = self._controller()
+                records = []
+
+                def create_fuzzer(*args, **kwargs):
+                    return fuzzer_class(*args, records, **kwargs)
+
+                run_options = {
+                    "urls": [
+                        "https://first.example/",
+                        "https://second.example/",
+                    ],
+                    "request_backend": request_backend,
+                    "async_mode": async_mode,
+                    "subdirs": [""],
+                    "exclude_subdirs": [],
+                    "recursion_depth": 0,
+                    "max_time": 0,
+                    "target_max_time": 0,
+                    "session_file": None,
+                }
+
+                with (
+                    patch.dict(options, run_options),
+                    patch(
+                        "lib.connection.requester.Requester",
+                        return_value=Mock(),
+                    ),
+                    patch(
+                        "lib.connection.requester.AsyncRequester",
+                        return_value=Mock(),
+                    ),
+                    patch("lib.core.fuzzer.Fuzzer", create_fuzzer),
+                    patch("lib.core.fuzzer.AsyncFuzzer", create_fuzzer),
+                    patch("lib.core.fuzzer.NativeFuzzer", create_fuzzer),
+                    patch("lib.controller.controller.signal.signal"),
+                    patch("lib.controller.controller.interface"),
+                ):
+                    try:
+                        controller.run()
+                    finally:
+                        loop = getattr(controller, "loop", None)
+                        if isinstance(loop, asyncio.AbstractEventLoop):
+                            loop.close()
+
+                self.assertEqual(
+                    records,
+                    [
+                        ("current/", ["in-flight", "later"]),
+                        ("next/", ["done", "in-flight", "later"]),
+                        ("second/", ["done", "in-flight", "later"]),
+                    ],
+                )
+                self.assertEqual(controller.jobs_processed, 6)
+                self.assertEqual(controller.directories, [])

--- a/tests/controller/test_session_store.py
+++ b/tests/controller/test_session_store.py
@@ -103,6 +103,54 @@ class TestSessionStore(TestCase):
 
         self.assertEqual(restored["data"], body)
 
+    def test_resume_preserves_later_jobs_and_targets_with_full_wordlist(self):
+        target_urls = ["https://first.example/", "https://second.example/"]
+        session_options = {
+            "urls": target_urls,
+            "output_formats": [],
+        }
+        controller = self._controller()
+        controller.directories = ["current/", "next/"]
+        controller.jobs_processed = 3
+        controller.dictionary = object.__new__(Dictionary)
+        controller.dictionary.__setstate__(
+            (["done", "in-flight", "later"], 1, [], 0)
+        )
+        self.assertEqual(controller.dictionary.claim_next(), "in-flight")
+
+        with tempfile.TemporaryDirectory() as session_dir:
+            store = SessionStore(session_options)
+            store.save(controller, session_dir, "")
+            payload = store.load(session_dir)
+            restored_options = store.restore_options(payload["options"])
+            resumed = SimpleNamespace(dictionary=None)
+            SessionStore(restored_options).apply_to_controller(resumed, payload)
+
+        self.assertEqual(resumed.directories, ["current/", "next/"])
+        self.assertEqual(resumed.jobs_processed, 3)
+        self.assertEqual(restored_options["urls"], target_urls)
+
+        self.assertEqual(
+            [next(resumed.dictionary), next(resumed.dictionary)],
+            ["in-flight", "later"],
+        )
+        with self.assertRaises(StopIteration):
+            next(resumed.dictionary)
+
+        for boundary in ("next job", "next target"):
+            with self.subTest(boundary=boundary):
+                resumed.dictionary.reset()
+                self.assertEqual(
+                    [
+                        next(resumed.dictionary),
+                        next(resumed.dictionary),
+                        next(resumed.dictionary),
+                    ],
+                    ["done", "in-flight", "later"],
+                )
+                with self.assertRaises(StopIteration):
+                    next(resumed.dictionary)
+
     @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
     def test_new_session_directory_and_files_are_private(self):
         with tempfile.TemporaryDirectory() as root:

--- a/tests/core/test_async_fuzzer.py
+++ b/tests/core/test_async_fuzzer.py
@@ -141,6 +141,11 @@ class TestAsyncFuzzer(IsolatedAsyncioTestCase):
         with self.assertRaises(StopIteration):
             next(resumed)
 
+        resumed.reset()
+        self.assertEqual([next(resumed), next(resumed)], ["admin", "login"])
+        with self.assertRaises(StopIteration):
+            next(resumed)
+
     async def test_awaits_async_match_callbacks(self):
         dictionary = DummyDictionary(["home.html"])
         callback_finished = asyncio.Event()

--- a/tests/core/test_fuzzer_lifecycle.py
+++ b/tests/core/test_fuzzer_lifecycle.py
@@ -4,6 +4,7 @@ from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import patch
 
 from lib.core.data import options
+from lib.core.dictionary import Dictionary
 from lib.core.exceptions import RequestException, SkipTargetInterrupt
 from lib.core.fuzzer import AsyncFuzzer, Fuzzer
 
@@ -54,6 +55,18 @@ class CoordinatedSyncRequester:
         raise RequestException(path)
 
 
+class BlockingSyncRequester:
+    def __init__(self):
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def request(self, path):
+        self.started.set()
+        if not self.release.wait(timeout=2):
+            raise AssertionError("blocked request was not released")
+        raise RequestException(path)
+
+
 class CoordinatedAsyncRequester:
     def __init__(self):
         self.paths = []
@@ -76,6 +89,43 @@ class CoordinatedAsyncRequester:
 
 
 class TestThreadedFuzzerLifecycle(TestCase):
+    def test_saved_state_retries_in_flight_path(self):
+        dictionary = object.__new__(Dictionary)
+        dictionary.__setstate__((["blocked", "later"], 0, [], 0))
+        requester = BlockingSyncRequester()
+        fuzzer = Fuzzer(
+            requester,
+            dictionary,
+            match_callbacks=(),
+            not_found_callbacks=(),
+            error_callbacks=(),
+        )
+        fuzzer.setup_scanners = lambda: None
+
+        with patch.dict(options, {"thread_count": 1, "delay": 0}):
+            fuzzer.start()
+            try:
+                self.assertTrue(requester.started.wait(timeout=2))
+                saved_state = dictionary.__getstate__()
+            finally:
+                fuzzer.quit()
+                requester.release.set()
+                for worker in fuzzer._threads:
+                    worker.join(timeout=2)
+
+        self.assertFalse(any(worker.is_alive() for worker in fuzzer._threads))
+        resumed = object.__new__(Dictionary)
+        resumed.__setstate__(saved_state)
+        self.assertEqual([next(resumed), next(resumed)], ["blocked", "later"])
+        with self.assertRaises(StopIteration):
+            next(resumed)
+
+        completed = object.__new__(Dictionary)
+        completed.__setstate__(dictionary.__getstate__())
+        self.assertEqual(next(completed), "later")
+        with self.assertRaises(StopIteration):
+            next(completed)
+
     def test_terminal_callback_failure_stops_intake_and_drains_siblings(self):
         requester = CoordinatedSyncRequester()
         callback_failed = threading.Event()

--- a/tests/core/test_fuzzer_lifecycle.py
+++ b/tests/core/test_fuzzer_lifecycle.py
@@ -120,6 +120,11 @@ class TestThreadedFuzzerLifecycle(TestCase):
         with self.assertRaises(StopIteration):
             next(resumed)
 
+        resumed.reset()
+        self.assertEqual([next(resumed), next(resumed)], ["blocked", "later"])
+        with self.assertRaises(StopIteration):
+            next(resumed)
+
         completed = object.__new__(Dictionary)
         completed.__setstate__(dictionary.__getstate__())
         self.assertEqual(next(completed), "later")

--- a/tests/core/test_native_fuzzer.py
+++ b/tests/core/test_native_fuzzer.py
@@ -265,6 +265,11 @@ class TestNativeFuzzer(TestCase):
         with self.assertRaises(StopIteration):
             next(resumed)
 
+        resumed.reset()
+        self.assertEqual([next(resumed), next(resumed)], ["admin", "login"])
+        with self.assertRaises(StopIteration):
+            next(resumed)
+
     def test_quit_cancels_active_native_engine(self):
         backend = FakeNativeBackend([])
         fuzzer = self.make_fuzzer(backend, DummyDictionary([]), [], [], [])


### PR DESCRIPTION
## Summary

- make threaded workers claim dictionary paths before starting a request
- release each claim only after request handling and callbacks finish
- preserve in-flight threaded paths in session snapshots, matching async and native behavior
- verify resume boundaries through the next queued directory and the next target on every stack

Previously, the threaded stack advanced the dictionary with `next()` before processing. If a session snapshot was written while that request was still in flight, resume started at the following word and silently skipped the unfinished path. `Dictionary` already provides claim tracking and includes outstanding claims in serialized state; this change adopts that contract in the threaded worker.

Session recovery now has the same at-least-once rule in every stack:

| Stack | Current interrupted job | Next directory/job | Next target |
| --- | --- | --- | --- |
| Threaded | Retry in-flight and continue pending paths | Full wordlist | Full wordlist |
| Async | Retry in-flight and continue pending paths | Full wordlist | Full wordlist |
| Native | Retry unreturned chunk paths and continue pending paths | Full wordlist | Full wordlist |

A path released after completed processing is not retried in the interrupted job. If completion races the snapshot, retrying is preferred to losing the path. Later directories and targets are independent jobs, so they intentionally start from the full wordlist.

## Tests

- the threaded in-flight regression fails against the base commit because `blocked` disappears and only `later` resumes
- stack-specific threaded, async, and native tests verify a fresh full wordlist after the resume state is reset
- a controller-level harness verifies the exact queue transition on all three stacks: current directory gets `in-flight` plus `later`; the next directory and next target each get `done`, `in-flight`, and `later`
- a JSON session round-trip verifies that queued directories, `jobs_processed`, remaining target URLs, and the partial dictionary cursor survive serialization
- `python -m unittest tests.core.test_fuzzer_lifecycle tests.core.test_async_fuzzer tests.core.test_native_fuzzer tests.controller.test_session_store tests.controller.test_session_resume_queue tests.controller.test_threaded_controller tests.controller.test_async_controller tests.controller.test_native_controller` (37 tests)
- `python -m unittest discover -s tests -t .` (437 tests, 20 skipped)
- `python -m compileall -q lib/core/fuzzer.py tests/core/test_fuzzer_lifecycle.py tests/core/test_async_fuzzer.py tests/core/test_native_fuzzer.py tests/controller/test_session_store.py tests/controller/test_session_resume_queue.py`
- `python -m flake8 lib/core/fuzzer.py tests/core/test_fuzzer_lifecycle.py tests/core/test_async_fuzzer.py tests/core/test_native_fuzzer.py tests/controller/test_session_store.py tests/controller/test_session_resume_queue.py`
- `git diff --check`
