### PR TITLE
Handle invalid target ports without aborting

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -686,7 +686,12 @@ class Controller:
         if parsed.scheme not in (UNKNOWN, "https", "http"):
             raise InvalidURLException(f"Unsupported URI scheme: {parsed.scheme}")
 
-        port = parsed.port
+        try:
+            port = parsed.port
+        except ValueError as error:
+            raise InvalidURLException(
+                f"Invalid port in target URL: {error}"
+            ) from error
         # If no port is specified, set default (80, 443) based on the scheme
         if not port:
             port = STANDARD_PORTS.get(parsed.scheme, None)

--- a/tests/controller/test_target_url.py
+++ b/tests/controller/test_target_url.py
@@ -1,4 +1,5 @@
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import asyncio
 import os
 import socket
 import threading
@@ -9,7 +10,7 @@ from lib.connection.native import NativeHTTPBackend
 from lib.connection.requester import AsyncRequester, Requester
 from lib.controller.controller import Controller
 from lib.core.data import options
-from lib.core.exceptions import RequestException
+from lib.core.exceptions import InvalidURLException, RequestException
 
 
 PROXY_ENVIRONMENT = {
@@ -149,6 +150,97 @@ class TestControllerTargetURL(TestCase):
         self.controller.requester.set_url.assert_called_once_with(
             "https://[2001:db8::1]:8443/"
         )
+
+    def test_invalid_ports_raise_invalid_url_exception(self):
+        targets = (
+            "http://example.test:not-a-port/",
+            "http://example.test:-1/",
+            "http://example.test:65536/",
+            "http://example.test:０/",
+            "http://[::1]:not-a-port/",
+        )
+
+        for request_backend in ("python", "native"):
+            options["request_backend"] = request_backend
+            for target in targets:
+                with self.subTest(
+                    request_backend=request_backend,
+                    target=target,
+                ):
+                    with self.assertRaisesRegex(
+                        InvalidURLException,
+                        "Invalid port in target URL",
+                    ):
+                        self.controller.set_target(target)
+
+    def test_invalid_port_does_not_discard_later_targets(self):
+        stack_cases = (
+            ("threaded", False, "python"),
+            ("async", True, "python"),
+            ("native", False, "native"),
+        )
+
+        for stack, async_mode, request_backend in stack_cases:
+            with self.subTest(stack=stack):
+                controller = object.__new__(Controller)
+                controller.start_time = 0
+                controller.passed_urls = set()
+                controller.directories = []
+                controller.jobs_processed = 0
+                controller.errors = 0
+                controller.consecutive_errors = 0
+                controller.old_session = False
+                controller.dictionary = Mock()
+                controller.output_history = []
+                controller.response_stores = ()
+                controller.reporter = Mock()
+                controller.crawl_target = Mock()
+                controller.start = Mock()
+                requester = Mock()
+
+                run_options = {
+                    "urls": [
+                        "http://bad.example:not-a-port/",
+                        "https://good.example/",
+                    ],
+                    "request_backend": request_backend,
+                    "async_mode": async_mode,
+                    "subdirs": [""],
+                    "session_file": None,
+                }
+
+                with (
+                    patch.dict(options, run_options),
+                    patch(
+                        "lib.connection.requester.Requester",
+                        return_value=requester,
+                    ),
+                    patch(
+                        "lib.connection.requester.AsyncRequester",
+                        return_value=requester,
+                    ),
+                    patch("lib.core.fuzzer.Fuzzer", return_value=Mock()),
+                    patch("lib.core.fuzzer.AsyncFuzzer", return_value=Mock()),
+                    patch("lib.core.fuzzer.NativeFuzzer", return_value=Mock()),
+                    patch("lib.controller.controller.signal.signal"),
+                    patch("lib.controller.controller.interface") as interface,
+                ):
+                    try:
+                        controller.run()
+                    finally:
+                        loop = getattr(controller, "loop", None)
+                        if isinstance(loop, asyncio.AbstractEventLoop):
+                            loop.close()
+
+                controller.start.assert_called_once_with()
+                controller.reporter.prepare.assert_called_once_with(
+                    "https://good.example/"
+                )
+                interface.error.assert_called_once()
+                self.assertIn(
+                    "Invalid port in target URL",
+                    interface.error.call_args.args[0],
+                )
 
     def test_threaded_requester_reaches_ipv6_literal(self):
         with patch.dict(os.environ, PROXY_ENVIRONMENT):


### PR DESCRIPTION
## Summary

- translate `urllib.parse` port parsing failures into `InvalidURLException`
- keep the original parsing detail in the user-facing error and exception chain
- allow later targets to continue after an invalid port in threaded, async, and native modes

## Bug

`ParseResult.port` validates lazily and raises `ValueError` for non-numeric, negative, Unicode-numeric, and out-of-range ports. `Controller.run()` handles `InvalidURLException`, but not this raw exception, so one malformed target aborts the entire target queue.

## Validation

- Red phase: 10 direct backend cases and all 3 target-queue modes failed with an uncaught `ValueError` before the fix
- Invalid-port matrix covers alphabetic, negative, out-of-range, Unicode, and bracketed IPv6 authorities
- Queue regression verifies that a valid target after the malformed target is still prepared in threaded, async, and native modes
- Python 3.12 focused suite: 7 passed, 1 optional native test skipped
- Python 3.14 focused suite with native extension: 7 passed, no skips
- Python 3.12 full suite: 460 passed, 22 optional-native skips
- Python 3.14 full suite with native extension: 460 passed, no skips
- `python testing.py`: 460 passed, 22 optional-native skips
- `python -m flake8 lib/controller/controller.py tests/controller/test_target_url.py`
- `python -m compileall -q lib/controller/controller.py tests/controller/test_target_url.py`
- `codespell lib/controller/controller.py tests/controller/test_target_url.py`
- `git diff --check`
