### PR TITLE
Keep async replays in the scan lifecycle

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -27,7 +27,7 @@ import re
 import threading
 import time
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Awaitable
 
 from urllib.parse import unquote, urlparse
 
@@ -819,7 +819,11 @@ class Controller:
                     f"{store.destination}: {error}"
                 )
 
-    def match_callback(self, response: BaseResponse) -> None:
+    def match_callback(
+        self, response: BaseResponse
+    ) -> Awaitable[BaseResponse] | None:
+        replay = None
+
         if response.status in options["skip_on_status"]:
             raise SkipTargetInterrupt(
                 f"Skipped the target due to {response.status} status code"
@@ -853,9 +857,17 @@ class Controller:
         if options["replay_proxy"]:
             # Replay the request with new proxy
             if options["async_mode"]:
-                self.loop.create_task(self.requester.replay_request(response.full_path, proxy=options["replay_proxy"]))
+                # AsyncFuzzer awaits callback results, so replay remains inside
+                # the scan lifecycle and receives cancellation with its worker.
+                replay = self.requester.replay_request(
+                    response.full_path,
+                    proxy=options["replay_proxy"],
+                )
             else:
-                self.requester.request(response.full_path, proxy=options["replay_proxy"])
+                self.requester.request(
+                    response.full_path,
+                    proxy=options["replay_proxy"],
+                )
 
         if options["crawl"]:
             self.add_crawled_paths(response)
@@ -864,6 +876,8 @@ class Controller:
             path = lstrip_once(response.path, self.base_path)
             for backup_path in generate_backup_paths(path):
                 self.dictionary.add_extra(backup_path)
+
+        return replay
 
     def update_progress_bar(self, response: BaseResponse) -> None:
         jobs_count = (

--- a/tests/controller/test_replay_lifecycle.py
+++ b/tests/controller/test_replay_lifecycle.py
@@ -1,0 +1,156 @@
+import asyncio
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import Mock, patch
+
+from lib.connection.response import NativeResponse
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.exceptions import RequestException
+from lib.core.fuzzer import AsyncFuzzer
+
+
+def matched_response() -> NativeResponse:
+    return NativeResponse(
+        "https://example.test/admin",
+        200,
+        [("Content-Type", "text/plain")],
+        b"found",
+    )
+
+
+class ReplayOptionsMixin:
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "skip_on_status": set(),
+                "full_url": False,
+                "recursion_status_codes": set(),
+                "recursive": False,
+                "deep_recursive": False,
+                "force_recursive": False,
+                "replay_proxy": "http://replay.test:8080",
+                "crawl": False,
+                "find_backup": False,
+            }
+        )
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+
+class RecordingAsyncRequester:
+    def __init__(self):
+        self.completed = False
+        self.calls = []
+
+    async def replay_request(self, path: str, proxy: str):
+        self.calls.append((path, proxy))
+        await asyncio.sleep(0)
+        self.completed = True
+
+
+class BlockingAsyncRequester:
+    def __init__(self):
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.task = None
+
+    async def replay_request(self, path: str, proxy: str):
+        del path, proxy
+        self.task = asyncio.current_task()
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
+class FailingAsyncRequester:
+    async def replay_request(self, path: str, proxy: str):
+        del path, proxy
+        await asyncio.sleep(0)
+        raise RequestException("replay failed")
+
+
+class TestAsyncReplayLifecycle(ReplayOptionsMixin, IsolatedAsyncioTestCase):
+    async def test_match_callback_waits_for_replay_to_finish(self):
+        options["async_mode"] = True
+        requester = RecordingAsyncRequester()
+        controller = object.__new__(Controller)
+        controller.loop = asyncio.get_running_loop()
+        controller.requester = requester
+
+        with patch("lib.controller.controller.interface"):
+            await AsyncFuzzer.run_callbacks(
+                (controller.match_callback,),
+                matched_response(),
+            )
+
+        completed_when_callback_returned = requester.completed
+        await asyncio.sleep(0)
+
+        self.assertTrue(completed_when_callback_returned)
+        self.assertEqual(
+            requester.calls,
+            [("admin", "http://replay.test:8080")],
+        )
+
+    async def test_cancelling_callback_cancels_in_progress_replay(self):
+        options["async_mode"] = True
+        requester = BlockingAsyncRequester()
+        controller = object.__new__(Controller)
+        controller.loop = asyncio.get_running_loop()
+        controller.requester = requester
+
+        with patch("lib.controller.controller.interface"):
+            callback_task = asyncio.create_task(
+                AsyncFuzzer.run_callbacks(
+                    (controller.match_callback,),
+                    matched_response(),
+                )
+            )
+            await asyncio.wait_for(requester.started.wait(), timeout=1)
+            callback_task.cancel()
+            await asyncio.gather(callback_task, return_exceptions=True)
+
+        cancelled_with_callback = requester.cancelled.is_set()
+        if requester.task is not None and not requester.task.done():
+            requester.task.cancel()
+            await asyncio.gather(requester.task, return_exceptions=True)
+
+        self.assertTrue(cancelled_with_callback)
+
+    async def test_replay_failure_is_observed_by_callback_runner(self):
+        options["async_mode"] = True
+        controller = object.__new__(Controller)
+        controller.loop = asyncio.get_running_loop()
+        controller.requester = FailingAsyncRequester()
+
+        with (
+            patch("lib.controller.controller.interface"),
+            self.assertRaisesRegex(RequestException, "replay failed"),
+        ):
+            await AsyncFuzzer.run_callbacks(
+                (controller.match_callback,),
+                matched_response(),
+            )
+
+
+class TestSyncReplayLifecycle(ReplayOptionsMixin, TestCase):
+    def test_match_callback_replays_inline(self):
+        options["async_mode"] = False
+        requester = Mock()
+        controller = object.__new__(Controller)
+        controller.requester = requester
+
+        with patch("lib.controller.controller.interface"):
+            result = controller.match_callback(matched_response())
+
+        self.assertIsNone(result)
+        requester.request.assert_called_once_with(
+            "admin",
+            proxy="http://replay.test:8080",
+        )


### PR DESCRIPTION
## Summary
- return async replay requests to the existing awaitable callback runner instead of creating detached tasks
- keep replay completion and cancellation within the owning async scan worker
- preserve inline replay behavior for threaded and native scans

## User-visible effect
Async scans using a replay proxy no longer finish a callback, advance a target, or close the requester while that callback's replay is still pending. Replay failures are observed by the scan task instead of becoming unobserved background-task exceptions.

The awaited callbacks also provide bounded backpressure through the existing async worker concurrency rather than allowing an unbounded set of replay tasks to accumulate.

## Regression proof
Before the implementation, the focused harness observed `match_callback` returning while its replay coroutine remained incomplete. After the implementation, completion is awaited, cancellation reaches an in-progress replay, replay errors are observed, and the existing synchronous call remains inline.

## Tests
- `python -m unittest tests.controller.test_replay_lifecycle tests.controller.test_async_controller tests.core.test_async_fuzzer tests.connection.test_requester` (57 passed)
- `python -m unittest discover -s tests -t .` (451 passed)
- `python testing.py` (451 passed)
- `python -m flake8 lib/controller/controller.py tests/controller/test_replay_lifecycle.py`
- `git diff --check`
