### PR TITLE
Resolve HTML crawler URLs against document base

### DIFF
--- a/lib/core/settings.py
+++ b/lib/core/settings.py
@@ -123,7 +123,7 @@ DB_ENGINES = ("mysql", "postgres", "postgresql", "sqlite", "mariadb", "mongodb",
 
 CRAWL_ATTRIBUTES = ("action", "cite", "data", "formaction", "href", "longdesc", "poster", "src", "srcset", "xmlns")
 
-CRAWL_TAGS = ("a", "area", "base", "blockquote", "button", "embed", "form", "frame", "frameset", "html", "iframe", "input", "ins", "noframes", "object", "q", "script", "source")
+CRAWL_TAGS = ("a", "area", "base", "blockquote", "button", "embed", "form", "frame", "frameset", "html", "iframe", "img", "input", "ins", "noframes", "object", "q", "script", "source")
 
 AUTHENTICATION_TYPES = ("basic", "digest", "bearer", "ntlm", "jwt")
 

--- a/lib/utils/crawl.py
+++ b/lib/utils/crawl.py
@@ -18,16 +18,15 @@
 
 import re
 import string
+from urllib.parse import urljoin, urlsplit
 
 from bs4 import BeautifulSoup
 
 from lib.core.settings import (
     CRAWL_ATTRIBUTES, CRAWL_TAGS,
     MEDIA_EXTENSIONS, ROBOTS_TXT_REGEX,
-    URI_REGEX,
 )
-from lib.parse.url import clean_path, parse_path
-from lib.utils.common import merge_path
+from lib.parse.url import clean_path, same_origin_path
 
 
 _ESCAPED_SLASH_REGEX = re.compile(r"\\(?:/|u002f|x2f)", re.IGNORECASE)
@@ -37,6 +36,7 @@ _TEXT_URL_CHARS = frozenset(
     string.ascii_letters + string.digits + "-._~%!$&'()*+,;=:@/?#[]"
 )
 _TEXT_URL_QUOTES = frozenset("\"'`")
+_ASCII_WHITESPACE = frozenset("\t\n\f\r ")
 
 
 def _filter(paths):
@@ -89,6 +89,97 @@ def _extract_scoped_paths(scope, content):
             yield path
 
 
+def _srcset_urls(value):
+    """Yield URL tokens from an HTML srcset value."""
+    position = 0
+    length = len(value)
+
+    while position < length:
+        while (
+            position < length
+            and (value[position] in _ASCII_WHITESPACE or value[position] == ",")
+        ):
+            position += 1
+
+        if position >= length:
+            return
+
+        start = position
+        while position < length and value[position] not in _ASCII_WHITESPACE:
+            position += 1
+
+        url = value[start:position]
+        if url.endswith(","):
+            url = url.rstrip(",")
+            if url:
+                yield url
+            continue
+
+        if url:
+            yield url
+
+        parentheses = 0
+        while position < length:
+            character = value[position]
+            position += 1
+
+            if character == "(":
+                parentheses += 1
+            elif character == ")" and parentheses:
+                parentheses -= 1
+            elif character == "," and not parentheses:
+                break
+
+
+def _browser_url_value(value):
+    """Normalize reverse solidus in an HTTP URL path like a browser."""
+    query = value.find("?")
+    fragment = value.find("#")
+    suffixes = [position for position in (query, fragment) if position >= 0]
+    path_end = min(suffixes) if suffixes else len(value)
+
+    return value[:path_end].replace("\\", "/") + value[path_end:]
+
+
+def _document_base_url(url, soup):
+    base = soup.find("base", href=True)
+    if base is None:
+        return url
+
+    href = base.get("href")
+    if not isinstance(href, str):
+        return url
+
+    try:
+        resolved = urljoin(url, _browser_url_value(href.strip()))
+        parsed = urlsplit(resolved)
+        parsed.port
+    except ValueError:
+        return url
+
+    if not parsed.scheme or parsed.scheme.lower() in ("data", "javascript"):
+        return url
+
+    return resolved
+
+
+def _same_origin_crawl_path(scope, base_url, value):
+    if not isinstance(value, str):
+        return None
+
+    try:
+        resolved = urljoin(base_url, _browser_url_value(value.strip()))
+        parsed = urlsplit(resolved)
+        parsed.port
+    except ValueError:
+        return None
+
+    if not parsed.scheme or parsed.hostname is None:
+        return None
+
+    return same_origin_path(scope, resolved)
+
+
 class Crawler:
     @classmethod
     def crawl(cls, response):
@@ -109,22 +200,28 @@ class Crawler:
     def html_crawl(url, scope, content):
         results = []
         soup = BeautifulSoup(content, 'html.parser')
+        base_url = _document_base_url(url, soup)
 
         for tag in CRAWL_TAGS:
             for found in soup.find_all(tag):
+                if found.name == "base":
+                    continue
+
                 for attr in CRAWL_ATTRIBUTES:
                     value = found.get(attr)
 
-                    if not value:
+                    if not isinstance(value, str) or not value:
                         continue
 
-                    if value.startswith("/"):
-                        results.append(value[1:])
-                    elif value.startswith(scope):
-                        results.append(value[len(scope):])
-                    elif not re.search(URI_REGEX, value):
-                        new_url = merge_path(url, value)
-                        results.append(parse_path(new_url))
+                    values = _srcset_urls(value) if attr == "srcset" else (value,)
+                    for candidate in values:
+                        path = _same_origin_crawl_path(
+                            scope,
+                            base_url,
+                            candidate,
+                        )
+                        if path is not None:
+                            results.append(path)
 
         return _filter(results)
 

--- a/tests/controller/test_root_crawl.py
+++ b/tests/controller/test_root_crawl.py
@@ -40,6 +40,20 @@ def root_response():
     )
 
 
+def resolved_html_response():
+    return NativeResponse(
+        "https://example.test/base/page",
+        200,
+        [("Content-Type", "text/html")],
+        (
+            b'<base href="/base/assets/">'
+            b'<a href="api">API</a>'
+            b'<a href="//other.test/external">external</a>'
+            b'<img srcset="/base/render?size=1 1x, /base/render?size=2 2x">'
+        ),
+    )
+
+
 def create_controller(requester):
     controller = object.__new__(Controller)
     controller.requester = requester
@@ -110,6 +124,16 @@ class TestRootCrawl(TestCase):
 
         requester.request.assert_awaited_once_with("base/")
         self.assertEqual(controller.dictionary.extra, ["root-only"])
+
+    def test_crawled_html_paths_are_resolved_before_queueing(self):
+        controller = create_controller(Mock())
+
+        controller.add_crawled_paths(resolved_html_response())
+
+        self.assertEqual(
+            set(controller.dictionary.extra),
+            {"assets/api", "render?size=1", "render?size=2"},
+        )
 
     def test_disabled_crawl_does_not_request_target_root(self):
         requester = Mock()

--- a/tests/utils/test_crawl.py
+++ b/tests/utils/test_crawl.py
@@ -149,6 +149,107 @@ class TestCrawl(TestCase):
         html_doc = f'<a href="{DUMMY_URL}foo">link</a><script src="/bar.js"><img src="/bar.png">'
         self.assertEqual(Crawler.html_crawl(DUMMY_URL, DUMMY_URL, html_doc), {"foo", "bar.js"})
 
+    def test_html_crawl_resolves_only_canonical_same_origin_urls(self):
+        url = "https://example.com/section/page"
+        html_doc = r"""
+            <a href="//EXAMPLE.COM:443/protocol-relative">same origin</a>
+            <a href="https://EXAMPLE.COM:443/absolute">same origin</a>
+            <a href="\\EXAMPLE.COM:443\backslash-relative">same origin</a>
+            <a href="/query?pattern=\d+">query backslash is data</a>
+            <a href="//cdn.example/external">external host</a>
+            <a href="\\cdn.example\external-backslash">external host</a>
+            <a href="http://example.com/wrong-scheme">wrong scheme</a>
+            <a href="https://example.com:444/wrong-port">wrong port</a>
+            <a href="https://example.com:invalid/bad-port">invalid port</a>
+            <a href="https://[invalid/bad-host">invalid host</a>
+            <a href="https://example.com.evil.test/lookalike">lookalike</a>
+        """
+
+        self.assertEqual(
+            Crawler.html_crawl(url, DUMMY_URL, html_doc),
+            {
+                "absolute",
+                "backslash-relative",
+                "protocol-relative",
+                r"query?pattern=\d+",
+            },
+        )
+
+    def test_html_crawl_uses_first_base_without_queueing_it(self):
+        url = "https://example.com/section/page"
+        html_doc = """
+            <base href="/assets/">
+            <base href="/ignored/">
+            <a href="api/users?next=/dashboard#details">API</a>
+            <script src="scripts/app.js"></script>
+        """
+
+        self.assertEqual(
+            Crawler.html_crawl(url, DUMMY_URL, html_doc),
+            {
+                "assets/api/users?next=/dashboard",
+                "assets/scripts/app.js",
+            },
+        )
+
+    def test_html_crawl_does_not_localize_paths_under_external_base(self):
+        url = "https://example.com/section/page"
+        html_doc = """
+            <base href="https://cdn.example/assets/">
+            <a href="relative-api">external through base</a>
+            <a href="https://example.com/local-api">explicitly local</a>
+        """
+
+        self.assertEqual(
+            Crawler.html_crawl(url, DUMMY_URL, html_doc),
+            {"local-api"},
+        )
+
+    def test_html_crawl_ignores_invalid_or_unsafe_first_base(self):
+        url = "https://example.com/section/page"
+
+        for base in (
+            "data:text/html,ignored",
+            "javascript:alert(1)",
+            "http://[invalid",
+        ):
+            with self.subTest(base=base):
+                html_doc = (
+                    f'<base href="{base}">'
+                    '<base href="/second-base-is-ignored/">'
+                    '<a href="relative-api">API</a>'
+                )
+
+                self.assertEqual(
+                    Crawler.html_crawl(url, DUMMY_URL, html_doc),
+                    {"section/relative-api"},
+                )
+
+    def test_html_crawl_parses_source_and_img_srcset_candidates(self):
+        url = "https://example.com/page"
+        html_doc = """
+            <source srcset="/render/small?format=jpg 1x,
+                            /render/large?format=jpg 2x,
+                            /render/no-descriptor,
+                            /render/final-no-descriptor">
+            <img src="/image-endpoint"
+                 srcset="/image?crop=1,2 640w,
+                         //cdn.example/external 2x,
+                         data:image/svg+xml,&lt;svg&gt;&lt;/svg&gt; 3x">
+        """
+
+        self.assertEqual(
+            Crawler.html_crawl(url, DUMMY_URL, html_doc),
+            {
+                "image-endpoint",
+                "image?crop=1,2",
+                "render/large?format=jpg",
+                "render/final-no-descriptor",
+                "render/no-descriptor",
+                "render/small?format=jpg",
+            },
+        )
+
     def test_html_crawl_handles_rtl_override(self):
         html_doc = '<a href="/admin/\u202eexe.txt/">link</a>'
 


### PR DESCRIPTION
## Summary

- resolve HTML URL attributes against the document's first effective `<base href>`
- enforce canonical same-origin checks for absolute, protocol-relative, default-port, and reverse-solidus URL forms
- parse individual `srcset` candidates and include `img` sources
- keep external and unsafe URL schemes out of the dynamic scan queue

## User-visible effect

HTML crawling no longer turns external protocol-relative links into local scan paths, misses equivalent same-origin links because of host casing/default ports, ignores document base semantics, or queues a complete `srcset` as one malformed path.

## Validation

- `python -m unittest discover -s tests -t .` (478 passed, 22 skipped)
- focused crawler/controller suite on Python 3.14 (23 passed)
- focused crawler/controller suite on Python 3.12 (23 passed)
- `python -m flake8` on changed source and tests
- `git diff --check`