### PR TITLE
Enable configured log rotation

### DIFF
--- a/lib/core/logger.py
+++ b/lib/core/logger.py
@@ -44,6 +44,8 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.disabled = True
 
+LOG_HANDLER_NAME = "dirsearch-log-file"
+
 
 def redact_log_text(text: str) -> str:
     """Remove credentials and query values from rendered log output."""
@@ -78,9 +80,20 @@ class RedactingFormatter(logging.Formatter):
 
 
 def enable_logging() -> None:
-    logger.disabled = False
     formatter = RedactingFormatter('%(asctime)s [%(levelname)s] %(message)s')
-    handler = RotatingFileHandler(options["log_file"], maxBytes=options["log_file_size"])
+    handler = RotatingFileHandler(
+        options["log_file"],
+        maxBytes=options["log_file_size"],
+        backupCount=1,
+    )
+    handler.set_name(LOG_HANDLER_NAME)
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(formatter)
+
+    for existing_handler in tuple(logger.handlers):
+        if existing_handler.get_name() == LOG_HANDLER_NAME:
+            logger.removeHandler(existing_handler)
+            existing_handler.close()
+
     logger.addHandler(handler)
+    logger.disabled = False

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -6,7 +6,7 @@ from lib.core.data import options
 from lib.core.logger import enable_logging, logger, redact_log_text
 
 
-class TestLogRedaction(TestCase):
+class TestLogger(TestCase):
     def setUp(self):
         self.original_options = dict(options)
         self.original_handlers = tuple(logger.handlers)
@@ -15,14 +15,17 @@ class TestLogRedaction(TestCase):
             logger.removeHandler(handler)
 
     def tearDown(self):
-        for handler in tuple(logger.handlers):
-            handler.close()
-            logger.removeHandler(handler)
+        self.close_handlers()
         for handler in self.original_handlers:
             logger.addHandler(handler)
         logger.disabled = self.original_disabled
         options.clear()
         options.update(self.original_options)
+
+    def close_handlers(self):
+        for handler in tuple(logger.handlers):
+            handler.close()
+            logger.removeHandler(handler)
 
     def test_redacts_url_secrets_without_hiding_request_metadata(self):
         options["proxy_auth"] = "proxy-user:scheme-less-password"
@@ -67,10 +70,7 @@ class TestLogRedaction(TestCase):
                 logger.exception(error)
             logger.info('THREAD-7 started')
 
-            for handler in tuple(logger.handlers):
-                handler.flush()
-                handler.close()
-                logger.removeHandler(handler)
+            self.close_handlers()
             with open(log_path, encoding="utf-8") as log_file:
                 contents = log_file.read()
 
@@ -92,3 +92,45 @@ class TestLogRedaction(TestCase):
         self.assertIn("Traceback (most recent call last)", contents)
         self.assertIn("ValueError: Invalid proxy URL", contents)
         self.assertIn("THREAD-7 started", contents)
+
+    def test_rotates_log_file_at_configured_size(self):
+        with tempfile.TemporaryDirectory() as root:
+            log_path = os.path.join(root, "dirsearch.log")
+            options["log_file"] = log_path
+            options["log_file_size"] = 256
+            enable_logging()
+
+            for index in range(20):
+                logger.info("entry-%02d-%s", index, "x" * 40)
+            for handler in logger.handlers:
+                handler.flush()
+            self.close_handlers()
+
+            self.assertTrue(os.path.exists(f"{log_path}.1"))
+            self.assertFalse(os.path.exists(f"{log_path}.2"))
+            self.assertLessEqual(os.path.getsize(log_path), 256)
+            self.assertLessEqual(os.path.getsize(f"{log_path}.1"), 256)
+            with open(log_path, encoding="utf-8") as log_file:
+                self.assertIn("entry-19-", log_file.read())
+
+    def test_enabling_logging_twice_does_not_duplicate_records(self):
+        with tempfile.TemporaryDirectory() as root:
+            log_path = os.path.join(root, "dirsearch.log")
+            options["log_file"] = log_path
+            options["log_file_size"] = 0
+
+            enable_logging()
+            first_handler = logger.handlers[0]
+            enable_logging()
+            logger.info("single-record")
+            for handler in logger.handlers:
+                handler.flush()
+
+            handler_count = len(logger.handlers)
+            first_handler_closed = first_handler.stream is None
+            self.close_handlers()
+
+            self.assertEqual(handler_count, 1)
+            self.assertTrue(first_handler_closed)
+            with open(log_path, encoding="utf-8") as log_file:
+                self.assertEqual(log_file.read().count("single-record"), 1)


### PR DESCRIPTION
## Summary
- retain one rotated log backup so `log-file-size` actually triggers `RotatingFileHandler` rollover
- replace and close dirsearch's existing file handler when logging is enabled again
- add filesystem regressions for bounded rotation, backup retention, duplicate records, and handler cleanup

## User-visible effect
Configured log size limits now rotate `dirsearch.log` to `dirsearch.log.1` instead of allowing the active log to grow indefinitely. Reinitializing logging in the same process no longer duplicates every record. A size of `0` continues to mean no rotation.

## Tests
- `python -m unittest discover -s tests -t .` (482 passed, 22 skipped; Python 3.12)
- `python testing.py` (482 passed, 22 skipped; Python 3.12)
- `python -m unittest tests.core.test_logger -v` (4 passed; Python 3.14)
- `python -m flake8 lib/core/logger.py tests/core/test_logger.py`
- `git diff --check`
