### PR TITLE
Keep redirect recursion on the target origin

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -70,7 +70,12 @@ from lib.core.settings import (
 )
 from lib.core.wordlist_template import generate_backup_paths
 from lib.parse.rawrequest import parse_raw
-from lib.parse.url import clean_path, ensure_trailing_path_slash, parse_path
+from lib.parse.url import (
+    clean_path,
+    ensure_trailing_path_slash,
+    parse_path,
+    same_origin_path,
+)
 from lib.report.manager import ReportManager
 from lib.report.response_store import (
     BaseResponseStore,
@@ -830,8 +835,12 @@ class Controller:
             )
         ):
             if response.redirect:
-                new_path = clean_path(parse_path(response.redirect))
-                added_to_queue = self.recur_for_redirect(response.path, new_path)
+                new_path = same_origin_path(response.url, response.redirect)
+                added_to_queue = (
+                    self.recur_for_redirect(response.path, clean_path(new_path))
+                    if new_path is not None
+                    else []
+                )
             elif len(response.history):
                 old_path = clean_path(parse_path(response.history[0]))
                 added_to_queue = self.recur_for_redirect(old_path, response.path)

--- a/lib/parse/url.py
+++ b/lib/parse/url.py
@@ -16,9 +16,48 @@
 #
 #  Author: Mauro Soria
 
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from lib.utils.common import lstrip_once
+
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin(value: str) -> tuple[str, str, int | None] | None:
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+
+    scheme = parsed.scheme.lower()
+    if not scheme or hostname is None:
+        return None
+
+    return (
+        scheme,
+        hostname.lower(),
+        port if port is not None else _DEFAULT_PORTS.get(scheme),
+    )
+
+
+def same_origin(first: str, second: str) -> bool:
+    first_origin = _origin(first)
+    return first_origin is not None and first_origin == _origin(second)
+
+
+def same_origin_path(base_url: str, location: str) -> str | None:
+    try:
+        resolved = urljoin(base_url, location)
+    except ValueError:
+        return None
+
+    if not same_origin(base_url, resolved):
+        return None
+
+    return parse_path(resolved)
 
 
 def clean_path(path: str, keep_queries: bool = False, keep_fragment: bool = False) -> str:

--- a/tests/controller/test_redirect_recursion.py
+++ b/tests/controller/test_redirect_recursion.py
@@ -1,0 +1,81 @@
+import threading
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.connection.response import NativeResponse
+from lib.controller.controller import Controller
+from lib.core.data import options
+
+
+def redirect_response(location: str) -> NativeResponse:
+    return NativeResponse(
+        "https://example.test/admin",
+        301,
+        [("Location", location)],
+        b"",
+    )
+
+
+class TestRedirectRecursionOrigin(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "skip_on_status": set(),
+                "full_url": False,
+                "recursion_status_codes": {301},
+                "recursive": True,
+                "deep_recursive": False,
+                "force_recursive": False,
+                "replay_proxy": None,
+                "crawl": False,
+                "find_backup": False,
+                "exclude_subdirs": [],
+                "recursion_depth": 0,
+            }
+        )
+
+        self.controller = object.__new__(Controller)
+        self.controller._operation_lock = threading.Lock()
+        self.controller.url = "https://example.test/"
+        self.controller.base_path = ""
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def queued_directories(self, location: str) -> list[str]:
+        self.controller.directories = []
+        self.controller.passed_urls = set()
+
+        with patch("lib.controller.controller.interface"):
+            self.controller.match_callback(redirect_response(location))
+
+        return self.controller.directories
+
+    def test_cross_origin_redirects_do_not_recur_on_the_target(self):
+        locations = (
+            "https://other.test/admin/",
+            "//other.test/admin/",
+            "http://example.test/admin/",
+            "https://example.test:444/admin/",
+            "https://example.test:0/admin/",
+            "https://[invalid/admin/",
+        )
+
+        for location in locations:
+            with self.subTest(location=location):
+                self.assertEqual(self.queued_directories(location), [])
+
+    def test_same_origin_redirects_still_recur(self):
+        locations = (
+            "/admin/",
+            "admin/",
+            "https://example.test/admin/",
+            "https://EXAMPLE.TEST:443/admin/",
+            "//EXAMPLE.TEST:443/admin/",
+        )
+
+        for location in locations:
+            with self.subTest(location=location):
+                self.assertEqual(self.queued_directories(location), ["admin/"])

--- a/tests/parse/test_url.py
+++ b/tests/parse/test_url.py
@@ -19,7 +19,14 @@
 from unittest import TestCase
 
 from lib.core.settings import DUMMY_URL
-from lib.parse.url import append_query_string, clean_path, ensure_trailing_path_slash, parse_path
+from lib.parse.url import (
+    append_query_string,
+    clean_path,
+    ensure_trailing_path_slash,
+    parse_path,
+    same_origin,
+    same_origin_path,
+)
 
 
 class TestURLParsers(TestCase):
@@ -54,3 +61,38 @@ class TestURLParsers(TestCase):
             append_query_string("admin?existing=true", "debug=true"),
             "admin?existing=true",
         )
+
+    def test_same_origin_normalizes_host_case_and_default_ports(self):
+        self.assertTrue(
+            same_origin(
+                "https://example.com/path",
+                "https://EXAMPLE.COM:443/other",
+            )
+        )
+        self.assertTrue(
+            same_origin(
+                "http://[2001:db8::1]/path",
+                "http://[2001:DB8::1]:80/other",
+            )
+        )
+
+    def test_same_origin_rejects_origin_changes_and_invalid_ports(self):
+        base_url = "https://example.com/path"
+
+        for url in (
+            "https://other.example/path",
+            "http://example.com/path",
+            "https://example.com:444/path",
+            "https://example.com:0/path",
+            "https://example.com:invalid/path",
+            "https://[invalid/path",
+        ):
+            with self.subTest(url=url):
+                self.assertFalse(same_origin(base_url, url))
+
+    def test_same_origin_path_resolves_relative_and_protocol_relative_urls(self):
+        base_url = "https://example.com/admin"
+
+        self.assertEqual(same_origin_path(base_url, "admin/"), "admin/")
+        self.assertEqual(same_origin_path(base_url, "/admin/"), "admin/")
+        self.assertIsNone(same_origin_path(base_url, "//other.example/admin/"))


### PR DESCRIPTION
## Summary
- resolve redirect locations relative to the requested URL before deriving recursion paths
- compare normalized scheme, hostname, and effective port before adding redirected directories
- ignore cross-origin and malformed redirect authorities without aborting the scan

## User-visible effect
A response for `admin` that redirects to `https://other.test/admin/` no longer causes `admin/` to be queued against the original target. Relative redirects and same-origin absolute redirects, including host-case and default-port variants, continue to recurse normally.

## Regression proof
Before the implementation, the focused controller harness queued `admin/` for changes in host, scheme, and port, including protocol-relative redirects. After the implementation, those inputs are rejected while same-origin cases remain accepted.

## Tests
- `/tmp/dirsearch-native-venv/bin/python -m unittest tests.controller.test_redirect_recursion tests.parse.test_url`
- `/tmp/dirsearch-native-venv/bin/python -m unittest discover -s tests -t .` (447 passed)
- `/tmp/dirsearch-native-venv/bin/python testing.py` (447 passed)
- `/tmp/dirsearch-native-venv/bin/python -m flake8 lib/parse/url.py lib/controller/controller.py tests/parse/test_url.py tests/controller/test_redirect_recursion.py`
- `git diff --check`
