### PR TITLE
Decode compressed responses in the native client

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -33,6 +33,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f10dafd0c8d2e51ae9a748805777613ed0bbe17bf586b76c8311f45c020a32f"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +124,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a6d0db8759036a783bc7c3f7a07f8cef3bf9470eb1db3bc86e8bcd1c5d0fe8"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,14 +179,18 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 name = "dirsearch_native"
 version = "0.1.0"
 dependencies = [
+ "async-compression",
  "brotli",
  "flate2",
+ "futures-util",
+ "http",
  "indexmap",
  "pyo3",
  "rayon",
  "regex",
  "reqwest",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -229,6 +263,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,7 +298,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -896,6 +951,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -916,12 +972,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1408,6 +1466,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -9,11 +9,17 @@ name = "dirsearch_native"
 crate-type = ["cdylib"]
 
 [dependencies]
+async-compression = { version = "0.4", features = ["brotli", "gzip", "tokio", "zlib"] }
 brotli = "8.0"
 flate2 = "1.1"
+futures-util = "0.3"
 indexmap = "2.7"
 pyo3 = { version = "0.24", features = ["extension-module", "abi3-py313"] }
 rayon = "1.10"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "stream"] }
 regex = "1.11"
-tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "time"] }
+tokio = { version = "1.43", features = ["rt-multi-thread", "macros", "net", "time", "io-util"] }
+tokio-util = { version = "0.7", features = ["io"] }
+
+[dev-dependencies]
+http = "1.3"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,5 +1,7 @@
 mod raw_http;
 
+use async_compression::tokio::bufread::{BrotliDecoder, GzipDecoder, ZlibDecoder};
+use futures_util::TryStreamExt;
 use indexmap::IndexSet;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -7,12 +9,16 @@ use rayon::prelude::*;
 use regex::{Regex, RegexBuilder};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::fs;
+use std::io;
 #[cfg(test)]
 use std::io::Cursor;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
 use tokio::task::JoinSet;
+use tokio_util::io::StreamReader;
 
 const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -54,6 +60,7 @@ type NumericRange = (usize, usize);
 type TimeFilter = (String, f64);
 type HeaderPairs = Vec<(String, String)>;
 type RawHttpResponse = raw_http::Response;
+type AsyncBodyReader = Pin<Box<dyn AsyncRead + Send>>;
 
 struct RawHttpRequest<'a> {
     base_url: &'a str,
@@ -948,7 +955,7 @@ async fn request_with_client(
             )
         })
         .collect::<Vec<_>>();
-    let (body, body_length) = match read_response_body(response, max_body_size).await {
+    let (body, body_length) = match read_response_body(response, &headers, max_body_size).await {
         Ok(result) => result,
         Err(error) => {
             return native_error_result(
@@ -1051,20 +1058,54 @@ fn runtime_worker_count() -> usize {
 }
 
 async fn read_response_body(
-    mut response: reqwest::Response,
+    response: reqwest::Response,
+    headers: &HeaderPairs,
     max_body_size: usize,
-) -> Result<(Vec<u8>, usize), reqwest::Error> {
+) -> Result<(Vec<u8>, usize), String> {
     let capacity = response
         .content_length()
         .and_then(|length| usize::try_from(length).ok())
         .unwrap_or_default()
         .min(max_body_size);
+    let encodings = raw_http::comma_separated_header_values(headers, "content-encoding");
+    let stream = response.bytes_stream().map_err(io::Error::other);
+    let mut reader: AsyncBodyReader = Box::pin(StreamReader::new(stream));
+    for encoding in encodings.iter().rev() {
+        if encoding.eq_ignore_ascii_case("identity") {
+            continue;
+        }
+
+        let buffered = BufReader::new(reader);
+        reader = if encoding.eq_ignore_ascii_case("gzip") {
+            Box::pin(GzipDecoder::new(buffered))
+        } else if encoding.eq_ignore_ascii_case("deflate") {
+            Box::pin(ZlibDecoder::new(buffered))
+        } else if encoding.eq_ignore_ascii_case("br") {
+            Box::pin(BrotliDecoder::new(buffered))
+        } else {
+            return Err(format!("Unsupported HTTP Content-Encoding: {encoding}"));
+        };
+    }
     let mut body = Vec::with_capacity(capacity);
     let mut body_length = 0usize;
+    let mut buffer = [0u8; 8192];
 
-    while let Some(chunk) = response.chunk().await? {
-        body_length = body_length.saturating_add(chunk.len());
-        append_body_chunk(&mut body, &chunk, max_body_size);
+    loop {
+        let read = reader.read(&mut buffer).await.map_err(|error| {
+            if encodings.is_empty() {
+                error.to_string()
+            } else {
+                format!(
+                    "Failed to decode {} response body: {error}",
+                    encodings.join(", ")
+                )
+            }
+        })?;
+        if read == 0 {
+            break;
+        }
+        body_length = body_length.saturating_add(read);
+        append_body_chunk(&mut body, &buffer[..read], max_body_size);
     }
 
     Ok((body, body_length))
@@ -1407,6 +1448,90 @@ mod tests {
         let mut response = format!("HTTP/1.1 200 OK\r\n{headers}\r\n\r\n").into_bytes();
         response.extend_from_slice(body);
         response
+    }
+
+    fn compressed_body(encoding: &str, body: &[u8]) -> Vec<u8> {
+        if encoding == "gzip" {
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(body).unwrap();
+            encoder.finish().unwrap()
+        } else if encoding == "deflate" {
+            let mut encoder =
+                flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(body).unwrap();
+            encoder.finish().unwrap()
+        } else {
+            let mut compressed = Vec::new();
+            {
+                let mut encoder = brotli::CompressorWriter::new(&mut compressed, 4096, 5, 22);
+                encoder.write_all(body).unwrap();
+            }
+            compressed
+        }
+    }
+
+    fn reqwest_response(body: Vec<u8>, encoding: &str) -> (reqwest::Response, HeaderPairs) {
+        let headers = vec![
+            ("Content-Encoding".to_string(), encoding.to_string()),
+            ("Content-Length".to_string(), body.len().to_string()),
+        ];
+        let response = http::Response::builder()
+            .header("Content-Encoding", encoding)
+            .header("Content-Length", body.len())
+            .body(body)
+            .unwrap()
+            .into();
+        (response, headers)
+    }
+
+    #[test]
+    fn reqwest_response_decoder_streams_supported_content_encodings() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let plain = b"hello world";
+        let gzip = compressed_body("gzip", plain);
+        let cases = [
+            ("identity", plain.to_vec()),
+            ("gzip", gzip.clone()),
+            ("deflate", compressed_body("deflate", plain)),
+            ("br", compressed_body("br", plain)),
+            ("gzip, br", compressed_body("br", &gzip)),
+        ];
+
+        for (encoding, compressed) in cases {
+            let (response, headers) = reqwest_response(compressed, encoding);
+            let (body, length) = runtime
+                .block_on(read_response_body(response, &headers, 5))
+                .unwrap();
+
+            assert_eq!(body, b"hello");
+            assert_eq!(length, plain.len());
+        }
+    }
+
+    #[test]
+    fn reqwest_response_decoder_rejects_unknown_or_invalid_encodings() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (unknown, unknown_headers) = reqwest_response(b"hello world".to_vec(), "compress-test");
+        let unknown_error = runtime
+            .block_on(read_response_body(unknown, &unknown_headers, 80))
+            .unwrap_err();
+        let (invalid, invalid_headers) = reqwest_response(b"not gzip".to_vec(), "gzip");
+        let invalid_error = runtime
+            .block_on(read_response_body(invalid, &invalid_headers, 80))
+            .unwrap_err();
+
+        assert_eq!(
+            unknown_error,
+            "Unsupported HTTP Content-Encoding: compress-test"
+        );
+        assert!(invalid_error.starts_with("Failed to decode gzip response body:"));
     }
 
     #[test]

--- a/native/src/raw_http.rs
+++ b/native/src/raw_http.rs
@@ -202,7 +202,10 @@ fn content_length(headers: &HeaderPairs) -> Result<Option<usize>, String> {
     Ok(Some(expected))
 }
 
-fn comma_separated_header_values(headers: &HeaderPairs, wanted_name: &str) -> Vec<String> {
+pub(crate) fn comma_separated_header_values(
+    headers: &HeaderPairs,
+    wanted_name: &str,
+) -> Vec<String> {
     headers
         .iter()
         .filter(|(name, _)| name.eq_ignore_ascii_case(wanted_name))

--- a/tests/connection/test_native_engine.py
+++ b/tests/connection/test_native_engine.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import signal
 import socket
@@ -348,6 +349,32 @@ class TestNativeHttpEngine(TestCase):
             results = engine.scan(
                 server.url,
                 ["gzip%1"],
+                matcher_mode="and",
+                match_words=[(2, 2)],
+                match_regex="hello world",
+            )
+        finally:
+            server.close()
+
+        self.assertIsNone(results[0].error)
+        self.assertFalse(results[0].filtered)
+        self.assertEqual(results[0].body, b"hello world")
+
+    def test_client_decodes_gzip_before_body_matching(self):
+        compressed = gzip.compress(b"hello world", mtime=0)
+        server = RawResponseServer(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Encoding: gzip\r\n"
+            + f"Content-Length: {len(compressed)}\r\n".encode()
+            + b"Connection: close\r\n\r\n"
+            + compressed
+        )
+        engine = dirsearch_native.NativeHttpEngine(timeout_secs=1)
+
+        try:
+            results = engine.scan(
+                server.url,
+                ["gzip"],
                 matcher_mode="and",
                 match_words=[(2, 2)],
                 match_regex="hello world",

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -82,6 +82,11 @@ INDIC_TEXT = (
 )
 MULTISCRIPT_TEXT = f"{CHINESE_TEXT} | {ARABIC_TEXT} | {INDIC_TEXT}"
 ENCODED_RESPONSE_CASES = (
+    (
+        "encoded/normal-gzip",
+        "utf-8",
+        b"normal native gzip response",
+    ),
     ("encoded/multiscript-utf8%1", "utf-8", MULTISCRIPT_TEXT.encode("utf-8")),
     (
         "encoded/chinese-gb18030%1",


### PR DESCRIPTION
## Summary

- stream-decode gzip, zlib-wrapped deflate, and brotli in the ordinary native reqwest path
- decode stacked `Content-Encoding` values in reverse application order, matching the native raw-request fallback
- preserve the response's original `Content-Encoding` and `Content-Length` headers for reports and saved-response evidence
- keep captured response bodies bounded by the existing native body limit
- reject unsupported encodings and malformed compressed payloads as request errors instead of filtering compressed bytes

## Regression coverage

The cross-backend local fixture now includes a valid request target that stays on the ordinary reqwest path. Before the fix:

- threaded: passed
- async: passed
- native: failed and returned the gzip wire bytes

The expanded tests verify:

- decoded content reaches native word and regex filters
- threaded, async, and native return the same gzip-decoded response body
- saved JSONL evidence retains decoded bytes plus the original encoding headers
- gzip, deflate, brotli, identity, and stacked gzip-plus-brotli streams decode correctly
- capture limits remain bounded while decoded length is tracked
- unknown encodings and invalid gzip payloads fail clearly

## Validation

- `cargo fmt --manifest-path native/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path native/Cargo.toml` (24 passed)
- `cargo clippy --locked --manifest-path native/Cargo.toml --all-targets -- -D warnings`
- native wheel built and installed with Python 3.14
- `python -m unittest tests.connection.test_native_engine tests.connection.test_native_response tests.connection.test_native_backend tests.connection.test_requester -v` (68 passed before the final focused addition)
- `python -m unittest discover -s tests -t .` (442 passed)
- `python -m flake8 tests/connection/test_native_engine.py tests/connection/test_requester.py`
- `codespell native/Cargo.toml native/src/lib.rs native/src/raw_http.rs tests/connection/test_native_engine.py tests/connection/test_requester.py`
- `git diff --check`
