### PR TITLE
Encode configured proxy credentials

### DIFF
--- a/lib/connection/native.py
+++ b/lib/connection/native.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from lib.connection.proxy import (
     PROXY_AUTHENTICATION_REQUIRED,
+    add_proxy_authentication,
     format_proxy_error,
     is_proxy_connect_rejection,
     proxy_error_status,
@@ -133,10 +134,7 @@ class NativeHTTPBackend:
                     "--request-backend native supports HTTP and HTTPS proxies only"
                 )
 
-            if options["proxy_auth"] and "@" not in proxy:
-                proxy = proxy.replace(
-                    "://", f'://{options["proxy_auth"]}@', 1
-                )
+            proxy = add_proxy_authentication(proxy, options["proxy_auth"])
             proxies.append(proxy)
 
         return proxies

--- a/lib/connection/proxy.py
+++ b/lib/connection/proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from urllib.parse import quote, urlsplit
 
 
 PROXY_AUTHENTICATION_REQUIRED = 407
@@ -13,6 +14,19 @@ _HTTP_STATUS_PATTERNS = (
     ),
     re.compile(r"^\s*([1-5][0-9]{2})(?:\s|$)"),
 )
+
+
+def add_proxy_authentication(proxy: str, credential: str | None) -> str:
+    """Add percent-encoded configured credentials unless the proxy has userinfo."""
+    if not credential or "@" in urlsplit(proxy).netloc:
+        return proxy
+
+    username, separator, password = credential.partition(":")
+    userinfo = quote(username, safe="")
+    if separator:
+        userinfo += ":" + quote(password, safe="")
+
+    return proxy.replace("://", f"://{userinfo}@", 1)
 
 
 def proxy_error_status(error: BaseException | str) -> int | None:

--- a/lib/connection/requester.py
+++ b/lib/connection/requester.py
@@ -49,6 +49,7 @@ except ImportError:
 from lib.connection.dns import DNSResolver
 from lib.connection.proxy import (
     PROXY_AUTHENTICATION_REQUIRED,
+    add_proxy_authentication,
     format_proxy_error,
     proxy_error_status,
 )
@@ -522,9 +523,10 @@ class Requester(BaseRequester):
                     if not proxy_url.startswith(PROXY_SCHEMES):
                         proxy_url = f"http://{proxy_url}"
 
-                    if self.proxy_cred and "@" not in proxy_url:
-                        # socks5://localhost:9050 => socks5://[credential]@localhost:9050
-                        proxy_url = proxy_url.replace("://", f"://{self.proxy_cred}@", 1)
+                    proxy_url = add_proxy_authentication(
+                        proxy_url,
+                        self.proxy_cred,
+                    )
 
                     proxies["http"] = proxy_url
                     proxies["https"] = proxy_url
@@ -763,9 +765,7 @@ class AsyncRequester(BaseRequester):
         if not proxy.startswith(PROXY_SCHEMES):
             proxy = f"http://{proxy}"
 
-        if self.proxy_cred and "@" not in proxy:
-            # socks5://localhost:9050 => socks5://[credential]@localhost:9050
-            proxy = proxy.replace("://", f"://{self.proxy_cred}@", 1)
+        proxy = add_proxy_authentication(proxy, self.proxy_cred)
 
         if proxy.startswith("https://"):
             proxy_ssl_context = ssl.create_default_context()

--- a/tests/connection/test_native_backend.py
+++ b/tests/connection/test_native_backend.py
@@ -128,6 +128,17 @@ class TestNativeHTTPBackend(TestCase):
         self.assertEqual(kwargs["filter_header_regex"], "x-cache: fallback-[0-9]+")
         self.assertEqual(kwargs["match_time"], [(">", 100.0)])
 
+    def test_proxy_urls_encode_reserved_credentials(self):
+        options["proxy_auth"] = "proxy/user:p@ss/word?#%:tail"
+
+        self.assertEqual(
+            NativeHTTPBackend._proxy_urls(),
+            [
+                "http://proxy%2Fuser:p%40ss%2Fword%3F%23%25%3Atail"
+                "@127.0.0.1:8080"
+            ],
+        )
+
     def test_reuses_engine_across_chunks_and_forwards_cancellation(self):
         fake_native = FakeNativeModule()
 

--- a/tests/connection/test_proxy.py
+++ b/tests/connection/test_proxy.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from lib.connection import proxy as proxy_utils
 from lib.connection.proxy import (
     format_proxy_error,
     is_proxy_connect_rejection,
@@ -8,6 +9,54 @@ from lib.connection.proxy import (
 
 
 class TestProxyErrors(TestCase):
+    def test_proxy_authentication_encodes_userinfo_components(self):
+        cases = (
+            (
+                "http://proxy.example:8080",
+                "proxy/user:p@ss/word?#%:tail",
+                "http://proxy%2Fuser:p%40ss%2Fword%3F%23%25%3Atail"
+                "@proxy.example:8080",
+            ),
+            (
+                "socks5://proxy.example:1080",
+                "user name:password value",
+                "socks5://user%20name:password%20value@proxy.example:1080",
+            ),
+            (
+                "http://proxy.example:8080",
+                "user%name",
+                "http://user%25name@proxy.example:8080",
+            ),
+        )
+
+        for proxy, credential, expected in cases:
+            with self.subTest(credential=credential):
+                self.assertEqual(
+                    proxy_utils.add_proxy_authentication(proxy, credential),
+                    expected,
+                )
+
+    def test_explicit_proxy_userinfo_takes_precedence(self):
+        proxy = "http://inline-user:inline-password@proxy.example:8080"
+
+        self.assertEqual(
+            proxy_utils.add_proxy_authentication(proxy, "configured:credential"),
+            proxy,
+        )
+
+    def test_at_sign_outside_proxy_authority_does_not_suppress_authentication(self):
+        cases = (
+            "http://proxy.example:8080/path@marker",
+            "http://proxy.example:8080?tag=@marker",
+        )
+
+        for proxy in cases:
+            with self.subTest(proxy=proxy):
+                self.assertEqual(
+                    proxy_utils.add_proxy_authentication(proxy, "user:password"),
+                    proxy.replace("://", "://user:password@", 1),
+                )
+
     def test_extracts_status_from_connect_failure(self):
         error = RuntimeError("Tunnel connection failed: 429 Too Many Requests")
 

--- a/tests/connection/test_proxy_integration.py
+++ b/tests/connection/test_proxy_integration.py
@@ -21,6 +21,8 @@ except ImportError:
 
 
 PROXY_CREDENTIAL = "proxy-user:proxy-password"
+RESERVED_PROXY_CREDENTIAL = "proxy/user:p@ss/word?#%:tail"
+PROXY_CREDENTIALS = (PROXY_CREDENTIAL, RESERVED_PROXY_CREDENTIAL)
 INVALID_PROXY_CREDENTIAL = "wrong:credentials"
 PROXY_AUTHORIZATION = "Basic " + base64.b64encode(
     PROXY_CREDENTIAL.encode()
@@ -173,39 +175,63 @@ class TestProxyIntegration(TestCase):
                 self._assert_case(proxy, target, path, response)
 
     def test_sync_engine_authenticates_http_and_https_proxies(self):
-        for proxy, target in self._cases():
-            with self.subTest(proxy=proxy.scheme, target=target.scheme):
-                path = f"sync-auth-{proxy.scheme}-{target.scheme}"
-                self._prepare_authenticated_case(proxy, target)
-                options["proxy_auth"] = PROXY_CREDENTIAL
-                try:
-                    response, error, _ = self._sync_request(proxy, target, path)
-                finally:
-                    proxy.configure_proxy()
+        for credential in PROXY_CREDENTIALS:
+            for proxy, target in self._cases():
+                with self.subTest(
+                    credential=credential,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    path = f"sync-auth-{proxy.scheme}-{target.scheme}"
+                    authorization = self._prepare_authenticated_case(
+                        proxy,
+                        target,
+                        credential,
+                    )
+                    options["proxy_auth"] = credential
+                    try:
+                        response, error, _ = self._sync_request(proxy, target, path)
+                    finally:
+                        proxy.configure_proxy()
 
-                self.assertIsNone(error)
-                self._assert_case(proxy, target, path, response)
-                self.assertEqual(proxy.proxy_authorizations, [PROXY_AUTHORIZATION])
+                    self.assertIsNone(error)
+                    self._assert_case(proxy, target, path, response)
+                    self.assertEqual(
+                        proxy.proxy_authorizations,
+                        [authorization],
+                    )
 
     def test_async_engine_authenticates_http_and_https_proxies(self):
         asyncio.run(self._test_async_engine_authentication())
 
     async def _test_async_engine_authentication(self):
-        for proxy, target in self._cases():
-            with self.subTest(proxy=proxy.scheme, target=target.scheme):
-                path = f"async-auth-{proxy.scheme}-{target.scheme}"
-                self._prepare_authenticated_case(proxy, target)
-                options["proxy_auth"] = PROXY_CREDENTIAL
-                try:
-                    response, error, _ = await self._async_request(
-                        proxy, target, path
+        for credential in PROXY_CREDENTIALS:
+            for proxy, target in self._cases():
+                with self.subTest(
+                    credential=credential,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    path = f"async-auth-{proxy.scheme}-{target.scheme}"
+                    authorization = self._prepare_authenticated_case(
+                        proxy,
+                        target,
+                        credential,
                     )
-                finally:
-                    proxy.configure_proxy()
+                    options["proxy_auth"] = credential
+                    try:
+                        response, error, _ = await self._async_request(
+                            proxy, target, path
+                        )
+                    finally:
+                        proxy.configure_proxy()
 
-                self.assertIsNone(error)
-                self._assert_case(proxy, target, path, response)
-                self.assertEqual(proxy.proxy_authorizations, [PROXY_AUTHORIZATION])
+                    self.assertIsNone(error)
+                    self._assert_case(proxy, target, path, response)
+                    self.assertEqual(
+                        proxy.proxy_authorizations,
+                        [authorization],
+                    )
 
     @skipUnless(
         dirsearch_native is not None
@@ -213,19 +239,35 @@ class TestProxyIntegration(TestCase):
         "native extension is not installed",
     )
     def test_native_engine_authenticates_http_and_https_proxies(self):
-        for proxy, target in self._cases():
-            with self.subTest(proxy=proxy.scheme, target=target.scheme):
-                path = f"native-auth-{proxy.scheme}-{target.scheme}"
-                self._prepare_authenticated_case(proxy, target)
-                options["proxy_auth"] = PROXY_CREDENTIAL
-                try:
-                    response, error, _ = self._native_request(proxy, target, path)
-                finally:
-                    proxy.configure_proxy()
+        for credential in PROXY_CREDENTIALS:
+            for proxy, target in self._cases():
+                with self.subTest(
+                    credential=credential,
+                    proxy=proxy.scheme,
+                    target=target.scheme,
+                ):
+                    path = f"native-auth-{proxy.scheme}-{target.scheme}"
+                    authorization = self._prepare_authenticated_case(
+                        proxy,
+                        target,
+                        credential,
+                    )
+                    options["proxy_auth"] = credential
+                    try:
+                        response, error, _ = self._native_request(
+                            proxy,
+                            target,
+                            path,
+                        )
+                    finally:
+                        proxy.configure_proxy()
 
-                self.assertIsNone(error)
-                self._assert_case(proxy, target, path, response)
-                self.assertEqual(proxy.proxy_authorizations, [PROXY_AUTHORIZATION])
+                    self.assertIsNone(error)
+                    self._assert_case(proxy, target, path, response)
+                    self.assertEqual(
+                        proxy.proxy_authorizations,
+                        [authorization],
+                    )
 
     def test_sync_engine_rejects_missing_and_invalid_proxy_credentials(self):
         for credential in (None, INVALID_PROXY_CREDENTIAL):
@@ -382,10 +424,17 @@ class TestProxyIntegration(TestCase):
         target.clear_events()
         options["proxy_auth"] = None
 
-    def _prepare_authenticated_case(self, proxy, target):
+    def _prepare_authenticated_case(
+        self,
+        proxy,
+        target,
+        credential=PROXY_CREDENTIAL,
+    ):
         self._prepare_case(proxy, target)
         options["max_retries"] = 1
-        proxy.configure_proxy(required_authorization=PROXY_AUTHORIZATION)
+        authorization = "Basic " + base64.b64encode(credential.encode()).decode()
+        proxy.configure_proxy(required_authorization=authorization)
+        return authorization
 
     def _prepare_failure_case(self, proxy, target, behavior):
         self._prepare_case(proxy, target)


### PR DESCRIPTION
## Summary

- percent-encode configured proxy usernames and passwords before embedding them in proxy URLs
- use one helper for threaded, async (including replay), and native request backends
- preserve explicit inline proxy userinfo while treating `@` in paths or queries as data
- exercise reserved characters through real local HTTP and HTTPS proxy fixtures across all three engines

## User-visible effect

Credentials such as `proxy/user:p@ss/word?#%:tail` now authenticate correctly instead of being parsed as proxy URL structure, which could select the wrong host or send empty credentials.

## Validation

- `python -m unittest discover -s tests -t .` (472 passed, 22 skipped)
- focused proxy/native/logger suite (30 passed, 4 skipped)
- native-extension proxy integration (1 passed)
- `python -m flake8` on changed source and tests
- `git diff --check`