### PR TITLE
Preserve response capture completeness in JSONL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,9 @@ filtering, so memory and network use can increase on binary-heavy targets.
 
 `--save-response-jsonl FILE` appends one versioned JSON object per matched
 response. The `body` field is always Base64 encoded and identified by
-`bodyEncoding`, so text and binary responses use the same stable schema. Both
-response-saving options can be enabled together. Existing non-empty JSONL
-files must contain compatible `dirsearch.response.v1` records.
+`bodyEncoding`, so text and binary responses use the same stable schema.
+`capturedBodyLength` records the number of stored bytes, while `bodyComplete`
+and `bodyTruncated` explicitly identify whether the capture limit omitted any
+of the decoded response body. Both response-saving options can be enabled
+together. Existing non-empty JSONL files must contain compatible
+`dirsearch.response.v1` records.

--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -117,6 +117,7 @@ class NativeHTTPBackend:
                     length=getattr(result, "length", None),
                     filtered=getattr(result, "filtered", False),
                     filter_reason=getattr(result, "filter_reason", None),
+                    body_complete=getattr(result, "body_complete", None),
                 ),
                 None,
             )

--- a/lib/connection/response.py
+++ b/lib/connection/response.py
@@ -141,6 +141,16 @@ class BaseResponse:
         return get_readable_size(self.length)
 
     @property
+    def body_complete(self) -> bool:
+        """Return whether the captured body contains the complete response."""
+        return self._body_complete
+
+    @property
+    def body_truncated(self) -> bool:
+        """Return whether response capture stopped before the body was complete."""
+        return not self.body_complete
+
+    @property
     def text(self) -> str:
         if self.content:
             return self.content
@@ -272,6 +282,7 @@ class NativeResponse(BaseResponse):
         length: int | None = None,
         filtered: bool = False,
         filter_reason: str | None = None,
+        body_complete: bool | None = None,
     ) -> None:
         response = type(
             "NativeHTTPResponse",
@@ -289,7 +300,9 @@ class NativeResponse(BaseResponse):
         self.filtered = filtered
         self.filter_reason = filter_reason
         self.body = bytes(body)
-        if self._length is not None:
+        if body_complete is not None:
+            self._body_complete = body_complete
+        elif self._length is not None:
             self._body_complete = self._length == len(self.body)
         if not is_binary(self.body):
             self.content = self.body.decode(DEFAULT_ENCODING, errors="replace")

--- a/lib/report/jsonl_response_store.py
+++ b/lib/report/jsonl_response_store.py
@@ -83,6 +83,8 @@ class JsonlResponseStore(BaseResponseStore):
             "headers": dict(artifact.headers),
             "contentLength": artifact.content_length,
             "capturedBodyLength": len(artifact.body),
+            "bodyComplete": artifact.body_complete,
+            "bodyTruncated": artifact.body_truncated,
             "contentType": artifact.content_type,
             "redirect": artifact.redirect,
             "elapsed": round(artifact.elapsed, 3),

--- a/lib/report/response_store.py
+++ b/lib/report/response_store.py
@@ -23,6 +23,8 @@ class ResponseArtifact:
     redirect: str
     elapsed: float
     body: bytes
+    body_complete: bool
+    body_truncated: bool
 
     @classmethod
     def from_response(cls, response: BaseResponse) -> ResponseArtifact:
@@ -38,6 +40,8 @@ class ResponseArtifact:
             redirect=response.redirect,
             elapsed=response.elapsed,
             body=bytes(response.body),
+            body_complete=response.body_complete,
+            body_truncated=response.body_truncated,
         )
 
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -42,6 +42,8 @@ struct NativeHttpResult {
     headers: Vec<(String, String)>,
     #[pyo3(get)]
     body: Vec<u8>,
+    #[pyo3(get)]
+    body_complete: bool,
 }
 
 #[pyclass]
@@ -1022,6 +1024,7 @@ fn native_http_result_with_length(
         .filter_reason(status, length, &headers, &body, elapsed_ms)
         .map(str::to_string);
     let filtered = filter_reason.is_some();
+    let body_complete = !filtered && body.len() == body_length;
 
     NativeHttpResult {
         path,
@@ -1033,6 +1036,7 @@ fn native_http_result_with_length(
         filter_reason,
         headers,
         body: if filtered { Vec::new() } else { body },
+        body_complete,
     }
 }
 
@@ -1047,6 +1051,7 @@ fn native_error_result(path: String, elapsed_ms: f64, error: String) -> NativeHt
         filter_reason: None,
         headers: Vec::new(),
         body: Vec::new(),
+        body_complete: false,
     }
 }
 
@@ -1882,6 +1887,7 @@ mod tests {
 
         assert_eq!(result.length, 1024);
         assert_eq!(result.body, b"abcdef");
+        assert!(!result.body_complete);
     }
 
     #[test]

--- a/tests/connection/test_native_response.py
+++ b/tests/connection/test_native_response.py
@@ -115,3 +115,5 @@ class TestNativeResponse(TestCase):
         )
 
         self.assertNotEqual(left, right)
+        self.assertFalse(left.body_complete)
+        self.assertTrue(left.body_truncated)

--- a/tests/connection/test_requester.py
+++ b/tests/connection/test_requester.py
@@ -1147,6 +1147,8 @@ class TestResponseStoreTransportIntegration(
                 self.assertEqual(
                     record["capturedBodyLength"], len(expected_body)
                 )
+                self.assertTrue(record["bodyComplete"])
+                self.assertFalse(record["bodyTruncated"])
                 self.assertEqual(record["headers"]["content-encoding"], "gzip")
                 self.assertEqual(
                     record["headers"]["content-type"],

--- a/tests/connection/test_response.py
+++ b/tests/connection/test_response.py
@@ -133,6 +133,8 @@ class TestResponse(TestCase):
             )
 
         self.assertEqual(response.body, b"abcde")
+        self.assertFalse(response.body_complete)
+        self.assertTrue(response.body_truncated)
 
     def test_binary_responses_with_matching_prefixes_are_not_equal(self):
         prefix = b"\x00" + b"a" * 15
@@ -225,6 +227,8 @@ class TestAsyncResponse(IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(response.body, b"abcde")
+        self.assertFalse(response.body_complete)
+        self.assertTrue(response.body_truncated)
 
     async def test_binary_responses_with_matching_prefixes_are_not_equal(self):
         prefix = b"\x00" + b"a" * 15

--- a/tests/report/test_response_store.py
+++ b/tests/report/test_response_store.py
@@ -97,6 +97,22 @@ class TestResponseArtifact(TestCase):
         self.assertEqual(artifact.content_type, "application/octet-stream")
         self.assertEqual(artifact.elapsed, 0.125)
         self.assertEqual(dict(artifact.headers)["x-response-id"], "test-response")
+        self.assertTrue(artifact.body_complete)
+        self.assertFalse(artifact.body_truncated)
+
+    def test_preserves_truncated_body_state(self):
+        response = NativeResponse(
+            "https://example.com/large",
+            200,
+            [("Content-Type", "application/octet-stream")],
+            b"prefix",
+            length=1024,
+        )
+
+        artifact = ResponseArtifact.from_response(response)
+
+        self.assertFalse(artifact.body_complete)
+        self.assertTrue(artifact.body_truncated)
 
 
 class TestBaseResponseStore(TestCase):
@@ -392,12 +408,37 @@ class TestJsonlResponseStore(TestCase):
             self.assertEqual(records[0]["schema"], JSONL_RESPONSE_SCHEMA)
             self.assertEqual(records[0]["bodyEncoding"], "base64")
             self.assertEqual(records[0]["capturedBodyLength"], len(artifact.body))
+            self.assertTrue(records[0]["bodyComplete"])
+            self.assertFalse(records[0]["bodyTruncated"])
             self.assertEqual(records[0]["url"], artifact.url)
             self.assertEqual(records[0]["status"], artifact.status)
             self.assertEqual(
                 base64.b64decode(records[0]["body"]),
                 artifact.body,
             )
+
+    def test_records_truncated_body_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = os.path.join(directory, "responses.jsonl")
+            store = JsonlResponseStore(file_path)
+            artifact = ResponseArtifact.from_response(
+                NativeResponse(
+                    "https://example.com/large",
+                    200,
+                    [("Content-Type", "application/octet-stream")],
+                    b"prefix",
+                    length=1024,
+                )
+            )
+
+            store.save(artifact)
+            store.close()
+
+            record = read_jsonl(file_path)[0]
+            self.assertEqual(record["contentLength"], 1024)
+            self.assertEqual(record["capturedBodyLength"], len(b"prefix"))
+            self.assertFalse(record["bodyComplete"])
+            self.assertTrue(record["bodyTruncated"])
 
     def test_appends_after_existing_record_without_final_newline(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- expose complete/truncated body capture state on backend-neutral response artifacts
- include additive `bodyComplete` and `bodyTruncated` fields in JSONL evidence
- have the Rust backend report decoded-body completeness directly instead of inferring it from wire `Content-Length`
- document the JSONL capture metadata

## Bug

Responses already track whether capture stopped at the configured body limit, but `ResponseArtifact` discarded that state. `contentLength` and `capturedBodyLength` cannot prove completeness when `Content-Length` is absent, so exported evidence could not distinguish a complete body from a capped prefix.

Native responses need an explicit signal from Rust: for compressed responses, wire `Content-Length` and decoded body length legitimately differ. Comparing those values would incorrectly label a complete decoded body as truncated.

The new JSONL fields are additive under `dirsearch.response.v1`; existing compatible records remain appendable.

## Validation

- Red phase: 7 Python assertions failed on missing capture-state fields and the Rust regression failed to compile before implementation
- Truncated response regression verifies `contentLength=1024`, `capturedBodyLength=6`, `bodyComplete=false`, and `bodyTruncated=true`
- Gzip integration verifies complete decoded bodies are marked complete across threaded, async, and native-Rust
- Python 3.12 full suite: 462 passed, 22 optional-native skips
- Python 3.14 full suite with the rebuilt native extension: 462 passed, no skips
- `python testing.py`: 462 passed, 22 optional-native skips
- `cargo test --locked --manifest-path native/Cargo.toml`: 24 passed
- `cargo fmt --manifest-path native/Cargo.toml -- --check`
- focused flake8, compileall, codespell, and `git diff --check`
