### PR TITLE
Preserve IPv6 brackets in target URLs

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -717,7 +717,9 @@ class Controller:
         if options["ip"]:
             self.requester.set_ip(parsed.hostname, port, options["ip"])
 
-        self.url = f"{scheme}://{parsed.hostname}"
+        hostname = parsed.hostname
+        url_hostname = f"[{hostname}]" if hostname and ":" in hostname else hostname
+        self.url = f"{scheme}://{url_hostname}"
 
         if port != STANDARD_PORTS[scheme]:
             self.url += f":{port}"

--- a/tests/controller/test_target_url.py
+++ b/tests/controller/test_target_url.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+
+
+class TestControllerTargetURL(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "request_backend": "python",
+                "scheme": None,
+                "ip": None,
+                "proxies": [],
+                "tor": False,
+            }
+        )
+        self.controller = object.__new__(Controller)
+        self.controller.requester = Mock()
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def test_ipv6_target_authority_keeps_literal_brackets(self):
+        cases = (
+            ("http://[::1]/", "http://[::1]/"),
+            (
+                "https://[2001:db8::1]:443/private",
+                "https://[2001:db8::1]/",
+            ),
+            (
+                "http://[2001:db8::2]:8080/api",
+                "http://[2001:db8::2]:8080/",
+            ),
+            (
+                "http://[fe80::1%25eth0]:8000/",
+                "http://[fe80::1%25eth0]:8000/",
+            ),
+        )
+
+        for target, expected_url in cases:
+            with self.subTest(target=target):
+                self.controller.requester.reset_mock()
+
+                self.controller.set_target(target)
+
+                self.assertEqual(self.controller.url, expected_url)
+                self.controller.requester.set_url.assert_called_once_with(
+                    expected_url
+                )

--- a/tests/controller/test_target_url.py
+++ b/tests/controller/test_target_url.py
@@ -26,7 +26,30 @@ class TestControllerTargetURL(TestCase):
 
     def test_ipv6_target_authority_keeps_literal_brackets(self):
         cases = (
+            ("http://[::]/", "http://[::]/"),
             ("http://[::1]/", "http://[::1]/"),
+            (
+                "http://[0:0:0:0:0:0:0:1]/",
+                "http://[0:0:0:0:0:0:0:1]/",
+            ),
+            (
+                "http://[2001:0db8:0000:0000:0000:ff00:0042:8329]/",
+                "http://[2001:0db8:0000:0000:0000:ff00:0042:8329]/",
+            ),
+            (
+                "http://[2001:db8::ff00:42:8329]/",
+                "http://[2001:db8::ff00:42:8329]/",
+            ),
+            ("http://[2001:db8::]/", "http://[2001:db8::]/"),
+            ("http://[2001:DB8::ABCD]/", "http://[2001:db8::abcd]/"),
+            (
+                "http://[::ffff:192.0.2.128]/",
+                "http://[::ffff:192.0.2.128]/",
+            ),
+            (
+                "http://[64:ff9b::192.0.2.33]/",
+                "http://[64:ff9b::192.0.2.33]/",
+            ),
             (
                 "https://[2001:db8::1]:443/private",
                 "https://[2001:db8::1]/",
@@ -51,3 +74,13 @@ class TestControllerTargetURL(TestCase):
                 self.controller.requester.set_url.assert_called_once_with(
                     expected_url
                 )
+
+    def test_scheme_option_keeps_ipv6_literal_brackets(self):
+        options["scheme"] = "https"
+
+        self.controller.set_target("[2001:db8::1]:8443/private")
+
+        self.assertEqual(self.controller.url, "https://[2001:db8::1]:8443/")
+        self.controller.requester.set_url.assert_called_once_with(
+            "https://[2001:db8::1]:8443/"
+        )

--- a/tests/controller/test_target_url.py
+++ b/tests/controller/test_target_url.py
@@ -1,8 +1,73 @@
-from unittest import TestCase
-from unittest.mock import Mock
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+import socket
+import threading
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import Mock, patch
 
+from lib.connection.native import NativeHTTPBackend
+from lib.connection.requester import AsyncRequester, Requester
 from lib.controller.controller import Controller
 from lib.core.data import options
+from lib.core.exceptions import RequestException
+
+
+PROXY_ENVIRONMENT = {
+    name: ""
+    for name in (
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+    )
+}
+IPV6_LOOPBACK_FORMS = ("::1", "0:0:0:0:0:0:0:1")
+
+
+class IPv6HTTPServer(ThreadingHTTPServer):
+    address_family = socket.AF_INET6
+    daemon_threads = True
+
+
+class IPv6RequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.server.targets.append(self.path)
+        body = b"ipv6 ok"
+        self.send_response(200)
+        self.send_header("content-type", "text/plain")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+class LocalIPv6HTTPServer:
+    def __enter__(self):
+        self.server = IPv6HTTPServer(("::1", 0), IPv6RequestHandler)
+        self.server.targets = []
+        self.thread = threading.Thread(
+            target=lambda: self.server.serve_forever(poll_interval=0.01),
+            daemon=True,
+        )
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def url_for(self, hostname):
+        port = self.server.server_address[1]
+        return f"http://[{hostname}]:{port}/"
+
+    @property
+    def targets(self):
+        return self.server.targets
 
 
 class TestControllerTargetURL(TestCase):
@@ -84,3 +149,77 @@ class TestControllerTargetURL(TestCase):
         self.controller.requester.set_url.assert_called_once_with(
             "https://[2001:db8::1]:8443/"
         )
+
+    def test_threaded_requester_reaches_ipv6_literal(self):
+        with patch.dict(os.environ, PROXY_ENVIRONMENT):
+            with LocalIPv6HTTPServer() as server:
+                requester = Requester()
+                self.controller.requester = requester
+                try:
+                    for hostname in IPV6_LOOPBACK_FORMS:
+                        with self.subTest(hostname=hostname):
+                            self.controller.set_target(server.url_for(hostname))
+                            response = requester.request("ipv6-check")
+                            self.assertEqual(response.status, 200)
+                finally:
+                    requester.close()
+
+        self.assertEqual(server.targets, ["/ipv6-check", "/ipv6-check"])
+
+    def test_native_requester_reaches_ipv6_literal(self):
+        options["request_backend"] = "native"
+        try:
+            backend = NativeHTTPBackend()
+        except RequestException as error:
+            self.skipTest(str(error))
+
+        with patch.dict(os.environ, PROXY_ENVIRONMENT):
+            with LocalIPv6HTTPServer() as server:
+                requester = Requester()
+                self.controller.requester = requester
+                try:
+                    for hostname in IPV6_LOOPBACK_FORMS:
+                        with self.subTest(hostname=hostname):
+                            self.controller.set_target(server.url_for(hostname))
+                            results = list(backend.scan(requester._url, ["ipv6-check"]))
+                            self.assertIsNone(results[0][2])
+                            self.assertEqual(results[0][1].status, 200)
+                finally:
+                    requester.close()
+
+        self.assertEqual(server.targets, ["/ipv6-check", "/ipv6-check"])
+
+
+class TestAsyncControllerTargetURL(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        options.update(
+            {
+                "request_backend": "python",
+                "scheme": None,
+                "ip": None,
+                "proxies": [],
+                "tor": False,
+            }
+        )
+        self.controller = object.__new__(Controller)
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    async def test_async_requester_reaches_ipv6_literal(self):
+        with patch.dict(os.environ, PROXY_ENVIRONMENT):
+            with LocalIPv6HTTPServer() as server:
+                requester = AsyncRequester()
+                self.controller.requester = requester
+                try:
+                    for hostname in IPV6_LOOPBACK_FORMS:
+                        with self.subTest(hostname=hostname):
+                            self.controller.set_target(server.url_for(hostname))
+                            response = await requester.request("ipv6-check")
+                            self.assertEqual(response.status, 200)
+                finally:
+                    await requester.close()
+
+        self.assertEqual(server.targets, ["/ipv6-check", "/ipv6-check"])


### PR DESCRIPTION
## Summary

- preserve brackets when rebuilding target URLs from IPv6 literals
- retain the existing default-port elision and non-standard-port behavior
- cover unspecified and loopback addresses, full and compressed forms, uppercase hex, IPv4-embedded forms, custom ports, encoded zone identifiers, and bracketed targets using --scheme
- run real HTTP requests over IPv6 loopback through the threaded, async, and native backends

## Bug

urllib.parse exposes an IPv6 hostname without its URL authority brackets. Controller.set_target() reused that bare hostname, turning a valid target such as http://[::1]:8080/ into the invalid http://::1:8080/.

The normalization happens before the threaded, async, and native scan paths diverge. The transport-level tests pass both compressed and expanded loopback literals through Controller.set_target(), open a real IPv6 socket, and assert that the server receives /ipv6-check.

## Validation

- Red phase: the original regression test failed for all four IPv6 cases before the fix
- Parsing matrix: 12 explicit IPv6 authorities plus one bracketed target using --scheme
- Python 3.12 focused suite: 5 passed, 1 native test skipped because the extension requires Python 3.14
- Python 3.14 focused suite with a locally built native extension: 5 passed, no skips
- Python 3.14 full suite with native extension: 458 passed, no skips
- Live IPv6 connectivity smoke on an IPv6-enabled Linux host with Python 3.14.7: one GET to v6.ident.me by each of threaded, async, and locally built native-Rust; all returned HTTP 200 through a bracketed IPv6 literal
- python -m unittest discover -s tests -t . under Python 3.12: 458 passed, 22 skipped
- python testing.py under Python 3.12: 458 passed, 22 skipped
- python -m flake8 lib/controller/controller.py tests/controller/test_target_url.py
- python -m compileall -q lib/controller/controller.py tests/controller/test_target_url.py
- codespell lib/controller/controller.py tests/controller/test_target_url.py
- git diff --check
