### PR TITLE
Stream appendable file reports

### DIFF
--- a/lib/report/csv_report.py
+++ b/lib/report/csv_report.py
@@ -16,6 +16,8 @@
 #
 #  Author: Mauro Soria
 
+from io import StringIO
+
 from defusedcsv import csv
 
 from lib.core.decorators import locked
@@ -43,10 +45,19 @@ class CSVReport(FileReportMixin, BaseReport):
 
     @locked
     def save(self, file, result):
-        rows = self.parse(file)
         elapsed = round(result.elapsed, 3) if result.elapsed else ""
-        rows.append([result.url, result.status, result.length, result.type, result.redirect, elapsed])
-        self.write(file, rows)
+        row = StringIO(newline="")
+        csv.writer(row, delimiter=",", quotechar='"').writerow(
+            [
+                result.url,
+                result.status,
+                result.length,
+                result.type,
+                result.redirect,
+                elapsed,
+            ]
+        )
+        self.append(file, row.getvalue())
 
     def write(self, file, rows):
         with self._atomic_writer(file) as fh:

--- a/lib/report/factory.py
+++ b/lib/report/factory.py
@@ -87,6 +87,9 @@ class FileReportMixin:
         with self._atomic_writer(file) as fh:
             fh.write(data)
 
+    def append(self, file, data):
+        FileUtils.append_private_text(file, data, encoding=None)
+
     def finish(self):
         pass
 

--- a/lib/report/markdown_report.py
+++ b/lib/report/markdown_report.py
@@ -41,7 +41,9 @@ class MarkdownReport(FileReportMixin, BaseReport):
 
     @locked
     def save(self, file, result):
-        md = self.parse(file)
         elapsed_ms = int(result.elapsed * 1000) if result.elapsed else "-"
-        md += f"{result.url} | {result.status} | {result.length} | {result.type} | {result.redirect} | {elapsed_ms}" + NEW_LINE
-        self.write(file, md)
+        row = (
+            f"{result.url} | {result.status} | {result.length} | "
+            f"{result.type} | {result.redirect} | {elapsed_ms}{NEW_LINE}"
+        )
+        self.append(file, row)

--- a/lib/report/plain_text_report.py
+++ b/lib/report/plain_text_report.py
@@ -36,8 +36,7 @@ class PlainTextReport(FileReportMixin, BaseReport):
     @locked
     def save(self, file, result):
         readable_size = get_readable_size(result.length)
-        data = self.parse(file)
-        data += f"{result.status} {readable_size.rjust(6, chr(32))} {result.url}"
+        data = f"{result.status} {readable_size.rjust(6, chr(32))} {result.url}"
 
         if result.elapsed:
             elapsed_ms = int(result.elapsed * 1000)
@@ -48,4 +47,4 @@ class PlainTextReport(FileReportMixin, BaseReport):
 
         data += NEW_LINE
 
-        self.write(file, data)
+        self.append(file, data)

--- a/lib/report/simple_report.py
+++ b/lib/report/simple_report.py
@@ -30,6 +30,4 @@ class SimpleReport(FileReportMixin, BaseReport):
 
     @locked
     def save(self, file, result):
-        data = self.parse(file)
-        data += result.url + NEW_LINE
-        self.write(file, data)
+        self.append(file, result.url + NEW_LINE)

--- a/lib/utils/file.py
+++ b/lib/utils/file.py
@@ -184,6 +184,35 @@ class FileUtils:
         flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         return os.open(file_name, flags, 0o600)
 
+    @classmethod
+    def append_private_text(
+        cls,
+        file_name: str,
+        data: str,
+        encoding: str | None = "utf-8",
+    ) -> None:
+        """Append text and roll back a failed write to the previous file size."""
+        descriptor = cls.open_binary_append(file_name)
+        rollback_descriptor = -1
+        try:
+            original_size = os.fstat(descriptor).st_size
+            rollback_descriptor = os.dup(descriptor)
+            try:
+                with os.fdopen(descriptor, "a", encoding=encoding) as file_handle:
+                    descriptor = -1
+                    file_handle.write(data)
+            except BaseException:
+                try:
+                    os.ftruncate(rollback_descriptor, original_size)
+                except OSError:
+                    pass
+                raise
+        finally:
+            if descriptor != -1:
+                os.close(descriptor)
+            if rollback_descriptor != -1:
+                os.close(rollback_descriptor)
+
     @staticmethod
     def open_exclusive(file_name: str) -> int:
         """Create a private binary file without replacing or following a path."""

--- a/tests/report/test_atomic_file_reports.py
+++ b/tests/report/test_atomic_file_reports.py
@@ -86,7 +86,7 @@ class TestAtomicFileReports(TestCase):
 
                     def faulting_fdopen(descriptor, mode="r", *args, **kwargs):
                         file_handle = real_fdopen(descriptor, mode, *args, **kwargs)
-                        if "w" in mode:
+                        if "w" in mode or "a" in mode:
                             return PartialWriteFailure(file_handle)
                         return file_handle
 

--- a/tests/report/test_report_locking.py
+++ b/tests/report/test_report_locking.py
@@ -29,16 +29,13 @@ class MemorySimpleReport(SimpleReport):
         self._blocked = False
         self.contents = ""
 
-    def parse(self, _file):
+    def append(self, _file, data):
         if self._entered is not None and not self._blocked:
             self._blocked = True
             self._entered.set()
             if not self._release.wait(timeout=TEST_TIMEOUT):
                 raise TimeoutError("test did not release blocked report")
-        return self.contents
-
-    def write(self, _file, data):
-        self.contents = data
+        self.contents += data
 
 
 class TestReportLocking(TestCase):

--- a/tests/report/test_streaming_file_reports.py
+++ b/tests/report/test_streaming_file_reports.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from lib.report.csv_report import CSVReport
+from lib.report.markdown_report import MarkdownReport
+from lib.report.plain_text_report import PlainTextReport
+from lib.report.simple_report import SimpleReport
+
+
+APPENDABLE_REPORTS = (
+    (SimpleReport, "txt"),
+    (PlainTextReport, "txt"),
+    (MarkdownReport, "md"),
+    (CSVReport, "csv"),
+)
+
+
+def make_result(url):
+    return SimpleNamespace(
+        datetime="2026-09-11 06:00:00",
+        url=url,
+        status=200,
+        length=42,
+        type="text/plain",
+        redirect="",
+        elapsed=0.25,
+    )
+
+
+class TestStreamingFileReports(TestCase):
+    def test_saves_do_not_reparse_or_replace_appendable_reports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for report_class, extension in APPENDABLE_REPORTS:
+                with self.subTest(report=report_class.__name__):
+                    destination = os.path.join(
+                        directory,
+                        f"report-{report_class.__name__}.{extension}",
+                    )
+                    report = report_class()
+                    report.initiate(destination)
+
+                    with patch.object(
+                        report,
+                        "parse",
+                        side_effect=AssertionError("save reparsed the report"),
+                    ), patch.object(
+                        report,
+                        "write",
+                        side_effect=AssertionError("save replaced the report"),
+                    ):
+                        report.save(
+                            destination,
+                            make_result("https://example.test/first"),
+                        )
+                        report.save(
+                            destination,
+                            make_result("https://example.test/second"),
+                        )
+
+                    report.validate(destination)
+                    with open(destination, encoding="utf-8") as report_file:
+                        contents = report_file.read()
+                    self.assertLess(
+                        contents.index("https://example.test/first"),
+                        contents.index("https://example.test/second"),
+                    )
+
+                    resumed_report = report_class()
+                    resumed_report.initiate(destination)
+                    with patch.object(
+                        resumed_report,
+                        "parse",
+                        side_effect=AssertionError("save reparsed the report"),
+                    ), patch.object(
+                        resumed_report,
+                        "write",
+                        side_effect=AssertionError("save replaced the report"),
+                    ):
+                        resumed_report.save(
+                            destination,
+                            make_result("https://example.test/third"),
+                        )
+
+                    resumed_report.validate(destination)
+                    with open(destination, encoding="utf-8") as report_file:
+                        resumed_contents = report_file.read()
+                    self.assertLess(
+                        resumed_contents.index("https://example.test/second"),
+                        resumed_contents.index("https://example.test/third"),
+                    )

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -169,6 +169,30 @@ class TestFileUtils(TestCase):
 
             self.assertEqual(FileUtils.read_bytes(file_name), b"firstsecond")
 
+    def test_private_text_append_preserves_existing_text(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_name = FileUtils.build_path(directory, "report.txt")
+
+            FileUtils.append_private_text(file_name, "first\n")
+            FileUtils.append_private_text(file_name, "second\n")
+
+            self.assertEqual(
+                FileUtils.read_bytes(file_name),
+                b"first\nsecond\n",
+            )
+
+    @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")
+    def test_private_text_append_creates_private_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            file_name = FileUtils.build_path(directory, "report.txt")
+            previous_umask = os.umask(0o000)
+            try:
+                FileUtils.append_private_text(file_name, "result\n")
+            finally:
+                os.umask(previous_umask)
+
+            self.assertEqual(stat.S_IMODE(os.stat(file_name).st_mode), 0o600)
+
     @skipUnless(hasattr(os, "symlink"), "symbolic links are unavailable")
     def test_open_binary_append_does_not_follow_symbolic_link(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -178,7 +178,7 @@ class TestFileUtils(TestCase):
 
             self.assertEqual(
                 FileUtils.read_bytes(file_name),
-                b"first\nsecond\n",
+                f"first{os.linesep}second{os.linesep}".encode(),
             )
 
     @skipIf(os.name == "nt", "POSIX mode bits are unavailable on Windows")


### PR DESCRIPTION
## Summary

- append one serialized result at a time for simple, plain-text, Markdown, and CSV reports
- avoid reparsing and atomically replacing the full accumulated report for every match
- roll a failed partial append back to the previous byte length so earlier results remain intact
- keep validation when opening an existing report, including resumed output files

## Motivation

The append-compatible file formats previously read and rewrote all earlier results on every save. A report with `n` matches therefore performed quadratic cumulative report I/O. Structured JSON, XML, and HTML snapshots are deliberately left unchanged; optimizing those safely needs a separate journal/snapshot design.

## Tests

- `python -m unittest discover -s tests -t .` (465 passed, 22 skipped)
- focused report and FileUtils suite (21 passed)
- `python -m flake8 lib/report lib/utils/file.py tests/report/test_streaming_file_reports.py tests/report/test_atomic_file_reports.py tests/report/test_report_locking.py tests/utils/test_file.py`

The regression harness rejects any per-result `parse()` or full-file `write()` call for the four append-compatible formats. Existing injected partial-write tests continue to verify that an unsuccessful save preserves all earlier report bytes.
