### PR TITLE
Reset pause state after target transitions

### DIFF
--- a/lib/controller/controller.py
+++ b/lib/controller/controller.py
@@ -929,6 +929,10 @@ class Controller:
                 pass
         os._exit(1)
 
+    def _reset_pause_state(self) -> None:
+        self._handling_pause = False
+        self._force_quit_handler.on_resume()
+
     def handle_pause(self) -> None:
         """Handle SIGINT (Ctrl+C) by pausing execution and showing options."""
         if self._handling_pause:
@@ -997,16 +1001,17 @@ class Controller:
                             raise quitexc
 
                 elif option.lower() == "c":
-                    self._handling_pause = False
-                    self._force_quit_handler.on_resume()
+                    self._reset_pause_state()
                     self.fuzzer.play()
                     break
 
                 elif option.lower() == "n" and len(self.directories) > 1:
+                    self._reset_pause_state()
                     self.fuzzer.quit()
                     break
 
                 elif option.lower() == "s" and len(options["urls"]) > 1:
+                    self._reset_pause_state()
                     skipexc = SkipTargetInterrupt("Target skipped by the user")
                     if options["async_mode"]:
                         self.pause_future.set_exception(skipexc)

--- a/tests/controller/test_pause_state.py
+++ b/tests/controller/test_pause_state.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from lib.controller.controller import Controller
+from lib.core.data import options
+from lib.core.exceptions import SkipTargetInterrupt
+
+
+class RecordingForceQuitHandler:
+    def __init__(self):
+        self.pause_starts = 0
+        self.resumes = 0
+        self.force_quit_checks = 0
+
+    def check_force_quit(self):
+        self.force_quit_checks += 1
+        return False
+
+    def on_pause_start(self):
+        self.pause_starts += 1
+
+    def on_resume(self):
+        self.resumes += 1
+
+
+class RecordingPauseFuture:
+    def __init__(self):
+        self.error = None
+
+    def set_exception(self, error):
+        self.error = error
+
+
+class TestPauseState(TestCase):
+    def setUp(self):
+        self.original_options = dict(options)
+        self.reset_controller()
+
+    def reset_controller(self):
+        self.controller = object.__new__(Controller)
+        self.controller._handling_pause = False
+        self.controller._force_quit_handler = RecordingForceQuitHandler()
+        self.controller.fuzzer = Mock()
+        self.controller.fuzzer.pause.return_value = True
+        self.controller.directories = ["first/", "second/"]
+
+    def tearDown(self):
+        options.clear()
+        options.update(self.original_options)
+
+    def exercise_second_pause(self, first_option, second_option="c"):
+        with patch("builtins.input", side_effect=(first_option, second_option)), patch(
+            "lib.controller.controller.interface"
+        ):
+            self.controller.handle_pause()
+            self.controller.handle_pause()
+
+    def assert_pause_state_was_rearmed(self):
+        self.assertFalse(self.controller._handling_pause)
+        self.assertEqual(self.controller._force_quit_handler.force_quit_checks, 0)
+        self.assertEqual(self.controller._force_quit_handler.pause_starts, 2)
+        self.assertEqual(self.controller._force_quit_handler.resumes, 2)
+        self.assertEqual(self.controller.fuzzer.pause.call_count, 2)
+        self.controller.fuzzer.play.assert_called_once_with()
+
+    def test_next_directory_rearms_pause_for_every_engine(self):
+        engine_options = (
+            {"request_backend": "python", "async_mode": False},
+            {"request_backend": "python", "async_mode": True},
+            {"request_backend": "native", "async_mode": False},
+        )
+
+        for run_options in engine_options:
+            with self.subTest(options=run_options), patch.dict(
+                options,
+                {**run_options, "urls": ["https://example.test"]},
+            ):
+                self.reset_controller()
+                self.exercise_second_pause("n")
+                self.assert_pause_state_was_rearmed()
+                self.controller.fuzzer.quit.assert_called_once_with()
+
+    def test_skip_target_rearms_pause_for_threaded_and_native_engines(self):
+        for request_backend in ("python", "native"):
+            with self.subTest(request_backend=request_backend), patch.dict(
+                options,
+                {
+                    "request_backend": request_backend,
+                    "async_mode": False,
+                    "urls": ["https://first.test", "https://second.test"],
+                },
+            ), patch(
+                "builtins.input",
+                side_effect=("s", "c"),
+            ), patch(
+                "lib.controller.controller.interface"
+            ):
+                self.reset_controller()
+                with self.assertRaises(SkipTargetInterrupt):
+                    self.controller.handle_pause()
+                self.controller.handle_pause()
+
+                self.assert_pause_state_was_rearmed()
+                self.controller.fuzzer.quit.assert_not_called()
+
+    def test_skip_target_rearms_pause_for_async_engine(self):
+        self.reset_controller()
+        self.controller.pause_future = RecordingPauseFuture()
+        with patch.dict(
+            options,
+            {
+                "request_backend": "python",
+                "async_mode": True,
+                "urls": ["https://first.test", "https://second.test"],
+            },
+        ):
+            self.exercise_second_pause("s")
+
+        self.assertIsInstance(
+            self.controller.pause_future.error,
+            SkipTargetInterrupt,
+        )
+        self.assert_pause_state_was_rearmed()
+        self.controller.fuzzer.quit.assert_not_called()


### PR DESCRIPTION
## Summary

- reset the controller's pause guard when selecting the next directory or skipping the current target
- reset the platform-specific force-quit handler on those transitions, as already done for continue
- verify a later Ctrl+C enters the normal pause flow instead of the force-exit path

## Motivation

`handle_pause()` previously cleared `_handling_pause` only for the continue choice. Choosing next or skip left the guard set, so the next Ctrl+C was treated as a repeated interrupt and could force the process to exit instead of displaying the pause menu.

## Tests

- `python -m unittest tests.controller.test_pause_state -v` (3 passed; threaded, async, and native transitions covered)
- `python -m unittest discover -s tests/controller -t . -v` (64 passed, 1 skipped)
- `python -m unittest discover -s tests -t .` (468 passed, 22 skipped)
- `python -m flake8 lib/controller/controller.py tests/controller/test_pause_state.py`
