### PR TITLE
Close all async rotating proxy transports

### DIFF
--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -707,6 +707,18 @@ class ProxyRoatingTransport(httpx.AsyncBaseTransport):
         transport = random.choice(self._transports)
         return await transport.handle_async_request(request)
 
+    async def aclose(self) -> None:
+        first_error = None
+        for transport in self._transports:
+            try:
+                await transport.aclose()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+
+        if first_error is not None:
+            raise first_error
+
 
 class AsyncRequester(BaseRequester):
     def __init__(self) -> None:

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -336,6 +336,17 @@ class DummyAsyncSession:
         self.closed = True
 
 
+class RecordingAsyncTransport:
+    def __init__(self, close_error=None):
+        self.close_error = close_error
+        self.close_calls = 0
+
+    async def aclose(self):
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
 class BaseRequesterTestCase(TestCase):
     def setUp(self) -> None:
         self.original_options = dict(options)
@@ -686,6 +697,40 @@ class TestRequesterProxyRouting(BaseRequesterTestCase):
 class TestAsyncRequesterProxyRouting(
     BaseRequesterTestCase, IsolatedAsyncioTestCase
 ):
+    async def test_requester_close_closes_every_rotating_proxy_transport(self):
+        options["proxies"] = [
+            "http://proxy-one.invalid:8080",
+            "http://proxy-two.invalid:8080",
+        ]
+        children = [RecordingAsyncTransport(), RecordingAsyncTransport()]
+
+        with patch(
+            "lib.connection.requester.PathPreservingAsyncHTTPTransport",
+            side_effect=children,
+        ):
+            requester = AsyncRequester()
+
+        await requester.close()
+
+        self.assertEqual([child.close_calls for child in children], [1, 1])
+
+    async def test_rotating_proxy_close_continues_after_child_failure(self):
+        failure = RuntimeError("first transport close failed")
+        children = [
+            RecordingAsyncTransport(close_error=failure),
+            RecordingAsyncTransport(
+                close_error=RuntimeError("second transport close failed")
+            ),
+            RecordingAsyncTransport(),
+        ]
+        transport = object.__new__(ProxyRoatingTransport)
+        transport._transports = children
+
+        with self.assertRaisesRegex(RuntimeError, "first transport close failed"):
+            await transport.aclose()
+
+        self.assertEqual([child.close_calls for child in children], [1, 1, 1])
+
     async def test_explicit_proxy_overrides_environment_proxy_rules(self):
         options["proxies"] = ["http://cli.invalid:8080"]
         environments = (


### PR DESCRIPTION
## Summary
- explicitly close every child transport owned by the async rotating-proxy wrapper
- continue closing remaining children when one child cleanup fails
- re-raise the first cleanup error after all children have been attempted

## User-visible effect
Closing an async requester configured with multiple proxies now releases every owned HTTP transport and its connection pool. Repeated in-process scans no longer rely on garbage collection or process exit to release those proxy resources.

This PR intentionally does not change the separate `--ip` plus proxy routing semantics.

## Regression proof
Before the implementation, closing a requester left both instrumented child transports with zero close calls, and the inherited no-op close never surfaced child failures. After the implementation, every child is closed once; a failure in the first child does not prevent later children from closing, and the first error remains observable.

## Tests
- `python -m unittest tests.connection.test_requester.TestAsyncRequesterProxyRouting` (5 passed)
- `python -m unittest tests.connection.test_requester tests.connection.test_proxy_integration tests.controller.test_async_controller` (67 passed)
- `python -m unittest discover -s tests -t .` (453 passed)
- `python testing.py` (453 passed)
- `python -m flake8 lib/connection/requester.py tests/connection/test_requester.py`
- `git diff --check`
