### PR TITLE
Preserve file reports after write failures

### DIFF
--- a/lib/report/csv_report.py
+++ b/lib/report/csv_report.py
@@ -49,7 +49,7 @@ class CSVReport(FileReportMixin, BaseReport):
         self.write(file, rows)
 
     def write(self, file, rows):
-        with open(file, "w") as fh:
+        with self._atomic_writer(file) as fh:
             writer = csv.writer(fh, delimiter=",", quotechar='"')
             for row in rows:
                 writer.writerow(row)

--- a/lib/report/factory.py
+++ b/lib/report/factory.py
@@ -77,10 +77,14 @@ class FileReportMixin:
             raise FileExistsException(f"Output file {file} already exists") from error
 
     def parse(self, file):
-        return open(file, "r").read()
+        with open(file, "r") as file_handle:
+            return file_handle.read()
+
+    def _atomic_writer(self, file):
+        return FileUtils.atomic_write_private_text(file, encoding=None)
 
     def write(self, file, data):
-        with open(file, "w") as fh:
+        with self._atomic_writer(file) as fh:
             fh.write(data)
 
     def finish(self):

--- a/lib/report/json_report.py
+++ b/lib/report/json_report.py
@@ -53,5 +53,5 @@ class JSONReport(FileReportMixin, BaseReport):
         self.write(file, data)
 
     def write(self, file, data):
-        with open(file, "w") as fh:
+        with self._atomic_writer(file) as fh:
             json.dump(data, fh, sort_keys=True, indent=4)

--- a/lib/utils/file.py
+++ b/lib/utils/file.py
@@ -196,7 +196,10 @@ class FileUtils:
 
     @staticmethod
     @contextmanager
-    def atomic_write_private_text(file_name: str, encoding: str = "utf-8"):
+    def atomic_write_private_text(
+        file_name: str,
+        encoding: str | None = "utf-8",
+    ):
         """Write text through a private same-directory replacement file."""
         descriptor, temporary_path = tempfile.mkstemp(
             prefix=f".{os.path.basename(file_name)}.",

--- a/tests/report/test_atomic_file_reports.py
+++ b/tests/report/test_atomic_file_reports.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+import builtins
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.report.csv_report import CSVReport
+from lib.report.html_report import HTMLReport
+from lib.report.json_report import JSONReport
+from lib.report.markdown_report import MarkdownReport
+from lib.report.plain_text_report import PlainTextReport
+from lib.report.simple_report import SimpleReport
+from lib.report.xml_report import XMLReport
+
+
+FILE_REPORTS = (
+    (SimpleReport, "txt"),
+    (PlainTextReport, "txt"),
+    (JSONReport, "json"),
+    (XMLReport, "xml"),
+    (MarkdownReport, "md"),
+    (CSVReport, "csv"),
+    (HTMLReport, "html"),
+)
+
+
+def make_result(url):
+    return SimpleNamespace(
+        datetime="2026-09-11 06:00:00",
+        url=url,
+        status=200,
+        length=42,
+        type="text/plain",
+        redirect="",
+        elapsed=0.25,
+    )
+
+
+class PartialWriteFailure:
+    def __init__(self, file_handle):
+        self._file_handle = file_handle
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self._file_handle.close()
+
+    def __getattr__(self, name):
+        return getattr(self._file_handle, name)
+
+    def write(self, data):
+        self._file_handle.write(data[:3])
+        self._file_handle.flush()
+        raise OSError("injected report write failure")
+
+
+class TestAtomicFileReports(TestCase):
+    def test_failed_save_preserves_previous_report_for_every_file_format(self):
+        real_open = builtins.open
+        real_fdopen = os.fdopen
+
+        with tempfile.TemporaryDirectory() as directory:
+            for report_class, extension in FILE_REPORTS:
+                with self.subTest(report=report_class.__name__):
+                    report = report_class()
+                    destination = os.path.join(
+                        directory,
+                        f"report-{report_class.__name__}.{extension}",
+                    )
+                    first_url = "https://example.test/first"
+                    second_url = "https://example.test/second"
+                    report.initiate(destination)
+                    report.save(destination, make_result(first_url))
+                    original = Path(destination).read_bytes()
+
+                    def faulting_open(file, mode="r", *args, **kwargs):
+                        file_handle = real_open(file, mode, *args, **kwargs)
+                        if os.fspath(file) == destination and "w" in mode:
+                            return PartialWriteFailure(file_handle)
+                        return file_handle
+
+                    def faulting_fdopen(descriptor, mode="r", *args, **kwargs):
+                        file_handle = real_fdopen(descriptor, mode, *args, **kwargs)
+                        if "w" in mode:
+                            return PartialWriteFailure(file_handle)
+                        return file_handle
+
+                    with patch("builtins.open", new=faulting_open), patch(
+                        "lib.utils.file.os.fdopen",
+                        new=faulting_fdopen,
+                    ):
+                        with self.assertRaisesRegex(
+                            OSError,
+                            "injected report write failure",
+                        ):
+                            report.save(destination, make_result(second_url))
+
+                    self.assertEqual(Path(destination).read_bytes(), original)
+                    self.assertIn(first_url, original.decode())
+                    self.assertNotIn(second_url, original.decode())
+                    self.assertEqual(
+                        list(Path(directory).glob(f".{Path(destination).name}.*.tmp")),
+                        [],
+                    )
+                    report.validate(destination)
+
+                    report.save(destination, make_result(second_url))
+                    recovered = Path(destination).read_text()
+                    self.assertIn(first_url, recovered)
+                    self.assertIn(second_url, recovered)


### PR DESCRIPTION
## Summary

- write file-report snapshots to a private temporary file in the destination directory
- replace the prior report only after the complete snapshot has been written and closed successfully
- apply the same durability contract to simple, plain text, JSON, XML, Markdown, CSV, and HTML reports
- close generic report readers deterministically while retaining the existing platform-default text encoding behavior

## Regression coverage

The new fault-injection harness first reproduced the bug on `master`: an interrupted save truncated all seven file report formats to partial output. It now verifies that:

- the exact prior report bytes survive a partial-write failure
- the preserved report remains valid
- temporary files are cleaned up
- a later save succeeds and retains both the earlier and recovered result

## Validation

- `python -W error::ResourceWarning -m unittest tests.report.test_atomic_file_reports tests.report.test_report_locking tests.test_report_exception_handling -v`
- `python -m unittest discover -s tests -t .` (441 passed, 20 skipped)
- `python -m flake8 lib/report/csv_report.py lib/report/factory.py lib/report/json_report.py lib/utils/file.py tests/report/test_atomic_file_reports.py`
- `git diff --check`

The separate quadratic report rewrite/performance issue is intentionally out of scope for this durability fix.
