### PR TITLE
Fix HTML report length filters

### DIFF
--- a/lib/report/templates/html_report_template.html
+++ b/lib/report/templates/html_report_template.html
@@ -53,7 +53,7 @@ function search(app, result){
     return app.searchQuery.toLowerCase().split(" ").every(
       (v) => result.url.toLowerCase().includes(v) ||
       (result.contentType && result.contentType.toLowerCase().includes(v)) ||
-      result.contentLength.toLowerCase().includes(v) ||
+      String(result.contentLength).includes(v) ||
       result.status.toString().includes(v) ||
       (result.redirect && result.redirect.toLowerCase().includes(v))
     );
@@ -65,7 +65,7 @@ function statusExcludeSearch(app, result){
 }
 function lengthExcludeSearch(app, result){
     return app.lengthExcludeSearchQuery.toLowerCase().split(" ").every(
-      (v) => !result.contentLength.toLowerCase() != v
+      (v) => String(result.contentLength) !== v
     );
 }
 function sort(app, results){

--- a/tests/report/test_html_report_template.py
+++ b/tests/report/test_html_report_template.py
@@ -1,0 +1,118 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from unittest import TestCase, skipUnless
+
+
+TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "lib"
+    / "report"
+    / "templates"
+    / "html_report_template.html"
+)
+
+
+def extract_function(source, name):
+    start = source.index(f"function {name}(")
+    opening_brace = source.index("{", start)
+    depth = 0
+
+    for position in range(opening_brace, len(source)):
+        if source[position] == "{":
+            depth += 1
+        elif source[position] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:position + 1]
+
+    raise AssertionError(f"Unterminated JavaScript function: {name}")
+
+
+@skipUnless(shutil.which("node"), "Node.js is required for JavaScript tests")
+class TestHTMLReportFilters(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = TEMPLATE_PATH.read_text(encoding="utf-8")
+        cls.functions = "\n".join(
+            extract_function(source, name)
+            for name in ("search", "lengthExcludeSearch")
+        )
+
+    def evaluate(self, expression):
+        script = f"""
+{self.functions}
+const value = (() => {{
+{expression}
+}})();
+process.stdout.write(JSON.stringify(value));
+"""
+        completed = subprocess.run(
+            ["node", "-"],
+            input=script,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return json.loads(completed.stdout)
+
+    def test_search_matches_numeric_content_lengths_and_other_fields(self):
+        result = self.evaluate(
+            """
+const result = {
+  url: "https://example.test/admin",
+  status: 200,
+  contentLength: 42,
+  contentType: "text/plain",
+  redirect: "/login"
+};
+return [
+  search({searchQuery: "42"}, result),
+  search({searchQuery: "4"}, result),
+  search({searchQuery: "admin 42"}, result),
+  search({searchQuery: "200"}, result),
+  search({searchQuery: "text/plain"}, result),
+  search({searchQuery: "login"}, result),
+  search({searchQuery: "0"}, {...result, contentLength: 0}),
+  search({searchQuery: "42"}, {...result, contentLength: "42"}),
+  search({searchQuery: "43"}, result),
+  search({searchQuery: "42 missing"}, result)
+];
+"""
+        )
+
+        self.assertEqual(
+            result,
+            [True, True, True, True, True, True, True, True, False, False],
+        )
+
+    def test_length_exclusion_uses_exact_numeric_matches(self):
+        result = self.evaluate(
+            """
+const result = {
+  url: "https://example.test/admin",
+  status: 200,
+  contentLength: 42,
+  contentType: "text/plain",
+  redirect: ""
+};
+return [
+  lengthExcludeSearch({lengthExcludeSearchQuery: "42"}, result),
+  lengthExcludeSearch({lengthExcludeSearchQuery: "42 100"}, result),
+  lengthExcludeSearch({lengthExcludeSearchQuery: "4"}, result),
+  lengthExcludeSearch({lengthExcludeSearchQuery: "100 101"}, result),
+  lengthExcludeSearch(
+    {lengthExcludeSearchQuery: "0"},
+    {...result, contentLength: 0}
+  ),
+  lengthExcludeSearch(
+    {lengthExcludeSearchQuery: "42"},
+    {...result, contentLength: "42"}
+  )
+];
+"""
+        )
+
+        self.assertEqual(result, [False, False, True, True, False, False])


### PR DESCRIPTION
## Summary
- convert numeric content lengths to text before applying the HTML report's global substring search
- make the content-length exclusion filter compare each space-separated value exactly
- execute the template's real JavaScript functions in regression tests, covering numeric and string lengths, zero, multiple tokens, partial matches, negative matches, and the other searchable fields

## User-visible effect
Searching an HTML report by response size no longer throws a JavaScript error. Excluding one or more exact response sizes now actually removes those rows.

## Tests
- `python -m unittest discover -s tests -t .` (480 passed, 22 skipped; Python 3.12)
- `python -m unittest tests.report.test_html_report_template tests.report.test_report_manager -v` (5 passed; Python 3.14)
- `python -m flake8 tests/report/test_html_report_template.py`
- `git diff --check`
