### PR TITLE
Write sessions as atomic checkpoints

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -4,15 +4,20 @@ dirsearch supports saving and resuming scan sessions, allowing you to pause a lo
 
 ## Session Format
 
-Sessions are stored in JSON format using a directory-based structure for human readability and inspection. Legacy `.pickle` and `.pkl` session files are no longer supported.
+Sessions are stored as one JSON checkpoint inside a session directory. The
+checkpoint contains the output history, controller state, wordlist position,
+and command-line options as one atomic snapshot.
 
 ```text
 session_name/
-├── meta.json        # Version, timestamps, output history
-├── controller.json  # Scan state (URLs, directories, progress)
-├── dictionary.json  # Wordlist state and position
-└── options.json     # Command-line options used
+└── dirsearch-session.json
 ```
+
+Replacing one combined checkpoint prevents a failed save from mixing new scan
+state with an older wordlist position or option set. dirsearch can still read
+the previous four-file JSON directory format; successfully saving that session
+again migrates it to the combined checkpoint. Legacy `.pickle` and `.pkl`
+session files are no longer supported.
 
 ## Saving a Session
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -19,6 +19,10 @@ the previous four-file JSON directory format; successfully saving that session
 again migrates it to the combined checkpoint. Legacy `.pickle` and `.pkl`
 session files are no longer supported.
 
+Support for reading the four-file JSON format is a temporary migration bridge.
+It should be removed in a future breaking release after users have had a
+documented deprecation window in which to resume and resave older sessions.
+
 ## Saving a Session
 
 When you pause a scan with `CTRL+C`, dirsearch prompts you to save the session:

--- a/lib/controller/session.py
+++ b/lib/controller/session.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+from collections.abc import Iterable
 import json
 import os
 from typing import Any
@@ -34,6 +35,7 @@ from lib.view.terminal import interface
 class SessionStore:
     SESSION_VERSION = 1
     SESSION_BYTES_MARKER = "__dirsearch_bytes_b64__"
+    CHECKPOINT_FILE = "dirsearch-session.json"
     SESSION_OPTION_SET_KEYS = {
         "recursion_status_codes",
         "include_status_codes",
@@ -72,15 +74,21 @@ class SessionStore:
             return sessions
 
         for root, dirs, files in os.walk(base_path):
+            is_session_dir = (
+                self.CHECKPOINT_FILE in files
+                or self.FILES["meta"] in files
+            )
             if root == base_path:
                 for file_name in files:
+                    if is_session_dir and file_name == self.CHECKPOINT_FILE:
+                        continue
                     summary = self._summarize_session_file(
                         FileUtils.build_path(root, file_name)
                     )
                     if summary:
                         sessions.append(summary)
 
-            if self.FILES["meta"] in files:
+            if is_session_dir:
                 summary = self._summarize_session_dir(root)
                 if summary:
                     sessions.append(summary)
@@ -96,6 +104,14 @@ class SessionStore:
             return payload
 
         session_dir = self._get_session_dir(session_path)
+        checkpoint_path = FileUtils.build_path(
+            session_dir, self.CHECKPOINT_FILE
+        )
+        if os.path.isfile(checkpoint_path):
+            payload = self._read_json(checkpoint_path)
+            self._validate_payload(payload)
+            return payload
+
         meta_payload = self._read_json(
             FileUtils.build_path(session_dir, self.FILES["meta"])
         )
@@ -127,37 +143,21 @@ class SessionStore:
             output_history.append(
                 {"start_time": controller.start_time, "output": last_output}
             )
-        controller.output_history = output_history
         payload = {
             "version": self.SESSION_VERSION,
             "controller": self._serialize_controller_state(controller),
             "dictionary": self._serialize_dictionary(controller),
             "options": self._serialize_options(),
             "last_output": last_output,
+            "output_history": output_history,
         }
         FileUtils.create_private_dir(session_dir)
-
-        meta_path = FileUtils.build_path(session_dir, self.FILES["meta"])
         self._write_json(
-            meta_path,
-            {
-                "version": payload["version"],
-                "last_output": last_output,
-                "output_history": output_history,
-            },
+            FileUtils.build_path(session_dir, self.CHECKPOINT_FILE),
+            payload,
         )
-        self._write_json(
-            FileUtils.build_path(session_dir, self.FILES["controller"]),
-            payload["controller"],
-        )
-        self._write_json(
-            FileUtils.build_path(session_dir, self.FILES["dictionary"]),
-            payload["dictionary"],
-        )
-        self._write_json(
-            FileUtils.build_path(session_dir, self.FILES["options"]),
-            payload["options"],
-        )
+        self._delete_session_files(session_dir, self.FILES.values())
+        controller.output_history = output_history
 
     def delete(self, session_path: str) -> None:
         """Delete session-owned files without removing unrelated entries."""
@@ -165,11 +165,10 @@ class SessionStore:
             os.remove(session_path)
             return
 
-        for file_name in self.FILES.values():
-            try:
-                os.remove(FileUtils.build_path(session_path, file_name))
-            except FileNotFoundError:
-                pass
+        self._delete_session_files(
+            session_path,
+            (*self.FILES.values(), self.CHECKPOINT_FILE),
+        )
 
         if not os.listdir(session_path):
             os.rmdir(session_path)
@@ -270,6 +269,17 @@ class SessionStore:
     def _get_session_dir(self, session_path: str) -> str:
         return session_path
 
+    def _delete_session_files(
+        self,
+        session_dir: str,
+        file_names: Iterable[str],
+    ) -> None:
+        for file_name in file_names:
+            try:
+                FileUtils.remove(FileUtils.build_path(session_dir, file_name))
+            except FileNotFoundError:
+                pass
+
     def _read_json(self, path: str) -> dict[str, Any]:
         try:
             with open(path, "r", encoding="utf-8") as file_handle:
@@ -302,6 +312,21 @@ class SessionStore:
         return None
 
     def _load_output_history(self, session_dir: str) -> list[dict[str, Any]]:
+        checkpoint_path = FileUtils.build_path(
+            session_dir, self.CHECKPOINT_FILE
+        )
+        if os.path.isfile(checkpoint_path):
+            try:
+                checkpoint_payload = self._read_json(checkpoint_path)
+            except UnpicklingError:
+                return []
+            if checkpoint_payload.get("version") != self.SESSION_VERSION:
+                return []
+            return self._deserialize_output_history(
+                checkpoint_payload,
+                checkpoint_payload.get("controller", {}).get("start_time"),
+            )
+
         meta_path = FileUtils.build_path(session_dir, self.FILES["meta"])
         if not os.path.isfile(meta_path):
             return []
@@ -311,7 +336,24 @@ class SessionStore:
             return []
         if meta_payload.get("version") != self.SESSION_VERSION:
             return []
-        history_payload = meta_payload.get("output_history")
+        start_time = None
+        controller_path = FileUtils.build_path(
+            session_dir, self.FILES["controller"]
+        )
+        if os.path.isfile(controller_path):
+            try:
+                controller_payload = self._read_json(controller_path)
+                start_time = controller_payload.get("start_time")
+            except UnpicklingError:
+                start_time = None
+        return self._deserialize_output_history(meta_payload, start_time)
+
+    def _deserialize_output_history(
+        self,
+        payload: dict[str, Any],
+        start_time: Any,
+    ) -> list[dict[str, Any]]:
+        history_payload = payload.get("output_history")
         if isinstance(history_payload, list):
             history: list[dict[str, Any]] = []
             for entry in history_payload:
@@ -325,22 +367,29 @@ class SessionStore:
                 )
             return history
 
-        last_output = meta_payload.get("last_output")
+        last_output = payload.get("last_output")
         if not last_output:
             return []
-
-        start_time = None
-        controller_path = FileUtils.build_path(session_dir, self.FILES["controller"])
-        if os.path.isfile(controller_path):
-            try:
-                controller_payload = self._read_json(controller_path)
-                start_time = controller_payload.get("start_time")
-            except UnpicklingError:
-                start_time = None
 
         return [{"start_time": start_time, "output": last_output}]
 
     def _summarize_session_dir(self, session_dir: str) -> dict[str, Any] | None:
+        checkpoint_path = FileUtils.build_path(
+            session_dir, self.CHECKPOINT_FILE
+        )
+        if os.path.isfile(checkpoint_path):
+            try:
+                payload = self._read_json(checkpoint_path)
+                self._validate_payload(payload)
+            except UnpicklingError:
+                return None
+            return self._build_summary(
+                session_dir,
+                checkpoint_path,
+                payload["controller"],
+                payload["options"],
+            )
+
         meta_path = FileUtils.build_path(session_dir, self.FILES["meta"])
         if not os.path.isfile(meta_path):
             return None

--- a/tests/controller/test_session_cleanup.py
+++ b/tests/controller/test_session_cleanup.py
@@ -56,7 +56,11 @@ class TestSessionCleanup(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             session_dir = os.path.join(tmpdir, "session")
             os.makedirs(session_dir)
-            for file_name in SessionStore.FILES.values():
+            owned_files = (
+                *SessionStore.FILES.values(),
+                SessionStore.CHECKPOINT_FILE,
+            )
+            for file_name in owned_files:
                 with open(os.path.join(session_dir, file_name), "w", encoding="utf-8"):
                     pass
             unrelated_path = os.path.join(session_dir, "keep.txt")
@@ -66,14 +70,17 @@ class TestSessionCleanup(TestCase):
             self._complete_scan(session_dir)
 
             self.assertTrue(os.path.isfile(unrelated_path))
-            for file_name in SessionStore.FILES.values():
+            for file_name in owned_files:
                 self.assertFalse(os.path.exists(os.path.join(session_dir, file_name)))
 
     def test_completed_session_removes_empty_owned_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             session_dir = os.path.join(tmpdir, "session")
             os.makedirs(session_dir)
-            for file_name in SessionStore.FILES.values():
+            for file_name in (
+                *SessionStore.FILES.values(),
+                SessionStore.CHECKPOINT_FILE,
+            ):
                 with open(os.path.join(session_dir, file_name), "w", encoding="utf-8"):
                     pass
 

--- a/tests/controller/test_session_store.py
+++ b/tests/controller/test_session_store.py
@@ -24,6 +24,7 @@ import stat
 import tempfile
 from types import SimpleNamespace
 from unittest import TestCase, skipIf
+from unittest.mock import patch
 
 from lib.controller.session import SessionStore
 from lib.core.dictionary import Dictionary
@@ -44,6 +45,10 @@ class TestSessionStore(TestCase):
         self._write_json(
             os.path.join(session_dir, SessionStore.FILES["controller"]),
             {"url": url, "directories": [], "jobs_processed": 1, "errors": 0},
+        )
+        self._write_json(
+            os.path.join(session_dir, SessionStore.FILES["dictionary"]),
+            {"items": ["legacy"], "index": 1, "extra": [], "extra_index": 0},
         )
         self._write_json(
             os.path.join(session_dir, SessionStore.FILES["options"]),
@@ -82,12 +87,17 @@ class TestSessionStore(TestCase):
             root_file = os.path.join(tmpdir, "session_root.json")
             self._write_session_file(root_file, "https://root.example.com")
 
+            current_dir = os.path.join(tmpdir, "2026-01-01", "session_02")
+            SessionStore({"urls": [], "output_formats": []}).save(
+                self._controller(), current_dir, ""
+            )
+
             sessions = SessionStore({}).list_sessions(tmpdir)
 
-            self.assertEqual(len(sessions), 2)
+            self.assertEqual(len(sessions), 3)
             self.assertEqual(
                 [session["path"] for session in sessions],
-                sorted([nested_dir, root_file]),
+                sorted([current_dir, nested_dir, root_file]),
             )
 
     def test_request_body_bytes_round_trip_through_json_session(self):
@@ -151,6 +161,54 @@ class TestSessionStore(TestCase):
                 with self.assertRaises(StopIteration):
                     next(resumed.dictionary)
 
+    def test_failed_resave_preserves_complete_previous_checkpoint(self):
+        old_urls = ["https://old.example/"]
+        new_urls = ["https://new.example/"]
+        session_options = {"urls": old_urls, "output_formats": []}
+        controller = self._controller()
+        controller.jobs_processed = 1
+        controller.dictionary = object.__new__(Dictionary)
+        controller.dictionary.__setstate__((["one", "two"], 1, [], 0))
+
+        with tempfile.TemporaryDirectory() as session_dir:
+            store = SessionStore(session_options)
+            store.save(controller, session_dir, "old output")
+
+            controller.jobs_processed = 2
+            controller.dictionary.__setstate__((["one", "two"], 2, [], 0))
+            session_options["urls"] = new_urls
+            original_dump = json.dump
+
+            def fail_during_checkpoint(payload, file_handle, *args, **kwargs):
+                original_dump(payload, file_handle, *args, **kwargs)
+                if "items" in payload or "dictionary" in payload:
+                    raise OSError("injected serialization failure")
+
+            with (
+                patch(
+                    "lib.controller.session.json.dump",
+                    side_effect=fail_during_checkpoint,
+                ),
+                self.assertRaisesRegex(OSError, "injected serialization failure"),
+            ):
+                store.save(controller, session_dir, "new output")
+
+            restored = store.load(session_dir)
+
+        self.assertEqual(restored["controller"]["jobs_processed"], 1)
+        self.assertEqual(restored["dictionary"]["index"], 1)
+        self.assertEqual(restored["options"]["urls"], old_urls)
+        self.assertEqual(restored["last_output"], "old output")
+        self.assertEqual(
+            controller.output_history,
+            [
+                {
+                    "start_time": controller.start_time,
+                    "output": "old output",
+                }
+            ],
+        )
+
     @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
     def test_new_session_directory_and_files_are_private(self):
         with tempfile.TemporaryDirectory() as root:
@@ -169,23 +227,29 @@ class TestSessionStore(TestCase):
                         stat.S_IMODE(os.stat(session_dir).st_mode),
                         0o700,
                     )
-                    for file_name in SessionStore.FILES.values():
-                        with self.subTest(file_name=file_name):
-                            file_path = os.path.join(session_dir, file_name)
-                            self.assertEqual(
-                                stat.S_IMODE(os.stat(file_path).st_mode),
-                                0o600,
-                            )
+                    self.assertEqual(
+                        os.listdir(session_dir),
+                        [SessionStore.CHECKPOINT_FILE],
+                    )
+                    checkpoint_path = os.path.join(
+                        session_dir, SessionStore.CHECKPOINT_FILE
+                    )
+                    self.assertEqual(
+                        stat.S_IMODE(os.stat(checkpoint_path).st_mode),
+                        0o600,
+                    )
 
     @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
-    def test_resaving_legacy_session_tightens_file_permissions(self):
+    def test_resaving_session_tightens_checkpoint_permissions(self):
         with tempfile.TemporaryDirectory() as root:
             session_dir = os.path.join(root, "session")
             store = SessionStore({"auth": "alice:secret"})
             store.save(self._controller(), session_dir, "")
             os.chmod(session_dir, 0o755)
-            for file_name in SessionStore.FILES.values():
-                os.chmod(os.path.join(session_dir, file_name), 0o644)
+            checkpoint_path = os.path.join(
+                session_dir, SessionStore.CHECKPOINT_FILE
+            )
+            os.chmod(checkpoint_path, 0o644)
 
             store.save(self._controller(), session_dir, "")
 
@@ -193,13 +257,73 @@ class TestSessionStore(TestCase):
                 stat.S_IMODE(os.stat(session_dir).st_mode),
                 0o755,
             )
+            self.assertEqual(
+                stat.S_IMODE(os.stat(checkpoint_path).st_mode),
+                0o600,
+            )
+
+    def test_resave_migrates_legacy_directory_to_atomic_checkpoint(self):
+        with tempfile.TemporaryDirectory() as root:
+            session_dir = os.path.join(root, "session")
+            self._write_session_dir(session_dir, "https://legacy.example/")
+            controller = self._controller()
+            controller.jobs_processed = 7
+            store = SessionStore({"urls": ["https://current.example/"]})
+
+            store.save(controller, session_dir, "current output")
+            restored = store.load(session_dir)
+
+            self.assertTrue(
+                os.path.isfile(
+                    os.path.join(session_dir, SessionStore.CHECKPOINT_FILE)
+                )
+            )
             for file_name in SessionStore.FILES.values():
-                with self.subTest(file_name=file_name):
-                    file_path = os.path.join(session_dir, file_name)
-                    self.assertEqual(
-                        stat.S_IMODE(os.stat(file_path).st_mode),
-                        0o600,
-                    )
+                self.assertFalse(
+                    os.path.exists(os.path.join(session_dir, file_name))
+                )
+            self.assertEqual(restored["controller"]["jobs_processed"], 7)
+            self.assertEqual(
+                restored["options"]["urls"],
+                ["https://current.example/"],
+            )
+            self.assertEqual(restored["last_output"], "current output")
+
+    def test_failed_legacy_migration_leaves_legacy_checkpoint_loadable(self):
+        with tempfile.TemporaryDirectory() as root:
+            session_dir = os.path.join(root, "session")
+            self._write_session_dir(session_dir, "https://legacy.example/")
+            store = SessionStore({"urls": ["https://new.example/"]})
+            original_dump = json.dump
+
+            def fail_checkpoint(payload, file_handle, *args, **kwargs):
+                original_dump(payload, file_handle, *args, **kwargs)
+                raise OSError("injected migration failure")
+
+            with (
+                patch(
+                    "lib.controller.session.json.dump",
+                    side_effect=fail_checkpoint,
+                ),
+                self.assertRaisesRegex(OSError, "injected migration failure"),
+            ):
+                store.save(self._controller(), session_dir, "new output")
+
+            restored = store.load(session_dir)
+
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(session_dir, SessionStore.CHECKPOINT_FILE)
+                )
+            )
+            self.assertEqual(
+                restored["controller"]["url"],
+                "https://legacy.example/",
+            )
+            self.assertEqual(
+                restored["options"]["urls"],
+                ["https://example.com"],
+            )
 
     def test_bytes_marker_in_headers_remains_a_header_mapping(self):
         marker = SessionStore.SESSION_BYTES_MARKER


### PR DESCRIPTION
## Summary

- store each directory session as one atomically replaced `dirsearch-session.json` checkpoint
- keep controller state, dictionary position, options, last output, and output history in the same commit unit
- continue loading and listing legacy four-file JSON sessions
- migrate a legacy directory after its first successful resave and remove the old secret-bearing files
- update in-memory output history only after the durable checkpoint commit succeeds

## Problem

The previous implementation replaced `meta.json`, `controller.json`, `dictionary.json`, and `options.json` independently. A failure after one or more replacements left a valid-looking directory containing different generations. `load()` accepted that mixed state, so resume could combine a new job count with an old wordlist cursor or target list and skip or repeat work.

The regression harness saves checkpoint 1, mutates controller/dictionary/options for checkpoint 2, then injects a serialization failure after data has been written to the temporary destination. On the base commit, `load()` observes the new controller and old dictionary/options. With this change, the temporary combined checkpoint is discarded and checkpoint 1 remains authoritative.

## Compatibility

- legacy four-file JSON session directories remain readable and listable
- a failed first migration leaves all legacy files untouched and loadable
- a successful resave creates the combined checkpoint, then removes the owned legacy files
- completed-session cleanup removes either layout while preserving unrelated directory entries
- the physical format for newly saved sessions changes, so older dirsearch versions cannot resume a new combined checkpoint; current dirsearch can resume both formats
- this guarantees generation atomicity for serialization and replacement failures; it does not claim filesystem power-loss durability beyond `os.replace`

## Follow-up retirement

The four-file JSON reader is a temporary migration bridge, not a permanent second session format. Remove it in a future breaking release only after a documented deprecation window gives users time to resume and resave old sessions as combined checkpoints.

## Tests

- pre-fix regression: the injected resave failure returned `jobs_processed = 2` with dictionary/options from checkpoint 1
- `python -m unittest tests.controller.test_session_store tests.controller.test_session_cleanup tests.controller.test_session_resume_queue tests.utils.test_file` (26 tests)
- `python -m unittest discover -s tests -t .` (440 tests, 20 skipped)
- `python testing.py` (440 tests, 20 skipped)
- `python -m compileall -q lib/controller/session.py tests/controller/test_session_store.py tests/controller/test_session_cleanup.py`
- `python -m flake8 lib/controller/session.py tests/controller/test_session_store.py tests/controller/test_session_cleanup.py`
- `git diff --check`
